### PR TITLE
Implemented bootstrap option for chef extension 

### DIFF
--- a/lib/commands/asm/vm._js
+++ b/lib/commands/asm/vm._js
@@ -185,6 +185,7 @@ exports.init = function(cli) {
     .option('-O, --validation-pem <validation-pem>', $('chef validation pem file path'))
     .option('-c, --client-config <client-config>', $('chef client configuration file(i.e client.rb) path'))
     .option('-a, --auto-update-client', $('auto update chef client'))
+    .option('-j, --bootstrap-options <bootstrap-json-attribute>', $('Bootstrap options in JSON format'))
     .option('-b, --disable', $('disable extension'))
     .option('-u, --uninstall', $('uninstall extension'))
     .option('-d, --dns-name <name>', $('consider VM hosted in this DNS name'))

--- a/lib/commands/asm/vm/vmclient.js
+++ b/lib/commands/asm/vm/vmclient.js
@@ -2929,7 +2929,7 @@ _.extend(VMClient.prototype, {
               config['client_rb'] = data.toString();
               config['runlist'] = options.runList;
               config['autoUpdateClient'] = options.autoUpdateClient ? 'true' : 'false';
-              config['bootstrap_options'] = options.bootstrapOptions;
+              config['bootstrap_options'] = JSON.parse(options.bootstrapOptions);
               options[propTo] = JSON.stringify(config);
             } else if (propTo == 'privateConfig') {
               config['validation_key'] = data.toString();

--- a/lib/commands/asm/vm/vmclient.js
+++ b/lib/commands/asm/vm/vmclient.js
@@ -2929,6 +2929,7 @@ _.extend(VMClient.prototype, {
               config['client_rb'] = data.toString();
               config['runlist'] = options.runList;
               config['autoUpdateClient'] = options.autoUpdateClient ? 'true' : 'false';
+              config['bootstrap_options'] = options.bootstrapOptions;
               options[propTo] = JSON.stringify(config);
             } else if (propTo == 'privateConfig') {
               config['validation_key'] = data.toString();


### PR DESCRIPTION
Added changes to support -bootstrap-options option for chef extension to send bootstrap config in JSON format. 
Ex: azure vm extension set-chef myvm --bootstrap-options '{"chef_node_name" : "mynode"}'