### PR TITLE
Fix for https://github.com/Azure/azure-xplat-cli/issues/1593.

### DIFF
--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -54,6 +54,7 @@ exports.createClient = function (factoryOrName, credentials, endpoint) {
   }
   var client = factoryOrName(credentials,
     exports.stringTrimEnd(endpoint, '/'))
+    .withFilter(exports.certAuthFilter(credentials))
     .withFilter(log.createLogFilter())
     .withFilter(azure.UserAgentFilter.create(exports.getUserAgent()))
     .withFilter(exports.createPostBodyFilter())
@@ -130,6 +131,19 @@ function createPostBodyFilter() {
 }
 
 exports.createPostBodyFilter = createPostBodyFilter;
+
+// TODO: workaround for https://github.com/Azure/azure-xplat-cli/issues/1593. Maybe better fix in SDK(WebSiteManagementClient, etc)
+function certAuthFilter(credentials) {
+  return function handle(resource, next, callback) {
+    if (credentials && credentials.credentials && credentials.credentials.key && credentials.credentials.cert) {
+      resource.key = credentials.credentials.key;
+      resource.cert = credentials.credentials.cert;
+    }
+    return next(resource, callback);
+  };
+}
+
+exports.certAuthFilter = certAuthFilter;
 
 function createFollowRedirectFilter() {
   return function handle (resource, next, callback) {


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-xplat-cli/issues/1593.
node_modules/azure-common/lib/services/filters/proxyfilter.js:61didn't receive key and cert in resource param.
