### PR TITLE
Fixes for the Mobile Service trackAsyncOperation:

### DIFF
--- a/lib/commands/asm/mobile._js
+++ b/lib/commands/asm/mobile._js
@@ -1130,7 +1130,7 @@ exports.init = function (cli) {
   };
 
   mobile.trackAsyncOperation = function (options, requestId, callback) {
-    function waitOne() {
+    function waitOne(errorCounter) {
       var client = createClient(options),
           webResource = getWebResource(options);
       webResource.json = true;
@@ -1142,6 +1142,13 @@ exports.init = function (cli) {
 
       asyncChannel.get(function (error, body) {
         if (error) {
+          log.info('Error when getting async operation status.');
+          log.silly('error');
+          log.json('silly', error);
+          if (++errorCounter < 3) {
+            return setTimeout(function() { waitOne(errorCounter); }, 5000);
+          }
+
           return callback(new Error($('Unable to determine the status of the async operation. Please check the status on the management portal.')));
         }
 
@@ -1155,12 +1162,12 @@ exports.init = function (cli) {
           callback(new Error($('Unexpected response from Microsoft Azure. ' +
             'Please confirm the status of the mobile service in the management portal')));
         } else {
-          setTimeout(waitOne(), 5000);
+          setTimeout(function() { waitOne(0); }, 5000);
         }
       });
     }
 
-    waitOne();
+    waitOne(0);
   };
 
   var resourceTypeView = {


### PR DESCRIPTION
1. When there is an error, retry twice more before returning an error.
2. Log the error message to the silly log.
3. Fix usage of setTimeout; need to pass a function, not call the function.