### PR TITLE
Disable blob cases for pending investigation for failures on node 0.8

### DIFF
--- a/test/commands/cli.storage.blob-tests.js
+++ b/test/commands/cli.storage.blob-tests.js
@@ -162,7 +162,8 @@ describe('cli', function () {
       });
     });
 
-    describe('blob', function() {
+    //Skip for pending investigation for failures on node 0.8, "Error: timeout of 500000ms exceeded"
+    describe.skip('blob', function() {
       var containerName = 'storage-cli-blob-test';
       var blobName = 'blobname';
       before(function(done) {

--- a/test/recordings/cli.storage.blob-tests.nock.js
+++ b/test/recordings/cli.storage.blob-tests.nock.js
@@ -6,8 +6,8 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: 'c9cbd920-c00c-427c-852b-8aaf38badaeb',
-    name: 'Azure SDK Powershell Test',
+    id: 'a0d901ba-9956-4f7d-830c-2d7974c36666',
+    name: 'Azure Storage DM Dev',
     user: {
       name: 'user@domain.example',
       type: 'user'
@@ -22,342 +22,572 @@ exports.getMockedProfile = function () {
 };
 
 exports.setEnvironment = function() {
-  process.env['AZURE_STORAGE_CONNECTION_STRING'] = 'DefaultEndpointsProtocol=https;AccountName=teststorage101;AccountKey=null';
+  process.env['AZURE_STORAGE_CONNECTION_STRING'] = 'DefaultEndpointsProtocol=https;AccountName=xplat;AccountKey=null';
 }
 
 exports.scopes = [[function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .head('/storageclitest?restype=container')
   .reply(404, "", { 'transfer-encoding': 'chunked',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '74cbf3d9-0001-0080-2808-9dd956000000',
+  'x-ms-request-id': '6acc5e06-0001-003b-6289-cebdd3000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:01:57 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:16 GMT' });
  return result; },
 function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .put('/storageclitest?restype=container')
   .reply(201, "", { 'transfer-encoding': 'chunked',
-  'last-modified': 'Fri, 05 Dec 2014 19:01:58 GMT',
-  etag: '"0x8D1DED5144BA2E7"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:18 GMT',
+  etag: '"0x8D1FE81C7837FCF"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': 'ab6c3337-0001-0064-1122-5e8172000000',
+  'x-ms-request-id': 'b28509f5-0001-001c-449f-b28335000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:01:57 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:18 GMT' });
  return result; },
 function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .head('/storageclitest?restype=container')
   .reply(200, "", { 'transfer-encoding': 'chunked',
-  'last-modified': 'Fri, 05 Dec 2014 19:01:58 GMT',
-  etag: '"0x8D1DED5144BA2E7"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:18 GMT',
+  etag: '"0x8D1FE81C7837FCF"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '7fe64160-0001-0035-3c23-84d365000000',
+  'x-ms-request-id': '899fd0c3-0001-0010-6e05-0f1f01000000',
   'x-ms-version': '2014-02-14',
   'x-ms-lease-status': 'unlocked',
   'x-ms-lease-state': 'available',
-  date: 'Fri, 05 Dec 2014 19:01:58 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:18 GMT' });
  return result; },
 function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .get('/storageclitest?restype=container&comp=acl')
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
   'content-type': 'application/xml',
-  'last-modified': 'Fri, 05 Dec 2014 19:01:58 GMT',
-  etag: '"0x8D1DED5144BA2E7"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:18 GMT',
+  etag: '"0x8D1FE81C7837FCF"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': 'a76b761b-0001-0019-465c-58677d000000',
+  'x-ms-request-id': '56ae3615-0001-0006-3357-339184000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:01:58 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:19 GMT' });
  return result; }],
 [function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .get('/?comp=list&include=metadata')
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://teststorage101.blob.core.windows.net/\"><Containers><Container><Name>storageclitest</Name><Properties><Last-Modified>Fri, 05 Dec 2014 19:01:58 GMT</Last-Modified><Etag>\"0x8D1DED5144BA2E7\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container></Containers><NextMarker /></EnumerationResults>", { 'transfer-encoding': 'chunked',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://xplat.blob.core.windows.net/\"><Containers><Container><Name>$root</Name><Properties><Last-Modified>Tue, 06 Jan 2015 08:50:04 GMT</Last-Modified><Etag>\"0x8D1F7A4E5F7D623\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata><metatest857a1d66>metavalue-bb299d5f418</metatest857a1d66><metatest0edd4a10>metavalue-30d370e2764149c8999</metatest0edd4a10><metatestf9151651>metavalue-4ab6ae9afa</metatestf9151651><metatest380fa6e5>metavalue-311a2c4535ed4bfea7e</metatest380fa6e5><metatest7972428f>metavalue-33eb660fb0064cfba</metatest7972428f><metatest92956204>metavalue-4190c59218</metatest92956204><metatest4f7e78a0>metavalue-a90151cab16a4b4</metatest4f7e78a0><metatest4d5b4d68>metavalue-b98bd4dfd53</metatest4d5b4d68><metatest583f38cb>metavalue-ae6a0ec7ebb</metatest583f38cb><metatest6f46cee5>metavalue-1a310810422</metatest6f46cee5><metatest399dcf8e>metavalue-8967c05b2e1</metatest399dcf8e><metatest44bee1d6>metavalue-88c85c6e722a42d</metatest44bee1d6><metatest10885255>metavalue-4150f9ed54c4467e</metatest10885255><metatest4e63e083>metavalue-85369d1c6699445</metatest4e63e083><metatest632fbb8f>metavalue-af71a6f9d9814ccd8</metatest632fbb8f><metatest02d4ea0f>metavalue-42272b3736e</metatest02d4ea0f><metatest5efddf52>metavalue-44ee9be6a857</metatest5efddf52><metatestbf12162a>metavalue-19627ff857b3</metatestbf12162a><metatestb51e36f6>metavalue-ea643f7fba274ae8</metatestb51e36f6><metatest170189c6>metavalue-3e26dd5c44204384</metatest170189c6><metatest9e5fb6cf>metavalue-acbef987f7f647ac</metatest9e5fb6cf><metatest087eaeea>metavalue-23d82fdd74124833b80</metatest087eaeea><metatestee8a6bf9>metavalue-fdd23fe0e0dc4</metatestee8a6bf9><metatestddc1ded2>metavalue-7da4b13c203</metatestddc1ded2><metatest86adcac5>metavalue-1607327ed19</metatest86adcac5><metatestd60fbadf>metavalue-1a9970648a404c</metatestd60fbadf><metatestabb1ca74>metavalue-7d960bf133a</metatestabb1ca74><metatest52a9e55e>metavalue-5d3f8c7fa6a143f29</metatest52a9e55e><metatestf1c9fb30>metavalue-0e3eb629c4854</metatestf1c9fb30><metatestb1398b57>metavalue-2eadf084ea4a</metatestb1398b57><metatest6122c17f>metavalue-d3172f9c2cf14c9</metatest6122c17f><metatesta9c1fb76>metavalue-4cad56068ff64</metatesta9c1fb76><metatestcc418509>metavalue-facc0369e4e44</metatestcc418509><metatest1f830f47>metavalue-8b46c01022b046ada</metatest1f830f47><metatest66a92b2c>metavalue-2d470eb9fc804a089</metatest66a92b2c><metatesta580e587>metavalue-126a53e5abd0493cb4</metatesta580e587><metatest71b397b0>metavalue-7bcbeed66d474fc889</metatest71b397b0><metateste9b248e0>metavalue-4a2df023d14242be95d</metateste9b248e0><metatest609f095d>metavalue-e07c703f06c</metatest609f095d><metatest24077990>metavalue-e7c7b9144fa94a8f8c</metatest24077990><metatest0b4e5af1>metavalue-c32dad4be26</metatest0b4e5af1><metatest0cd6668f>metavalue-60bca7e320</metatest0cd6668f><metateste6e43e4a>metavalue-c6f6584a58174922bba</metateste6e43e4a><metatest2f2c05ed>metavalue-382f534cfa6e4</metatest2f2c05ed><metatest4eeb14d6>metavalue-08f8f10f934</metatest4eeb14d6><metatest729c5671>metavalue-619e1501eb8</metatest729c5671><metatest246b2b19>metavalue-0e2e1b4a5ca3429a936</metatest246b2b19><metatest16a84a19>metavalue-6913ba4d3c1c</metatest16a84a19><metatestfd3c8cc9>metavalue-d07a265fe401</metatestfd3c8cc9><metatest3fdbf55b>metavalue-5c4eec98ce1843b</metatest3fdbf55b><metatest2f724a81>metavalue-70c628ba1ec54e6caaa</metatest2f724a81><metatest80303eb6>metavalue-9930a3cfbadd49</metatest80303eb6><metatest98d241cc>metavalue-76323b22aaa44d8</metatest98d241cc></Metadata></Container><Container><Name>cont-2a45b480-9a2b-11e4-bbeb-9718f3cddb5d</Name><Properties><Last-Modified>Mon, 12 Jan 2015 07:18:12 GMT</Last-Modified><Etag>\"0x8D1FC4F0F739008\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont-cfed5d90-9713-11e4-afcc-0b5d7e34cfcb</Name><Properties><Last-Modified>Thu, 08 Jan 2015 08:53:28 GMT</Last-Modified><Etag>\"0x8D1F937B4B0556B\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont-f248d630-9713-11e4-afcc-0b5d7e34cfcb</Name><Properties><Last-Modified>Thu, 08 Jan 2015 08:54:28 GMT</Last-Modified><Etag>\"0x8D1F937D81C754A\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata><key1 /></Metadata></Container><Container><Name>cont-testdata0</Name><Properties><Last-Modified>Fri, 09 Jan 2015 04:11:00 GMT</Last-Modified><Etag>\"0x8D1F9D9697E1ECC\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont1106615</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:12:11 GMT</Last-Modified><Etag>\"0x8D1F9212CB0785E\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont1109146</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:11:29 GMT</Last-Modified><Etag>\"0x8D1F92113D18E98\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont13702788</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:39:25 GMT</Last-Modified><Etag>\"0x8D1F924FAB86977\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont13708227</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:40:06 GMT</Last-Modified><Etag>\"0x8D1F92512F8EBF1\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont19554171</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:43:24 GMT</Last-Modified><Etag>\"0x8D1F92589014157\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont19558400</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:44:05 GMT</Last-Modified><Etag>\"0x8D1F925A1B72D44\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont37016117</Name><Properties><Last-Modified>Thu, 08 Jan 2015 09:01:44 GMT</Last-Modified><Etag>\"0x8D1F938DC32DE81\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont37018694</Name><Properties><Last-Modified>Thu, 08 Jan 2015 09:02:25 GMT</Last-Modified><Etag>\"0x8D1F938F4FE7E2A\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont50721210</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:15:12 GMT</Last-Modified><Etag>\"0x8D1F921989A519B\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont50726223</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:15:53 GMT</Last-Modified><Etag>\"0x8D1F921B0C36CBE\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont64384783</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:05:34 GMT</Last-Modified><Etag>\"0x8D1F920402538C1\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont64389397</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:06:16 GMT</Last-Modified><Etag>\"0x8D1F9205953A613\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont6529343</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:45:58 GMT</Last-Modified><Etag>\"0x8D1F925E51FD069\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont65297806</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:46:39 GMT</Last-Modified><Etag>\"0x8D1F925FD09EDF8\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont693975</Name><Properties><Last-Modified>Thu, 08 Jan 2015 06:02:35 GMT</Last-Modified><Etag>\"0x8D1F91FD54A80C3\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont73389181</Name><Properties><Last-Modified>Mon, 12 Jan 2015 07:12:23 GMT</Last-Modified><Etag>\"0x8D1FC4E3F42AB5B\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont83834379</Name><Properties><Last-Modified>Thu, 08 Jan 2015 09:05:13 GMT</Last-Modified><Etag>\"0x8D1F93958EA1A08\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont90545100</Name><Properties><Last-Modified>Thu, 08 Jan 2015 08:57:11 GMT</Last-Modified><Etag>\"0x8D1F938398FF0ED\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont90545865</Name><Properties><Last-Modified>Thu, 08 Jan 2015 08:57:49 GMT</Last-Modified><Etag>\"0x8D1F938501BD851\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>cont90549626</Name><Properties><Last-Modified>Thu, 08 Jan 2015 08:57:09 GMT</Last-Modified><Etag>\"0x8D1F938385A2DE6\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>storageclitest</Name><Properties><Last-Modified>Thu, 15 Jan 2015 02:26:18 GMT</Last-Modified><Etag>\"0x8D1FE81C7837FCF\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>test01</Name><Properties><Last-Modified>Wed, 14 Jan 2015 04:10:14 GMT</Last-Modified><Etag>\"0x8D1FDC721FD0625\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata><NameA>Uppercase,lowercase</NameA></Metadata></Container><Container><Name>test02</Name><Properties><Last-Modified>Mon, 15 Dec 2014 09:03:27 GMT</Last-Modified><Etag>\"0x8D1E65D1FECFF15\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>test03</Name><Properties><Last-Modified>Tue, 05 Aug 2014 14:50:34 GMT</Last-Modified><Etag>\"0x8D17ED3BF271FF4\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>xytest</Name><Properties><Last-Modified>Fri, 26 Dec 2014 05:42:19 GMT</Last-Modified><Etag>\"0x8D1EEE5D90BFE3D\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container><Container><Name>xytest01</Name><Properties><Last-Modified>Tue, 13 Jan 2015 05:38:32 GMT</Last-Modified><Etag>\"0x8D1FD0A4D5C587F\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container></Containers><NextMarker /></EnumerationResults>", { 'transfer-encoding': 'chunked',
   'content-type': 'application/xml',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '7170ce2a-0001-0026-117d-6ac020000000',
+  'x-ms-request-id': '5bcde21b-0001-004a-5ff4-2c3722000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:01:57 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:20 GMT' });
  return result; },
 function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/$root?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Tue, 06 Jan 2015 08:50:04 GMT',
