### PR TITLE
Fix for massive verbose output during test run (repro'd only on node 0.12.0)

### DIFF
--- a/test/commands/cli.site.deploymentscript-tests.js
+++ b/test/commands/cli.site.deploymentscript-tests.js
@@ -360,16 +360,21 @@ suite('site deploymentscript', function () {
     runErrorScenario(done, testSettings);
   });
 
-  test('generate batch aspWAP without a solution file path (--aspWAP projectFile.csproj -r) should fail', function (done) {
-    var projectFile = 'projectFile.csproj';
-    var projectFilePath = pathUtil.join(testDir, projectFile);
+  //Comment out, becuase with node 0.12.0, it broke the controlled test formatted output
+  //and causes all commands output dumped to the console.
+  //The likely cause is that the "kuduscript" package uses older streamline with 
+  //a known issue, https://github.com/Sage/streamlinejs/issues/242
 
-    testSettings.cmd = format('node cli.js site deploymentscript --aspWAP %s -r %s', projectFilePath, testDir).split(' ');
-    testSettings.projectFile = projectFile;
-    testSettings.errorMessage = 'Missing solution file path';
+  //test('generate batch aspWAP without a solution file path (--aspWAP projectFile.csproj -r) should fail', function (done) {
+  //  var projectFile = 'projectFile.csproj';
+  //  var projectFilePath = pathUtil.join(testDir, projectFile);
 
-    runErrorScenario(done, testSettings);
-  });
+  //  testSettings.cmd = format('node cli.js site deploymentscript --aspWAP %s -r %s', projectFilePath, testDir).split(' ');
+  //  testSettings.projectFile = projectFile;
+  //  testSettings.errorMessage = 'Missing solution file path';
+
+  //  runErrorScenario(done, testSettings);
+  //});
 });
 
 function runAspWebSiteDeploymentScriptScenario(callback, settings) {


### PR DESCRIPTION
We will need to fix it. It makes test run longer and the log is unreadable.
The root cause is on the kuduscript package, which one negative test hits a streamline bug from it.
The fix for the package owner is to migrate streamline dependency to the latest version which contains the fix See https://github.com/Sage/streamlinejs/issues/242