### PR TITLE
add script to regenerate metadata files during build installer

### DIFF
--- a/tools/osx-setup/scripts/azure
+++ b/tools/osx-setup/scripts/azure
@@ -4,12 +4,27 @@
 
 process.env.PRECOMPILE_STREAMLINE_FILES = 1
 
-var AzureCli = require('/usr/local/azure/lib/cli');
+var AutoComplete = require('/usr/local/azure/lib/autocomplete');
+//load the autocomplete, so that rest code in the file will not execute 
+//till the command gets committed. This gets autocomplete faster
+new AutoComplete();
 
-var cli = new AzureCli();
-cli.parse(process.argv);
-if (cli.args.length == 0) {
+var AzureCli = require('/usr/local/azure/lib/cli');
+var Constants = require('/usr/local/azure/lib/util/constants');
+
+if (process.argv[2] !== '--gen') {
+  cli = new AzureCli();
+  cli.parse(process.argv);
+  if (cli.args.length === 0) {
     cli.parse(['', '', '-h']);
+  }
+} else {
+  if (process.argv[3]) {
+    cli = new AzureCli(null, null, process.argv[3]);
+  } else {
+    cli = new AzureCli(null, null, Constants.API_VERSIONS.ARM);
+    cli = new AzureCli(null, null, Constants.API_VERSIONS.ASM);
+  }
 }
 
 // Note: this script makes use of a private, local binary of Node 

--- a/tools/osx-setup/scripts/createTarball.sh
+++ b/tools/osx-setup/scripts/createTarball.sh
@@ -146,6 +146,11 @@ node node_modules/streamline/bin/_node --verbose -c node_modules/streamline/lib/
 node node_modules/streamline/bin/_node --verbose -c node_modules/streamline-streams/lib
 popd
 
+# generate command metadata file
+pushd /tmp/azureInstallerTemporary
+node bin/azure --gen
+popd
+
 # Copy licensing files
 cp resources/ThirdPartyNotices.txt /tmp/azureInstallerTemporary/ThirdPartyNotices.txt
 cp resources/LICENSE.rtf /tmp/azureInstallerTemporary/LICENSE.rtf

--- a/tools/windows/scripts/prepareRepoClone.cmd
+++ b/tools/windows/scripts/prepareRepoClone.cmd
@@ -86,6 +86,11 @@ if %errorlevel% neq 0 goto ERROR
 if %errorlevel% neq 0 goto ERROR
 popd
 
+echo Generating streamline files...
+pushd %TEMP_REPO%
+.\bin\node.exe bin\azure --gen
+popd
+
 echo Removing unneeded files from azure module...
 pushd %TEMP_REPO%
 


### PR DESCRIPTION
we need to regenerate because the installer will  pre-compile streamline files so that the file extension needs to be refreshed from '._js' to '.js' in the metadata 