+  etag: '"0x8D1F7A4E5F7D623"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '7c8a881f-0001-0004-6329-ad58ac000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont-2a45b480-9a2b-11e4-bbeb-9718f3cddb5d?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Mon, 12 Jan 2015 07:18:12 GMT',
+  etag: '"0x8D1FC4F0F739008"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': 'bd815f2d-0001-0048-421c-b5e47f000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:20 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont-f248d630-9713-11e4-afcc-0b5d7e34cfcb?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 08:54:28 GMT',
+  etag: '"0x8D1F937D81C754A"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '1948339e-0001-0046-5265-466ac3000000',
+  'x-ms-version': '2014-02-14',
+  'x-ms-blob-public-access': 'blob',
+  date: 'Thu, 15 Jan 2015 02:26:20 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont-testdata0?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Fri, 09 Jan 2015 04:11:00 GMT',
+  etag: '"0x8D1F9D9697E1ECC"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '4ff25b6c-0001-003c-78b8-752ded000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont-cfed5d90-9713-11e4-afcc-0b5d7e34cfcb?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 08:53:28 GMT',
+  etag: '"0x8D1F937B4B0556B"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '82a32c9a-0001-003e-203d-09b336000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont1106615?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:12:11 GMT',
+  etag: '"0x8D1F9212CB0785E"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '7c8a887e-0001-0004-4229-ad58ac000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont1109146?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:11:29 GMT',
+  etag: '"0x8D1F92113D18E98"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': 'bd815f9a-0001-0048-2f1c-b5e47f000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont13702788?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:39:25 GMT',
+  etag: '"0x8D1F924FAB86977"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '194833c3-0001-0046-7765-466ac3000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:20 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont13708227?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:40:06 GMT',
+  etag: '"0x8D1F92512F8EBF1"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '4ff25b9a-0001-003c-26b8-752ded000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont19554171?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:43:24 GMT',
+  etag: '"0x8D1F92589014157"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '82a32cd6-0001-003e-5c3d-09b336000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont19558400?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:44:05 GMT',
+  etag: '"0x8D1F925A1B72D44"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '7c8a88d1-0001-0004-0329-ad58ac000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont37018694?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 09:02:25 GMT',
+  etag: '"0x8D1F938F4FE7E2A"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '194833ed-0001-0046-2165-466ac3000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont37016117?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 09:01:44 GMT',
+  etag: '"0x8D1F938DC32DE81"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': 'bd816005-0001-0048-171c-b5e47f000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont50726223?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:15:53 GMT',
+  etag: '"0x8D1F921B0C36CBE"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '82a32d1c-0001-003e-223d-09b336000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont64384783?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:05:34 GMT',
+  etag: '"0x8D1F920402538C1"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '7c8a8910-0001-0004-4229-ad58ac000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont64389397?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:06:16 GMT',
+  etag: '"0x8D1F9205953A613"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '1948341b-0001-0046-4f65-466ac3000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont6529343?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:45:58 GMT',
+  etag: '"0x8D1F925E51FD069"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': 'bd816075-0001-0048-071c-b5e47f000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont65297806?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:46:39 GMT',
+  etag: '"0x8D1F925FD09EDF8"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '82a32d8e-0001-003e-763d-09b336000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont693975?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:02:35 GMT',
+  etag: '"0x8D1F91FD54A80C3"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '7c8a8953-0001-0004-0529-ad58ac000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont73389181?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Mon, 12 Jan 2015 07:12:23 GMT',
+  etag: '"0x8D1FC4E3F42AB5B"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '19483444-0001-0046-7865-466ac3000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont83834379?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 09:05:13 GMT',
+  etag: '"0x8D1F93958EA1A08"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': 'bd8160f2-0001-0048-771c-b5e47f000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont90545100?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 08:57:11 GMT',
+  etag: '"0x8D1F938398FF0ED"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '82a32dcf-0001-003e-373d-09b336000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont90545865?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 08:57:49 GMT',
+  etag: '"0x8D1F938501BD851"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '7c8a897b-0001-0004-2c29-ad58ac000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont90549626?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 08:57:09 GMT',
+  etag: '"0x8D1F938385A2DE6"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '19483463-0001-0046-1765-466ac3000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
   .get('/storageclitest?restype=container&comp=acl')
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
   'content-type': 'application/xml',
