### PR TITLE
Corrected test data for extension test

### DIFF
--- a/test/data/imageUrn.json
+++ b/test/data/imageUrn.json
@@ -1,1 +1,1 @@
-{"ImageUrn":[{"Windows": "MicrosoftWindowsServer:WindowsServer:2008-R2-SP1:2.0.201502"},{"Linux":"Canonical:UbuntuServer:12.04.2-LTS:12.04.201302250"}]}
+{"ImageUrn":[{"Windows": "MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.0.201503"},{"Linux":"Canonical:UbuntuServer:12.04.2-LTS:12.04.201302250"}]}


### PR DESCRIPTION
There is a known issue where we are trying to set extension and it throws error on windows 2008 offers. Refering tracking bug in here https://github.com/MSOpenTech/azure-xplat-cli/issues/368. This test data is corrected to have windows 2012 offers where extension set works correctly.