### PR TITLE
fix login as service principal

### DIFF
--- a/lib/util/profile/environment.js
+++ b/lib/util/profile/environment.js
@@ -185,7 +185,7 @@ _.extend(Environment.prototype, {
         if (err) { return callback(err); }
         var tenantInfo = {
           tenantId: tenant, 
-          accessToken: token
+          authContext: token
         };
         subscriptionUtils.getSubscriptionsFromTenants(self, username, [tenantInfo], processSubscriptions);
       });

--- a/lib/util/profile/subscriptionUtils.js
+++ b/lib/util/profile/subscriptionUtils.js
@@ -44,7 +44,7 @@ function getSubscriptionsFromTenants(environment, username, tenantList, callback
   var subscriptions = [];
   async.eachSeries(tenantList, function (tenant, cb) {
     var tenantId = tenant.tenantId;
-    var armClient = environment.getArmClient(_createCredential(tenant.authContext));
+    var armClient = environment.getArmClient(_createCredential(tenant.accessToken));
     armClient.subscriptions.list(function (err, result) {
       if (!err) {
         subscriptions = subscriptions.concat(result.subscriptions.map(function (s) {

--- a/lib/util/profile/subscriptionUtils.js
+++ b/lib/util/profile/subscriptionUtils.js
@@ -44,7 +44,7 @@ function getSubscriptionsFromTenants(environment, username, tenantList, callback
   var subscriptions = [];
   async.eachSeries(tenantList, function (tenant, cb) {
     var tenantId = tenant.tenantId;
-    var armClient = environment.getArmClient(_createCredential(tenant.accessToken));
+    var armClient = environment.getArmClient(_createCredential(tenant.authContext));
     armClient.subscriptions.list(function (err, result) {
       if (!err) {
         subscriptions = subscriptions.concat(result.subscriptions.map(function (s) {


### PR DESCRIPTION
this is a temp fix. The good fix, which would happen shortly in dev branch, would be refactor the environment.js and do not use the "accessToken" field naming, which really means an authentication context