### PR TITLE
Speed improvement when running apiapp tests mocked

### DIFF
--- a/test/commands/arm/apiapp/arm.apiapp-tests.js
+++ b/test/commands/arm/apiapp/arm.apiapp-tests.js
@@ -45,6 +45,7 @@ describe('arm', function () {
   var subscription;
   var resourceClient;
   var deploymentNameStub;
+  var originalSetTimeout = setTimeout;
 
   before(function (done) {
     // Stub deployLib's createDeploymentName function so that
@@ -57,6 +58,11 @@ describe('arm', function () {
       location = process.env.AZURE_APIAPP_TEST_LOCATION;
       subscription = profile.current.getSubscription();
       resourceClient = utils.createResourceClient(subscription);
+      if (suite.isPlayback()) {
+        setTimeout = function (action, timeout) {
+          process.nextTick(action);
+        };
+      }
       done();
     });
   });
@@ -72,6 +78,7 @@ describe('arm', function () {
           resourceClient.resourceGroups.deleteMethod(groupName, next);
         }, done);
       } else {
+        setTimeout = originalSetTimeout;
         done();
       }
     });

--- a/test/commands/arm/apiapp/lib/deployLib-tests.js
+++ b/test/commands/arm/apiapp/lib/deployLib-tests.js
@@ -40,6 +40,7 @@ describe('apiapp', function () {
     var createdGroups = [];
     var subscription;
     var resourceClient;
+    var originalSetTimeout = setTimeout;
 
     before(function(done) {
       suite = new CLITest(this, testPrefix, requiredEnvironment);
@@ -47,6 +48,11 @@ describe('apiapp', function () {
         location = process.env.AZURE_APIAPP_TEST_LOCATION;
         subscription = profile.current.getSubscription();
         resourceClient = utils.createResourceClient(subscription);
+        if (suite.isPlayback()) {
+          setTimeout = function (action, timeout) {
+            process.nextTick(action);
+          };
+        }
         done();
       });
     });
@@ -60,6 +66,7 @@ describe('apiapp', function () {
             resourceClient.resourceGroups.deleteMethod(groupName, next);
           }, done);
         } else {
+          setTimeout = originalSetTimeout;
           done();
         }
       });


### PR DESCRIPTION
Mocked out setTimeout so that it's not waiting five seconds per poll even when running mocked.