### PR TITLE
Bug fix for hdinsight cluster management commands.

### DIFF
--- a/lib/commands/asm/hdinsight._js
+++ b/lib/commands/asm/hdinsight._js
@@ -246,8 +246,7 @@ var hdInsightCommandLine = function(cli, userInteractor, executionProcessor) {
     this.processor = new ExecutionProcessor(this.cli);
   }
 
-  this.createClusterCommand = function (clusterName, osType, storageAccountName, storageAccountKey, storageContainer, dataNodeCount, headNodeSize, dataNodeSize, location, userName, password, subscription, sshUserName, sshPassword, _) {
-
+  this.createClusterCommand = function (clusterName, osType, storageAccountName, storageAccountKey, storageContainer, dataNodeCount, headNodeSize, dataNodeSize, location, userName, password, sshUserName, sshPassword, _) {
     clusterName = self.user.promptIfNotGiven($('Cluster name: '), clusterName, _);
     osType = self.user.promptIfNotGiven($('OS type: '), osType, _);
     storageAccountName = self.user.promptIfNotGiven($('storage account name: '), storageAccountName, _);
@@ -276,11 +275,11 @@ var hdInsightCommandLine = function(cli, userInteractor, executionProcessor) {
       clusterPayload += '                <RemoteDesktopSettings z:Id="i3">';
       clusterPayload += '                  <AuthenticationCredential z:Id="i4"/>';
       clusterPayload += '                </RemoteDesktopSettings>';
-      clusterPayload += '                <VMSize>Large</VMSize>';
-      clusterPayload += '                <VMSizeAsString>A6</VMSizeAsString>';
+      clusterPayload += '                <VMSize>Small</VMSize>';
+      clusterPayload += '                <VMSizeAsString>Small</VMSizeAsString>';
       clusterPayload += '              </ClusterRole><ClusterRole z:Id="i5">';
       clusterPayload += '              <FriendlyName>HeadNodeRole</FriendlyName>';
-      clusterPayload += '              <InstanceCount>1</InstanceCount>';
+      clusterPayload += '              <InstanceCount>2</InstanceCount>';
       clusterPayload += '              <RemoteDesktopSettings z:Id="i6">';
       clusterPayload += '                <AuthenticationCredential z:Id="i7"/>';
       clusterPayload += '              </RemoteDesktopSettings>';
@@ -359,12 +358,12 @@ var hdInsightCommandLine = function(cli, userInteractor, executionProcessor) {
       var cluster2Payload = '<Resource xmlns="http://schemas.microsoft.com/windowsazure">';
       cluster2Payload += ' <SchemaVersion>1.0</SchemaVersion><IntrinsicSettings><IaasCluster xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management"><ApiVersion xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">1.0</ApiVersion><DeploymentDocuments xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management"><a:KeyValueOfstringstring><a:Key>AmbariConfiguration</a:Key><a:Value>{';
       cluster2Payload += ' "blueprint": "hadoop",';
-      cluster2Payload += ' "default_password": "admin",';
+      cluster2Payload += ' "default_password": "' + password + '",';
       cluster2Payload += ' "configurations": [';
         cluster2Payload += ' {';
           cluster2Payload += ' "core-site":{';
-            cluster2Payload += ' "fs.defaultFS": "wasb://' + storageContainer + '@' + storageAccountName + '.blob.core.windows.net",';
-            cluster2Payload += ' "fs.azure.account.key.' + storageAccountName + '.blob.core.windows.net": "' + storageAccountKey + '"';
+            cluster2Payload += ' "fs.defaultFS": "wasb://' + storageContainer + '@' + storageAccountName + '",';
+            cluster2Payload += ' "fs.azure.account.key.' + storageAccountName + '": "' + storageAccountKey + '"';
           cluster2Payload += ' }';
         cluster2Payload += ' }';
       cluster2Payload += ' ],';
@@ -389,8 +388,8 @@ var hdInsightCommandLine = function(cli, userInteractor, executionProcessor) {
                     cluster2Payload += ' "osProfile": {';
                         cluster2Payload += ' "computerNamePattern": "gateway\#\#\#\#",';
                         cluster2Payload += ' "windowsOperatingSystemProfile": {';
-                            cluster2Payload += ' "adminUsername": "' + userName + '",';
-                            cluster2Payload += ' "adminPassword": "' + password + '",';
+                            cluster2Payload += ' "adminUsername": "hdiuser",';
+                            cluster2Payload += ' "adminPassword": "",';
                             cluster2Payload += ' "customData": "",';
                             cluster2Payload += ' "storedCertificateSettingsProfile": []';
                         cluster2Payload += ' }';
@@ -609,10 +608,10 @@ var hdInsightCommandLine = function(cli, userInteractor, executionProcessor) {
     cluster2Payload += ' }';
     cluster2Payload += ' </a:Value></a:KeyValueOfstringstring></DeploymentDocuments>' + 
     '<HdiVersion xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">3.2</HdiVersion>' + 
-    '<Id xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">"' + clusterName + 
-    '"</Id><Location xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">"' + location + 
-    '"</Location><UserSubscriptionId xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">"' + 
-    subscriptionId + '"</UserSubscriptionId><UserTags xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">' + 
+    '<Id xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">' + clusterName + 
+    '</Id><Location xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">' + location + 
+    '</Location><UserSubscriptionId xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">' + 
+    subscriptionId + '</UserSubscriptionId><UserTags xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays" xmlns="http://schemas.microsoft.com/hdinsight/2014/05/management">' + 
     '<a:KeyValueOfstringstring><a:Key>Client</a:Key><a:Value>HDInsight xplat SDK 1.0.0.0</a:Value></a:KeyValueOfstringstring></UserTags></IaasCluster></IntrinsicSettings></Resource>';
     
     clusterCreationPayload = {'payload' : cluster2Payload};


### PR DESCRIPTION
List of bugs fixed in this change. 

1. Xplat-CLI tool failed to create Linux cluster, Error "Version '3.2' is not available in Azure region '"East US 2"'."

2. XPlat-CLI failed to create windows cluster. Error: "VM size is not allowed for the specified cluster"

3. XPlat-CLI shows succeeded to create linux cluster but actually failed. error "DeploymentDocument 'CsmDocument_2_0' failed the validation. Error: 'UserPassword for Linux OS Profile must be 6-72 characters long and meet complexity requirements'"

4. XPlat-CLI shows succeeded but actually failed to create linux cluster: "DeploymentDocument 'AmbariConfiguration_1_7' failed the validation. Error: 'The password set in Ambari configuration default_password field must meet Azure password policy'"

5. XPlat-CLI failed to create linux cluster: DeploymentDocument 'AmbariConfiguration_1_7' failed the validation. Error: 'Failed to resolve DNS of default storage account'