### PR TITLE
Move events client out of azure rollup into its own azure-monitoring

### DIFF
--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -182,7 +182,8 @@ exports.createResourceFeatureClient = function (subscription) {
 };
 
 exports.createEventsClient = function (subscription) {
-  return _createArmClient('createEventsClient', subscription);
+  var factoryMethod = require('azure-monitoring').createEventsClient;
+  return _createArmClient(factoryMethod, subscription);
 };
 
 exports.createKeyVaultClient = function (subscription, vaultUri) {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "azure-insights": "0.7.7-pre",
     "azure-mgmt-authorization": "0.9.0-pre.6",
     "azure-mgmt-resource": "2.0.0-pre.17",
+    "azure-monitoring": "0.10.0",
     "azure-storage": "0.4.1",
     "azure-storage-legacy": "0.9.13",
     "azure-keyvault": "0.9.2",


### PR DESCRIPTION
Move events client out of azure rollup into its own azure-monitoring. This will also fix a bug with "caller" field missing for group log commands using the old monitoring sdk