### PR TITLE
add --remote-subnet option for setting acl-rule

### DIFF
--- a/lib/commands/asm/vm._js
+++ b/lib/commands/asm/vm._js
@@ -452,6 +452,7 @@ exports.init = function(cli) {
     .option('-o, --order <id>', $('the ACL rule order'))
     .option('-w, --new-order <id>', $('the new order for the ACL'))
     .option('-a, --action  <name>', $('the new action for the ACL'))
+    .option('-t, --remote-subnet  <subnet>', $('the ACL rule remote subnet'))
     .option('-r, --description  <name>', $('the new description for the ACL'))
     .option('-d, --dns-name <name>', $('filter VMs for the specified DNS name'))
     .option('-s, --subscription <id>', $('the subscription id'))


### PR DESCRIPTION
The --remote-subnet option is missing from commander settings.