### PR TITLE
ensure values returned from prompt is not empty by prompt 

### DIFF
--- a/lib/commands/storage/storage.blob._js
+++ b/lib/commands/storage/storage.blob._js
@@ -551,8 +551,6 @@ exports.init = function(cli) {
     var isOnContainer = !blob;
     container = interaction.promptIfNotGiven($('Container name: '), container, _);
 
-    blob = interaction.promptIfNotGiven($('Blob name: '), blob, _);
-
     if (!options.policy) {
       permissions = interaction.promptIfNotGiven($('Permissions: '), permissions, _);
       if (isOnContainer) {

--- a/lib/util/interaction._js
+++ b/lib/util/interaction._js
@@ -212,12 +212,11 @@ __.extend(Interactor.prototype, {
   },
 
   promptIfNotGiven: function (promptString, currentValue, _) {
-    if (__.isUndefined(currentValue)) {
-      var value = this.prompt(promptString, _);
-      return value;
-    } else {
-      return currentValue;
+    var givenValue = currentValue;
+    while (!givenValue) {
+      givenValue = this.prompt(promptString, _);
     }
+    return givenValue;
   },
 
   choose: function (values, callback) {


### PR DESCRIPTION
Before, you can press ENTER, and the command continues and fails later; with the change, you will be prompted again, till you input a non-null value.
I could create a new routine for enforced check, but after cross checked all code, i see no reason to accept empty value. If some commands do, then they should not even prompt.