-  'last-modified': 'Fri, 05 Dec 2014 19:01:58 GMT',
-  etag: '"0x8D1DED5144BA2E7"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:18 GMT',
+  etag: '"0x8D1FE81C7837FCF"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '293b8446-0001-0032-0b0a-72a7bf000000',
+  'x-ms-request-id': 'bd816173-0001-0048-6a1c-b5e47f000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:01:58 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/test01?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>p2</Id><AccessPolicy><Start>2015-01-02T00:00:00.0000000Z</Start><Expiry>2015-02-02T00:00:00.0000000Z</Expiry><Permission>w</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>p1</Id><AccessPolicy><Start>2015-01-01T00:00:00.0000000Z</Start><Expiry>2015-02-01T00:00:00.0000000Z</Expiry><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>p3</Id><AccessPolicy><Start>2015-01-03T00:00:00.0000000Z</Start><Expiry>2015-02-03T00:00:00.0000000Z</Expiry><Permission>d</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>p4</Id><AccessPolicy><Start>2015-01-04T00:00:00.0000000Z</Start><Expiry>2015-02-04T00:00:00.0000000Z</Expiry><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>p5</Id><AccessPolicy><Start>2014-12-01T00:00:00.0000000Z</Start><Expiry>2099-12-31T00:00:00.0000000Z</Expiry><Permission>rl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Wed, 14 Jan 2015 04:10:14 GMT',
+  etag: '"0x8D1FDC721FD0625"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '82a32e16-0001-003e-7e3d-09b336000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/test02?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>p1</Id></SignedIdentifier><SignedIdentifier><Id>p2</Id></SignedIdentifier></SignedIdentifiers>", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Mon, 15 Dec 2014 09:03:27 GMT',
+  etag: '"0x8D1E65D1FECFF15"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '7c8a89b1-0001-0004-6229-ad58ac000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:23 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/test03?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Tue, 05 Aug 2014 14:50:34 GMT',
+  etag: '"0x8D17ED3BF271FF4"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '194834a9-0001-0046-5165-466ac3000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/xytest?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>p1</Id><AccessPolicy><Start>2014-12-24T16:00:00.0000000Z</Start><Expiry>2014-12-29T16:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>p2</Id><AccessPolicy><Start>2014-12-24T16:00:00.0000000Z</Start><Expiry>2014-12-29T16:00:00.0000000Z</Expiry><Permission>wd</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Fri, 26 Dec 2014 05:42:19 GMT',
+  etag: '"0x8D1EEE5D90BFE3D"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': 'bd8161c6-0001-0048-3d1c-b5e47f000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:21 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/cont50721210?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Thu, 08 Jan 2015 06:15:12 GMT',
+  etag: '"0x8D1F921989A519B"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': 'f5e547ac-0001-0030-4d1d-f6bc3c000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://xplat.blob.core.windows.net:443')
+  .get('/xytest01?restype=container&comp=acl')
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
+  'content-type': 'application/xml',
+  'last-modified': 'Tue, 13 Jan 2015 05:38:32 GMT',
+  etag: '"0x8D1FD0A4D5C587F"',
+  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id': '82a32e38-0001-003e-203d-09b336000000',
+  'x-ms-version': '2014-02-14',
+  date: 'Thu, 15 Jan 2015 02:26:22 GMT' });
  return result; }],
 [function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .get('/?comp=list&include=metadata&prefix=storageclitest')
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://teststorage101.blob.core.windows.net/\"><Prefix>storageclitest</Prefix><Containers><Container><Name>storageclitest</Name><Properties><Last-Modified>Fri, 05 Dec 2014 19:01:58 GMT</Last-Modified><Etag>\"0x8D1DED5144BA2E7\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container></Containers><NextMarker /></EnumerationResults>", { 'transfer-encoding': 'chunked',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://xplat.blob.core.windows.net/\"><Prefix>storageclitest</Prefix><Containers><Container><Name>storageclitest</Name><Properties><Last-Modified>Thu, 15 Jan 2015 02:26:18 GMT</Last-Modified><Etag>\"0x8D1FE81C7837FCF\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Container></Containers><NextMarker /></EnumerationResults>", { 'transfer-encoding': 'chunked',
   'content-type': 'application/xml',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '7b8184f6-0001-007b-6168-c3059e000000',
+  'x-ms-request-id': '8f4cf35f-0001-0011-6a0e-f572da000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:01:59 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:24 GMT' });
  return result; },
 function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .get('/storageclitest?restype=container&comp=acl')
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
   'content-type': 'application/xml',
