### PR TITLE
Changes to add deleteChefConfig option for set chef extension command

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -8,7 +8,10 @@ Version 0.9.2
     * Added commands to handle alerts and alert rules, autoscale events and autoscale settings, list metrics and metrics definitions, and list usage metrics
   * ApiApp
     * Added package create command
-
+*ASM
+  * VM
+    * Chef Extension
+      * Implemented new option --delete-chef-config for set-chef extension commands
 Version 0.9.1
 * ARM
   * Virtual machines 

--- a/lib/commands/asm/vm._js
+++ b/lib/commands/asm/vm._js
@@ -187,6 +187,7 @@ exports.init = function(cli) {
     .option('-c, --client-config <client-config>', $('chef client configuration file(i.e client.rb) path'))
     .option('-a, --auto-update-client', $('auto update chef client'))
     .option('-j, --bootstrap-options <bootstrap-json-attribute>', $('Bootstrap options in JSON format. Ex: -j \'{"chef_node_name":"test_node"}\''))
+    .option('-D, --delete-chef-config', $('delete chef config files during update/uninstall extension'))
     .option('-b, --disable', $('disable extension'))
     .option('-u, --uninstall', $('uninstall extension'))
     .option('-d, --dns-name <name>', $('consider VM hosted in this DNS name'))

--- a/lib/commands/asm/vm/vmclient.js
+++ b/lib/commands/asm/vm/vmclient.js
@@ -2931,6 +2931,7 @@ _.extend(VMClient.prototype, {
               config['client_rb'] = data.toString();
               config['runlist'] = options.runList;
               config['autoUpdateClient'] = options.autoUpdateClient ? 'true' : 'false';
+              config['deleteChefConfig'] = options.deleteChefConfig ? 'true' : 'false';
               if (options.bootstrapOptions) {
                 try {
                   config['bootstrap_options'] = JSON.parse(options.bootstrapOptions);


### PR DESCRIPTION
Introduced new option `--delete-chef-config` for azure vm extension set-chef command.

`--delete-chef-config` is useful in uninstall/update extension process to decide whether to keep chef config on VM.