### PR TITLE
Fix bug in creating log directory

### DIFF
--- a/test/framework/test-logger.js
+++ b/test/framework/test-logger.js
@@ -29,7 +29,7 @@ var currentTest = '';
 //provides the log directory where the test logs would reside 
 function getLogDir() {
   if(!fs.existsSync(testLogDir)) {
-    fs.mkdir(testLogDir);
+    fs.mkdirSync(testLogDir);
   }
   return testLogDir;
 };


### PR DESCRIPTION
Fix bug where create logging file would fail because mkdir method was not synchronous.

- Log directory would not be created in time on a slower computer, causing the log file creation to throw a 'file does not exist' error.