-  'last-modified': 'Fri, 05 Dec 2014 19:01:58 GMT',
-  etag: '"0x8D1DED5144BA2E7"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:18 GMT',
+  etag: '"0x8D1FE81C7837FCF"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '8dc61861-0001-0060-0b2b-786e71000000',
+  'x-ms-request-id': '740767e2-0001-002e-296c-8a790c000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:01:58 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:23 GMT' });
  return result; }],
 [function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .head('/storageclitest?restype=container')
   .reply(200, "", { 'transfer-encoding': 'chunked',
-  'last-modified': 'Fri, 05 Dec 2014 19:01:58 GMT',
-  etag: '"0x8D1DED5144BA2E7"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:18 GMT',
+  etag: '"0x8D1FE81C7837FCF"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': 'ba5b90c5-0001-0058-732d-941391000000',
+  'x-ms-request-id': '18a45549-0001-0037-3371-6a506f000000',
   'x-ms-version': '2014-02-14',
   'x-ms-lease-status': 'unlocked',
   'x-ms-lease-state': 'available',
-  date: 'Fri, 05 Dec 2014 19:01:59 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:24 GMT' });
  return result; },
 function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .get('/storageclitest?restype=container&comp=acl')
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
   'content-type': 'application/xml',
-  'last-modified': 'Fri, 05 Dec 2014 19:01:58 GMT',
-  etag: '"0x8D1DED5144BA2E7"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:18 GMT',
+  etag: '"0x8D1FE81C7837FCF"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '4d8e133c-0001-0049-3d22-6ea7e9000000',
+  'x-ms-request-id': 'b0ec26cf-0001-0040-112f-faf720000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:01:59 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:26 GMT' });
  return result; }],
 [function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .put('/storageclitest?restype=container&comp=acl')
   .reply(200, "", { 'transfer-encoding': 'chunked',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:00 GMT',
-  etag: '"0x8D1DED5156B9618"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:27 GMT',
+  etag: '"0x8D1FE81CCD686DD"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '6ed96eb6-0001-0042-6bd9-d4f3f6000000',
+  'x-ms-request-id': '209d9136-0001-0016-7ffb-d27a36000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:01:59 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:26 GMT' });
  return result; },
 function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .head('/storageclitest?restype=container')
   .reply(200, "", { 'transfer-encoding': 'chunked',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:00 GMT',
-  etag: '"0x8D1DED5156B9618"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:27 GMT',
+  etag: '"0x8D1FE81CCD686DD"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '1478e268-0001-004f-5bc9-95999b000000',
+  'x-ms-request-id': '998cb15c-0001-000b-4cc4-f6eb10000000',
   'x-ms-version': '2014-02-14',
   'x-ms-lease-status': 'unlocked',
   'x-ms-lease-state': 'available',
-  date: 'Fri, 05 Dec 2014 19:02:01 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:27 GMT' });
  return result; },
 function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .get('/storageclitest?restype=container&comp=acl')
   .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers />", { 'transfer-encoding': 'chunked',
   'content-type': 'application/xml',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:00 GMT',
