### PR TITLE
2 util commands to help people diagnose cli access token storage issues

### DIFF
--- a/tools/windows/scripts/deleteTokens.cmd
+++ b/tools/windows/scripts/deleteTokens.cmd
@@ -1,7 +1,7 @@
 ::
-:: Microsoft Azure CLI - scripts to disable tracing through fiddler
+:: Microsoft Azure CLI - delete all cli's access tokens saved 
+:: in the local security store.
 :: Copyright (C) Microsoft Corporation. All Rights Reserved.
 ::
 
-::delete all cli's access tokens saved in the local security store.
 ..\..\..\bin\windows\creds.exe -d -t AzureXplatCli:target=* -g

--- a/tools/windows/scripts/deleteTokens.cmd
+++ b/tools/windows/scripts/deleteTokens.cmd
@@ -1,0 +1,7 @@
+::
+:: Microsoft Azure CLI - scripts to disable tracing through fiddler
+:: Copyright (C) Microsoft Corporation. All Rights Reserved.
+::
+
+::delete all cli's access tokens saved in the local security store.
+..\..\..\bin\windows\creds.exe -d -t AzureXplatCli:target=* -g

--- a/tools/windows/scripts/listTokens.cmd
+++ b/tools/windows/scripts/listTokens.cmd
@@ -1,0 +1,7 @@
+::
+:: Microsoft Azure CLI - scripts to disable tracing through fiddler
+:: Copyright (C) Microsoft Corporation. All Rights Reserved.
+::
+
+::display all cli's access tokens saved in the local security store.
+..\..\..\bin\windows\creds.exe -s -t AzureXplatCli:target=* -g

--- a/tools/windows/scripts/listTokens.cmd
+++ b/tools/windows/scripts/listTokens.cmd
@@ -1,7 +1,7 @@
 ::
-:: Microsoft Azure CLI - scripts to disable tracing through fiddler
+:: Microsoft Azure CLI - display all cli's access tokens saved 
+:: in the local security store.
 :: Copyright (C) Microsoft Corporation. All Rights Reserved.
 ::
 
-::display all cli's access tokens saved in the local security store.
 ..\..\..\bin\windows\creds.exe -s -t AzureXplatCli:target=* -g


### PR DESCRIPTION
Simple wraps around cred.exe which has pretty hard-to-remember target filter formats 