### PR TITLE
Keep password authentication if --ssh or --no-ssh-endpoint is given.

### DIFF
--- a/lib/commands/asm/vm/vmclient.js
+++ b/lib/commands/asm/vm/vmclient.js
@@ -4525,7 +4525,7 @@ function createRole(name, dnsPrefix, image, options, logger, cli, callback) {
           userPassword: options.password
         };
 
-        if (options.ssh || options.noSshPassword) {
+        if (options.ssh || options.noSshEndpoint) {
           provisioningConfig.disableSshPasswordAuthentication = 'false';
 
           if (options.sshCert) {


### PR DESCRIPTION
WALinuxAgent currently disables SSH password authentication by default
unless provisioning data explicitely sets DisableSshPasswordAuthentication
to false.  This patch triggers adding DisableSshPasswordAuthentication
element when either --ssh or --no-ssh-endpoint is given.  Value is set
to false by default and true when --no-ssh-password is given.

See also #1601, #1625 and #1667.