### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "request": "~2",
     "streamline": "~0.4",
     "through": "2.3.4",
-    "tunnel": "0.0.2",
+    "tunnel": "~0.0.2",
     "underscore": "1.4.x",
     "validator": "~3.1.0",
     "winston": "0.6.x",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "kuduscript": "0.1.11",
     "moment": "2.6.0",
     "node-uuid": "1.2.0",
-    "omelette": "0.1.0",
+    "omelette": "~0",
     "request": "2.27.0",
     "streamline": "0.4.5",
     "through": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "moment": "2.6.0",
     "node-uuid": "1.2.0",
     "omelette": "~0",
-    "request": "2.27.0",
+    "request": "~2",
     "streamline": "0.4.5",
     "through": "2.3.4",
     "tunnel": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "adal-node": "~0.1.7",
-    "async": "0.2.7",
+    "async": "~0.9",
     "azure": "0.9.16",
     "azure-common": "0.9.8",
     "azure-gallery": "2.0.0-pre.10",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   ],
   "dependencies": {
-    "adal-node": "0.1.7",
+    "adal-node": "~0.1.7",
     "async": "0.2.7",
     "azure": "0.9.16",
     "azure-common": "0.9.8",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "node-uuid": "1.2.0",
     "omelette": "~0",
     "request": "~2",
-    "streamline": "0.4.5",
+    "streamline": "~0.4",
     "through": "2.3.4",
     "tunnel": "0.0.2",
     "underscore": "1.4.x",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "easy-table": "0.0.1",
     "event-stream": "3.1.5",
     "eyes": "0.x.x",
-    "github": "0.1.6",
+    "github": "~0",
     "kuduscript": "0.1.11",
     "moment": "2.6.0",
     "node-uuid": "1.2.0",


### PR DESCRIPTION
The following updates allow azure-cli to better follow current versions of dependent projects while currently showing no impact on the test suite.