### PR TITLE
Disabling DR test in automated runs

### DIFF
--- a/test/testlist.txt
+++ b/test/testlist.txt
@@ -3,6 +3,8 @@
 #commands/cli.site.domain-tests.js
 # TODO: Not recording call to log service properly, disabling
 # commands/cli.site.log.tail-tests.js
+# Disabling, do not want this run in automated test runs
+# commands/cli.mobile.migration-tests.js
 # TODO: This suite uses custom recording
 cli-tests.js
 commands/cli.account-tests.js
@@ -24,7 +26,6 @@ commands/cli.mobile.scale-tests.js
 commands/cli.mobile.script-tests.js
 commands/cli.mobile.table-tests.js
 commands/cli.mobilerecover-tests.js
-commands/cli.mobile.migration-tests.js
 commands/cli.sb-tests.js
 commands/cli.service-tests.js
 commands/cli.site.deployment-tests.js


### PR DESCRIPTION
Disabling cli.mobile.migration-tests as we do not want it to be run by automation (instability, static mobile service names, occasional environment cleanup required).  We run monthly disaster recovery tests which test this command.