-  etag: '"0x8D1DED5156B9618"',
+  'last-modified': 'Thu, 15 Jan 2015 02:26:27 GMT',
+  etag: '"0x8D1FE81CCD686DD"',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': 'f36dfd75-0001-000b-0927-be19bb000000',
+  'x-ms-request-id': '784af758-0001-0028-3491-215613000000',
   'x-ms-version': '2014-02-14',
   'x-ms-blob-public-access': 'container',
-  date: 'Fri, 05 Dec 2014 19:02:00 GMT' });
+  date: 'Thu, 15 Jan 2015 02:26:29 GMT' });
  return result; }],
 [],
 [function (nock) { 
 var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
+nock('https://xplat.blob.core.windows.net:443')
   .delete('/storageclitest?restype=container')
   .reply(202, "", { 'transfer-encoding': 'chunked',
   server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': 'deced94a-0001-0068-2c88-85c9cd000000',
+  'x-ms-request-id': 'c186e9dd-0001-0031-2972-20f85b000000',
   'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:02:00 GMT' });
- return result; }],
-[function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .head('/storage-cli-blob-test/blobname')
-  .reply(404, "", { 'transfer-encoding': 'chunked',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': 'dd9565e4-0001-0081-8078-738143000000',
-  'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:02:01 GMT' });
- return result; },
-function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .filteringRequestBody(function (path) { return '*';})
-.put('/storage-cli-blob-test/blobname', '*')
-  .reply(201, "", { 'transfer-encoding': 'chunked',
-  'content-md5': 'BLb4bUlxavjU8u3wGjCfyA==',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:01 GMT',
-  etag: '"0x8D1DED51652C44D"',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '6f072f89-0001-003e-2990-38979a000000',
-  'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:02:01 GMT' });
- return result; },
-function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .head('/storage-cli-blob-test/blobname')
-  .reply(200, "", { 'content-length': '9',
-  'content-type': 'text/plain',
-  'content-md5': 'BLb4bUlxavjU8u3wGjCfyA==',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:01 GMT',
-  'accept-ranges': 'bytes',
-  etag: '"0x8D1DED51652C44D"',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '826a3c54-0001-004a-4633-344ace000000',
-  'x-ms-version': '2014-02-14',
-  'x-ms-lease-status': 'unlocked',
-  'x-ms-lease-state': 'available',
-  'x-ms-blob-type': 'BlockBlob',
-  date: 'Fri, 05 Dec 2014 19:02:02 GMT' });
- return result; }],
-[function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .get('/storage-cli-blob-test?restype=container&comp=list&include=snapshots%2Cmetadata%2Ccopy')
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://teststorage101.blob.core.windows.net/\" ContainerName=\"storage-cli-blob-test\"><Blobs><Blob><Name>blobname</Name><Properties><Last-Modified>Fri, 05 Dec 2014 19:02:01 GMT</Last-Modified><Etag>0x8D1DED51652C44D</Etag><Content-Length>9</Content-Length><Content-Type>text/plain</Content-Type><Content-Encoding /><Content-Language /><Content-MD5>BLb4bUlxavjU8u3wGjCfyA==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties><Metadata /></Blob></Blobs><NextMarker /></EnumerationResults>", { 'transfer-encoding': 'chunked',
-  'content-type': 'application/xml',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': 'd904d5f9-0001-002f-5309-f2a1c3000000',
-  'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:02:02 GMT' });
- return result; }],
-[function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .head('/storage-cli-blob-test/blobname')
-  .reply(200, "", { 'content-length': '9',
-  'content-type': 'text/plain',
-  'content-md5': 'BLb4bUlxavjU8u3wGjCfyA==',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:01 GMT',
-  'accept-ranges': 'bytes',
-  etag: '"0x8D1DED51652C44D"',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '091d2887-0001-0077-045b-67208b000000',
-  'x-ms-version': '2014-02-14',
-  'x-ms-lease-status': 'unlocked',
-  'x-ms-lease-state': 'available',
-  'x-ms-blob-type': 'BlockBlob',
-  date: 'Fri, 05 Dec 2014 19:02:02 GMT' });
- return result; }],
-[function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .head('/storage-cli-blob-test/blobname')
-  .reply(200, "", { 'content-length': '9',
-  'content-type': 'text/plain',
-  'content-md5': 'BLb4bUlxavjU8u3wGjCfyA==',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:01 GMT',
-  'accept-ranges': 'bytes',
-  etag: '"0x8D1DED51652C44D"',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '1c0c118e-0001-0070-0e17-ef8f8f000000',
-  'x-ms-version': '2014-02-14',
-  'x-ms-lease-status': 'unlocked',
-  'x-ms-lease-state': 'available',
-  'x-ms-blob-type': 'BlockBlob',
-  date: 'Fri, 05 Dec 2014 19:02:02 GMT' });
- return result; },
-function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .get('/storage-cli-blob-test/blobname')
-  .reply(200, "HelloWord", { 'content-length': '9',
-  'content-type': 'text/plain',
-  'content-md5': 'BLb4bUlxavjU8u3wGjCfyA==',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:01 GMT',
-  'accept-ranges': 'bytes',
-  etag: '"0x8D1DED51652C44D"',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': 'de6ee039-0001-002c-3509-871d8a000000',
-  'x-ms-version': '2014-02-14',
-  'x-ms-lease-status': 'unlocked',
-  'x-ms-lease-state': 'available',
-  'x-ms-blob-type': 'BlockBlob',
-  date: 'Fri, 05 Dec 2014 19:02:03 GMT' });
- return result; },
-function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .head('/storage-cli-blob-test/blobname')
-  .reply(200, "", { 'content-length': '9',
-  'content-type': 'text/plain',
-  'content-md5': 'BLb4bUlxavjU8u3wGjCfyA==',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:01 GMT',
-  'accept-ranges': 'bytes',
-  etag: '"0x8D1DED51652C44D"',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '3788f964-0001-004d-4561-866ed9000000',
-  'x-ms-version': '2014-02-14',
-  'x-ms-lease-status': 'unlocked',
-  'x-ms-lease-state': 'available',
-  'x-ms-blob-type': 'BlockBlob',
-  date: 'Fri, 05 Dec 2014 19:02:03 GMT' });
- return result; },
-function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .head('/storage-cli-blob-test/blobname')
-  .reply(200, "", { 'content-length': '9',
-  'content-type': 'text/plain',
-  'content-md5': 'BLb4bUlxavjU8u3wGjCfyA==',
-  'last-modified': 'Fri, 05 Dec 2014 19:02:01 GMT',
-  'accept-ranges': 'bytes',
-  etag: '"0x8D1DED51652C44D"',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': '03342144-0001-0045-12b5-976d88000000',
-  'x-ms-version': '2014-02-14',
-  'x-ms-lease-status': 'unlocked',
-  'x-ms-lease-state': 'available',
-  'x-ms-blob-type': 'BlockBlob',
-  date: 'Fri, 05 Dec 2014 19:02:03 GMT' });
- return result; }],
-[],
-[],
-[function (nock) { 
-var result = 
-nock('https://teststorage101.blob.core.windows.net:443')
-  .delete('/storage-cli-blob-test/blobname')
-  .reply(202, "", { 'transfer-encoding': 'chunked',
-  server: 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id': 'edbb0602-0001-0007-6a33-a3804f000000',
-  'x-ms-version': '2014-02-14',
-  date: 'Fri, 05 Dec 2014 19:02:10 GMT' });
- return result; }],
-[],
-[],
-[],
-[],
-[],
-[]];
+  date: 'Thu, 15 Jan 2015 02:26:30 GMT' });
+ return result; }]];


### PR DESCRIPTION
As we met "Error: timeout of 500000ms exceeded" from time to time which was caused by stream issue in nodejs 0.8. So I disable the cases until we update storage nodejs SDK to 0.4.3.