### PR TITLE
Work around packaging failure on node 0.10.23 from unc path

### DIFF
--- a/lib/commands/arm/apiapp/lib/dirops.js
+++ b/lib/commands/arm/apiapp/lib/dirops.js
@@ -64,7 +64,6 @@ function ensureDirExists(destPath, done) {
 // Copies the entire contents of sourcePath to destPath. Ensures
 // destpath already exists.
 function copyDir(sourcePath, destPath, done) {
-
   var inProgressCopies = 0;
   var walkDone = false;
 
@@ -78,7 +77,15 @@ function copyDir(sourcePath, destPath, done) {
 
   walker.on('file', function (root, stats, next) {
     var fullPathToFile = path.join(root, stats.name);
-    var relativePathToFile = path.relative(sourcePath, fullPathToFile);
+
+    // Node 0.10.23's path.relative method has a bug on windows
+    // when using unc paths - the starting double backslash screws it up.
+    // Stripping off the first backslash works around the bug.
+    var source = sourcePath;
+    if (source.slice(0, 2) === '\\\\') {
+      source = source.slice(1);
+    }
+    var relativePathToFile = path.relative(source, fullPathToFile);
     var fullPathToDest = path.join(destPath, relativePathToFile);
     ++inProgressCopies;
 


### PR DESCRIPTION
A partner team reported failure to build packages when the package source was on a unc share. Turns out there's a bug in node 0.10.23's path module when the source directory is a full unc path. This fix works around the bug.