### PR TITLE
corrected parser error/configuration for "vm endpoint acl-rule create"

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,6 +2,7 @@ Contributors should submit an update to this file with a commit in order to rece
 
 List of Contributors
 ====================
+Geoffrey Huntley <ghuntley@ghuntley.com>
 
 Microsoft Corporation
 Microsoft Open Technologies, Inc

--- a/lib/commands/asm/vm._js
+++ b/lib/commands/asm/vm._js
@@ -377,7 +377,7 @@ exports.init = function(cli) {
     .option('-o, --order <id>', $('the ACL rule order'))
     .option('-a, --action  <name>', $('the ACL rule action'))
     .option('-t, --remote-subnet  <subnet>', $('the ACL rule remote subnet'))
-    .option('-r, --description', $('the ACL rule rule description'))
+    .option('-r, --description <description>', $('the ACL rule rule description'))
     .option('-d, --dns-name <name>', $('filter VMs for the specified DNS name'))
     .option('-s, --subscription <id>', $('the subscription id'))
     .execute(function(vmName, endpointName, order, action, remoteSubnet, options, callback) {


### PR DESCRIPTION
Hey Guys,

This pull request resolves #1500 whereby `--description` on `vm endpoint acl-rule create` would crash the command line tools. The simple omission of `<description>` resulted in your parser passing in a `bool` instead of a `string` into the description validation logic.

Regards,
Geoff

(contribution as per CLA; documents are signed)