### PR TITLE
#1811 use blobService.getUrl helper function to return a URL for the …

### DIFF
--- a/lib/commands/storage/storage.blob._js
+++ b/lib/commands/storage/storage.blob._js
@@ -570,7 +570,7 @@ exports.init = function(cli) {
       start = validation.parseDateTime(options.start);
     }
 
-    var output = { sas: '' };
+    var output = { sas: '', url: '' };
     var sharedAccessPolicy = StorageUtil.getSharedAccessPolicy(permissions, start, expiry, null, options.policy);
     var tips;
     if (isOnContainer) {
@@ -581,12 +581,14 @@ exports.init = function(cli) {
     startProgress(tips);
     try {
       output.sas = blobService.generateSharedAccessSignature(container, blob, sharedAccessPolicy);
+      output.url = blobService.getUrl(container, blob, output.sas);
     } finally {
       endProgress();
     }
 
     cli.interaction.formatOutput(output, function(outputData) {
       logger.data($('Shared Access Signature'), outputData.sas);
+      logger.data($('Shared Access URL'), outputData.url);
     });
   }
 


### PR DESCRIPTION
…SAS blobs/containers. See #1811. This makes the output of the command more human useable - you can then cut and paste the full SAS URL.