### PR TITLE
correct the help message for the default docker cert path

### DIFF
--- a/lib/commands/asm/vm._js
+++ b/lib/commands/asm/vm._js
@@ -196,7 +196,7 @@ exports.init = function(cli) {
     .usage('[options] <dns-name> <image> <user-name> [password]')
     .description($('Create a VM'))
     .option('-p, --docker-port [port]', $('Port to use for docker [4243]'))
-    .option('-C, --docker-cert-dir [dir]', $('Directory containing docker certs [.docker/]'))
+    .option('-C, --docker-cert-dir [dir]', $('Directory containing docker certs [~/.docker/]'))
     .option('-c, --connect', $('connect to existing VMs'))
     .option('-l, --location <name>', $('the location'))
     .option('-a, --affinity-group <name>', $('the affinity group'))


### PR DESCRIPTION
Modify the help message for the default docker certs dir from .docker/ to ~/.docker/   
    
### Origin
    MacBook-Pro:asm willy$ azure vm docker create -h
    help:    Create a VM 
    help:    
    help:    Usage: vm docker create [options] <dns-name> <image> <user-name> [password]
    help:    
    help:    Options:
    help:      -h, --help                             output usage information
    help:      -v, --verbose                          use verbose output
    help:      --json                                 use json output
    help:      -p, --docker-port [port]               Port to use for docker [4243]
    help:      -C, --docker-cert-dir [dir]            Directory containing docker certs [.docker/]

### New
    MacBook-Pro:asm willy$ azure vm docker create -h
    help:    Create a VM 
    help:    
    help:    Usage: vm docker create [options] <dns-name> <image> <user-name> [password]
    help:    
    help:    Options:
    help:      -h, --help                             output usage information
    help:      -v, --verbose                          use verbose output
    help:      --json                                 use json output
    help:      -p, --docker-port [port]               Port to use for docker [4243]
    help:      -C, --docker-cert-dir [dir]            Directory containing docker certs [~/.docker/]


Signed-off-by: Wei-Ting Kuo <waitingkuo0527@gmail.com>