### PR TITLE
Allow granting List SAS permission on storage blobs

### DIFF
--- a/lib/commands/asm/storage.blob._js
+++ b/lib/commands/asm/storage.blob._js
@@ -269,7 +269,7 @@ exports.init = function(cli) {
     .description($('Generate shared access signature of storage blob'))
     .option('--container <container>', $('the storage container name'))
     .option('--blob <blobName>', $('the storage blob name'))
-    .option('--permissions <permissions>', $('the operation permissions combining symbols of r(Read)/w(Write)/d(Delete)'))
+    .option('--permissions <permissions>', $('the operation permissions combining symbols of r(Read)/w(Write)/d(Delete)/l(List)'))
     .option('--start <start>', $('the UTC time at which the SAS becomes valid'))
     .option('--expiry <expiry>', $('the UTC time at which the SAS expires'))
     .option('--policy <policy>', $('the stored access policy identifier'))

--- a/lib/util/storage.util._js
+++ b/lib/util/storage.util._js
@@ -127,6 +127,7 @@ StorageUtil.BlobPermission = {
   Read: 'r',
   Write: 'w',
   Delete: 'd',
+  List: 'l',
 };
 
 /**


### PR DESCRIPTION
fixes #1639

This allows generating a SAS url to a VHD that is compatible with azure's marketplace certification process. The certification team requires blobs be submitting with both Read and List permissions, and recommends the use of the Azure Storage Explorer GUI to do so:

![image](https://cloud.githubusercontent.com/assets/2567/6815859/b1cff53c-d248-11e4-94cb-433d542036fd.png)
