### PR TITLE
update the azure-common version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "adal-node": "0.1.13",
     "async": "0.2.7",
-    "azure-common": "0.9.12",
+    "azure-common": "0.9.13",
     "azure-extra": "0.1.7",
     "azure-gallery": "2.0.0-pre.15",
     "azure-insights": "0.7.7-pre",

--- a/tools/windows/scripts/deleteTokens.cmd
+++ b/tools/windows/scripts/deleteTokens.cmd
@@ -4,4 +4,4 @@
 :: Copyright (C) Microsoft Corporation. All Rights Reserved.
 ::
 
-..\..\..\bin\windows\creds.exe -d -t AzureXplatCli:target=* -g
+%~dp0..\..\..\bin\windows\creds.exe -d -t AzureXplatCli:target=* -g

--- a/tools/windows/scripts/listTokens.cmd
+++ b/tools/windows/scripts/listTokens.cmd
@@ -4,4 +4,4 @@
 :: Copyright (C) Microsoft Corporation. All Rights Reserved.
 ::
 
-..\..\..\bin\windows\creds.exe -s -t AzureXplatCli:target=* -g
+%~dp0..\..\..\bin\windows\creds.exe -s -t AzureXplatCli:target=* -g


### PR DESCRIPTION
This will leverage recent version update on sdk lib of using ^ on common dependency. The positive consequence is we will have less different version of azure-common scattered under "node_modules"