### PR TITLE
Per-instance server certificate creation for azure vm docker create

### DIFF
--- a/lib/commands/asm/vm/vmclient.js
+++ b/lib/commands/asm/vm/vmclient.js
@@ -3370,7 +3370,7 @@ function createVM(options, callback, logger, cli) {
 
       progress = cli.interaction.progress($('Deleting cloud service'));
 
-      computeManagementClient.hostedServices.delete(options.dnsPrefix, function(err) {
+      computeManagementClient.hostedServices.deleteMethod(options.dnsPrefix, function(err) {
         progress.end();
         if (err) {
           logger.warn(util.format($('Error deleting %s cloud service'), options.dnsPrefix));
@@ -3394,7 +3394,7 @@ function deleteHostedServiceIfEmpty(computeManagementClient, dnsPrefix, cli, cal
     } else {
       if (response.deployments.length === 0) {
         var progress = cli.interaction.progress($('Deleting Cloud Service'));
-        computeManagementClient.hostedServices.delete(dnsPrefix, function(error) {
+        computeManagementClient.hostedServices.deleteMethod(dnsPrefix, function(error) {
           progress.end();
           if (error) {
             return callback(error);
@@ -3414,7 +3414,7 @@ function deleteRoleOrDeployment(computeManagementClient, svcname, deployment, vm
   var deleteFromStorage = options.blobDelete || false;
 
   if (deployment.roles.length > 1) {
-    computeManagementClient.virtualMachines.delete(svcname, deployment.name, vmName, deleteFromStorage, function(error) {
+    computeManagementClient.virtualMachines.deleteMethod(svcname, deployment.name, vmName, deleteFromStorage, function(error) {
       progress.end();
       return callback(error);
     });
@@ -3846,67 +3846,67 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
           logger.verbose(err);
         }
 
-              openssl.exec('genrsa', {
-                des3: true,
-                passout: 'pass:' + password,
-                out: options.dockerCerts.clientKey
+        openssl.exec('genrsa', {
+          des3: true,
+          passout: 'pass:' + password,
+          out: options.dockerCerts.clientKey
+        }, function(err) {
+          if (err) {
+            logger.verbose(err);
+          }
+
+          openssl.exec('req', {
+            new: true,
+            passin: 'pass:' + password,
+            subj: '/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=\\*',
+            key: options.dockerCerts.clientKey,
+            out: options.dockerCerts.client
+          }, function(err) {
+            if (err) {
+              logger.verbose(err.toString());
+            }
+
+            var configPath = path.join(options.dockerCertDir, 'extfile.cnf');
+            fs.writeFile(configPath, 'extendedKeyUsage = clientAuth', function(err) {
+              if (err) {
+                logger.verbose(err);
+              }
+
+              openssl.exec('x509', {
+                req: true,
+                days: 365,
+                in : options.dockerCerts.client,
+                passin: 'pass:' + password,
+                set_serial: 01,
+                extfile: configPath,
+                CA: options.dockerCerts.ca,
+                CAkey: options.dockerCerts.caKey,
+                out: options.dockerCerts.clientCert
               }, function(err) {
                 if (err) {
-                  logger.verbose(err);
+                  logger.verbose(err.toString());
                 }
 
-                openssl.exec('req', {
-                  new: true,
+                openssl.exec('rsa', {
                   passin: 'pass:' + password,
-                  subj: '/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=\\*',
-                  key: options.dockerCerts.clientKey,
-                  out: options.dockerCerts.client
+                  in : options.dockerCerts.clientKey,
+                  passout: 'pass:' + password,
+                  out: options.dockerCerts.clientKey
                 }, function(err) {
                   if (err) {
                     logger.verbose(err.toString());
                   }
 
-                  var configPath = path.join(options.dockerCertDir, 'extfile.cnf');
-                  fs.writeFile(configPath, 'extendedKeyUsage = clientAuth', function(err) {
-                    if (err) {
-                      logger.verbose(err);
-                    }
-
-                    openssl.exec('x509', {
-                      req: true,
-                      days: 365,
-                      in : options.dockerCerts.client,
-                      passin: 'pass:' + password,
-                      set_serial: 01,
-                      extfile: configPath,
-                      CA: options.dockerCerts.ca,
-                      CAkey: options.dockerCerts.caKey,
-                      out: options.dockerCerts.clientCert
-                    }, function(err) {
-                      if (err) {
-                        logger.verbose(err.toString());
-                      }
-
-                        openssl.exec('rsa', {
-                          passin: 'pass:' + password,
-                          in : options.dockerCerts.clientKey,
-                          passout: 'pass:' + password,
-                          out: options.dockerCerts.clientKey
-                        }, function(err) {
-                          if (err) {
-                            logger.verbose(err.toString());
-                          }
-
-                          // setting cert permissions
-                          fs.chmodSync(options.dockerCerts.caKey, 0600);
-                          fs.chmodSync(options.dockerCerts.ca, 0600);
-                          fs.chmodSync(options.dockerCerts.clientKey, 0600);
-                          fs.chmodSync(options.dockerCerts.client, 0600);
-                          fs.chmodSync(configPath, 0600);
-                          fs.chmodSync(options.dockerCerts.clientCert, 0600);
-                          return cb();
-                        });
-                      });
+                  // setting cert permissions
+                  fs.chmodSync(options.dockerCerts.caKey, 0600);
+                  fs.chmodSync(options.dockerCerts.ca, 0600);
+                  fs.chmodSync(options.dockerCerts.clientKey, 0600);
+                  fs.chmodSync(options.dockerCerts.client, 0600);
+                  fs.chmodSync(configPath, 0600);
+                  fs.chmodSync(options.dockerCerts.clientCert, 0600);
+                  return cb();
+                });
+              });
             });
           });
         });

--- a/lib/commands/asm/vm/vmclient.js
+++ b/lib/commands/asm/vm/vmclient.js
@@ -3370,7 +3370,7 @@ function createVM(options, callback, logger, cli) {
 
       progress = cli.interaction.progress($('Deleting cloud service'));
 
-      computeManagementClient.hostedServices.deleteMethod(options.dnsPrefix, function(err) {
+      computeManagementClient.hostedServices.delete(options.dnsPrefix, function(err) {
         progress.end();
         if (err) {
           logger.warn(util.format($('Error deleting %s cloud service'), options.dnsPrefix));
@@ -3394,7 +3394,7 @@ function deleteHostedServiceIfEmpty(computeManagementClient, dnsPrefix, cli, cal
     } else {
       if (response.deployments.length === 0) {
         var progress = cli.interaction.progress($('Deleting Cloud Service'));
-        computeManagementClient.hostedServices.deleteMethod(dnsPrefix, function(error) {
+        computeManagementClient.hostedServices.delete(dnsPrefix, function(error) {
           progress.end();
           if (error) {
             return callback(error);
@@ -3414,7 +3414,7 @@ function deleteRoleOrDeployment(computeManagementClient, svcname, deployment, vm
   var deleteFromStorage = options.blobDelete || false;
 
   if (deployment.roles.length > 1) {
-    computeManagementClient.virtualMachines.deleteMethod(svcname, deployment.name, vmName, deleteFromStorage, function(error) {
+    computeManagementClient.virtualMachines.delete(svcname, deployment.name, vmName, deleteFromStorage, function(error) {
       progress.end();
       return callback(error);
     });
@@ -3660,9 +3660,9 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
   options.dockerCerts = {
     caKey: path.join(options.dockerCertDir, 'ca-key.pem'),
     ca: path.join(options.dockerCertDir, 'ca.pem'),
-    serverKey: path.join(options.dockerCertDir, 'server-key.pem'),
-    server: path.join(options.dockerCertDir, 'server.csr'),
-    serverCert: path.join(options.dockerCertDir, 'server-cert.pem'),
+    serverKey: path.join(options.dockerCertDir, dnsName + '-server-key.pem'),
+    server: path.join(options.dockerCertDir, dnsName + '-server.csr'),
+    serverCert: path.join(options.dockerCertDir, dnsName + '-server-cert.pem'),
     clientKey: path.join(options.dockerCertDir, 'key.pem'),
     client: path.join(options.dockerCertDir, 'client.csr'),
     clientCert: path.join(options.dockerCertDir, 'cert.pem')
@@ -3761,6 +3761,11 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
         return cb(certDirError);
       }
 
+      var serverCertExists;
+      utils.fileExists(options.dockerCerts.serverCert, function(error, exists) {
+        serverCertExists = exists;
+      });
+
       if (!exists) {
         logger.verbose($('Certificates were not found.'));
         fs.mkdir(options.dockerCertDir, function(mkdirErr) {
@@ -3770,6 +3775,9 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
 
           var progress = cli.interaction.progress($('Generating docker certificates.'));
           generateDockerCertificates(function() {
+            if(!serverCertExists) {
+              generateDockerServerCertificates();
+            }
             progress.end();
             return cb();
           });
@@ -3778,7 +3786,7 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
         // We need to check if all certificates are in place.
         // If not, generate them from scratch
         checkExistingCertificates(function(missingCertificates) {
-          if (missingCertificates.length === 0) {
+          if (missingCertificates.length === 0 && serverCertExists) {
             logger.info($('Found docker certificates.'));
             return cb();
           }
@@ -3789,6 +3797,9 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
 
           var progress = cli.interaction.progress($('Generating docker certificates.'));
           generateDockerCertificates(function() {
+            if(!serverCertExists) {
+              generateDockerServerCertificates();
+            }
             progress.end();
             return cb();
           });
@@ -3801,13 +3812,9 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
     var missingCertificateErrors = [];
     checkIfCertificateExist(missingCertificateErrors, options.dockerCerts.caKey, function() {
       checkIfCertificateExist(missingCertificateErrors, options.dockerCerts.ca, function() {
-        checkIfCertificateExist(missingCertificateErrors, options.dockerCerts.serverKey, function() {
-          checkIfCertificateExist(missingCertificateErrors, options.dockerCerts.serverCert, function() {
-            checkIfCertificateExist(missingCertificateErrors, options.dockerCerts.clientKey, function() {
-              checkIfCertificateExist(missingCertificateErrors, options.dockerCerts.clientCert, function() {
-                return cb(missingCertificateErrors);
-              });
-            });
+        checkIfCertificateExist(missingCertificateErrors, options.dockerCerts.clientKey, function() {
+          checkIfCertificateExist(missingCertificateErrors, options.dockerCerts.clientCert, function() {
+            return cb(missingCertificateErrors);
           });
         });
       });
@@ -3838,40 +3845,6 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
         if (err) {
           logger.verbose(err);
         }
-
-        openssl.exec('genrsa', {
-          des3: true,
-          passout: 'pass:' + password,
-          out: options.dockerCerts.serverKey
-        }, function(err) {
-          if (err) {
-            logger.verbose(err);
-          }
-
-          openssl.exec('req', {
-            new: true,
-            passin: 'pass:' + password,
-            subj: '/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=\\*',
-            key: options.dockerCerts.serverKey,
-            out: options.dockerCerts.server
-          }, function(err) {
-            if (err) {
-              logger.verbose(err);
-            }
-
-            openssl.exec('x509', {
-              req: true,
-              days: 365,
-              in : options.dockerCerts.server,
-              passin: 'pass:' + password,
-              set_serial: 01,
-              CA: options.dockerCerts.ca,
-              CAkey: options.dockerCerts.caKey,
-              out: options.dockerCerts.serverCert
-            }, function(err) {
-              if (err) {
-                logger.verbose(err.toString());
-              }
 
               openssl.exec('genrsa', {
                 des3: true,
@@ -3914,16 +3887,6 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
                         logger.verbose(err.toString());
                       }
 
-                      openssl.exec('rsa', {
-                        passin: 'pass:' + password,
-                        in : options.dockerCerts.serverKey,
-                        passout: 'pass:' + password,
-                        out: options.dockerCerts.serverKey
-                      }, function(err) {
-                        if (err) {
-                          logger.verbose(err.toString());
-                        }
-
                         openssl.exec('rsa', {
                           passin: 'pass:' + password,
                           in : options.dockerCerts.clientKey,
@@ -3937,9 +3900,6 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
                           // setting cert permissions
                           fs.chmodSync(options.dockerCerts.caKey, 0600);
                           fs.chmodSync(options.dockerCerts.ca, 0600);
-                          fs.chmodSync(options.dockerCerts.serverKey, 0600);
-                          fs.chmodSync(options.dockerCerts.server, 0600);
-                          fs.chmodSync(options.dockerCerts.serverCert, 0600);
                           fs.chmodSync(options.dockerCerts.clientKey, 0600);
                           fs.chmodSync(options.dockerCerts.client, 0600);
                           fs.chmodSync(configPath, 0600);
@@ -3947,11 +3907,65 @@ function createDockerVM(dnsName, options, logger, cli, callback) {
                           return cb();
                         });
                       });
-                    });
-                  });
-                });
-              });
             });
+          });
+        });
+      });
+    });
+  }
+
+  function generateDockerServerCertificates() {
+    /*jshint camelcase: false */
+    var password = 'Docker123';
+    var serverCN = dnsName + '.cloudapp.net';
+
+    openssl.exec('genrsa', {
+      des3: true,
+      passout: 'pass:' + password,
+      out: options.dockerCerts.serverKey
+    }, function(err) {
+      if (err) {
+        logger.verbose(err);
+      }
+
+      openssl.exec('req', {
+        new: true,
+        passin: 'pass:' + password,
+        subj: '/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=' + serverCN,
+        key: options.dockerCerts.serverKey,
+        out: options.dockerCerts.server
+      }, function(err) {
+        if (err) {
+          logger.verbose(err);
+        }
+
+        openssl.exec('x509', {
+          req: true,
+          days: 365,
+          in : options.dockerCerts.server,
+          passin: 'pass:' + password,
+          set_serial: 01,
+          CA: options.dockerCerts.ca,
+          CAkey: options.dockerCerts.caKey,
+          out: options.dockerCerts.serverCert
+        }, function(err) {
+          if (err) {
+            logger.verbose(err.toString());
+          }
+
+          openssl.exec('rsa', {
+            passin: 'pass:' + password,
+            in : options.dockerCerts.serverKey,
+            passout: 'pass:' + password,
+            out: options.dockerCerts.serverKey
+          }, function(err) {
+            if (err) {
+              logger.verbose(err.toString());
+            }
+
+            fs.chmodSync(options.dockerCerts.serverKey, 0600);
+            fs.chmodSync(options.dockerCerts.server, 0600);
+            fs.chmodSync(options.dockerCerts.serverCert, 0600);
           });
         });
       });


### PR DESCRIPTION
As referenced in #1493 and #1523, in order to use --tlsverify the server certificates created upon first initialization of .docker need to have a CN different than *, this change generates the ca and client keys and certs upon .docker initialization, and the server keys and certs every time an instance is created, with dnsName + 'cloudapp.net' as CN.