### PR TITLE
Fix for creating apiapps without package id

### DIFF
--- a/lib/commands/arm/apiapp/apiapp._js
+++ b/lib/commands/arm/apiapp/apiapp._js
@@ -149,6 +149,10 @@ exports.init = function initApiAppCommands(cli) {
         }
       }
 
+      if (!options.nugetPackage) {
+        options.nugetPackage = 'Microsoft.ApiApp';
+      }
+
       var subscription = profile.current.getSubscription(options.subscription);
       var packageInfo = parsePackageName(options.nugetPackage);
       var resourceClient = utils.createResourceClient(subscription);


### PR DESCRIPTION
Fixes issue with "apiapp create" when you don't give the -u switch.
