### PR TITLE
Make "help <command>" work

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -499,8 +499,12 @@ _.extend(AzureCli.prototype, {
         }
       }
 
-      //we have found the command, let us load and execute it.
+      //we have found the command, execute it.
       if (targetCmd) {
+        //no need to load the command file, as we get help from the metadata file
+        if (i+1 < args.length && (args[i+1] === '-h' || args[i+1] === '--help')) {
+          return targetCmd.commandHelpInformation();
+        }
         this.executingCmd = true;
         if (!this.workaroundOnAsmSiteCommands(targetCmd, command)) {
           targetCmd = require(targetCmd.filePath);

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -14,34 +14,24 @@
 // limitations under the License.
 // 
 
-var util = require('util');
-
 var utils = require('../util/utils');
 var $ = utils.getLocaleString;
 
 exports.init = function (cli) {
   var log = cli.output;
-
+  
   cli.command('help [command]')
     .description($('Display help for a given command'))
     .execute(function (name) {
-      if (!name) {
-        if (log.format().json) {
-          log.json(cli.helpJSON());
-        } else {
-          cli.parse(['', '', '-h']);
-        }
-      } else if (!cli.categories[name]) {
-        throw new Error(util.format($('Unknown command name %s'), name));
+    if (!name) {
+      if (log.format().json) {
+        log.json(cli.helpJSON());
       } else {
-        var args = ['', ''].concat(cli.rawArgs.slice(4), ['-h']);
-
-        var cat = cli.categories[name];
-        if (cat.stub) {
-          cat = cli.loadCategory(cli, name);
-        }
-
-        cat.parse(args);
+        cli.parse(['', '', '-h']);
       }
-    });
+    } else {
+      var args = ['', ''].concat(cli.rawArgs.slice(3), ['-h']);
+      cli.parse(args);
+    }
+  });
 };

--- a/test/commands/cli.help-tests.js
+++ b/test/commands/cli.help-tests.js
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+require('should');
+var help = require('../../lib/commands/help');
+describe('cli', function(){
+  describe('help', function() {
+    it('should display help using help <command>', function (done) {
+      var cmdBody;
+      var argsToParse;
+      var cli = {
+        rawArgs : ['node', 'azure', 'help', 'vm' ],
+        command: function () { return this; },
+        description: function () { return this; },
+        execute: function (impl) { cmdBody = impl; },
+        parse: function (args) { argsToParse = args;}
+      };
+      help.init(cli);
+      cmdBody('help');
+      argsToParse.length.should.equal(4);
+      argsToParse[2].should.equal('vm');
+      argsToParse[3].should.equal('-h');
+      done();
+    });
+  });
+});

--- a/test/testlist.txt
+++ b/test/testlist.txt
@@ -11,6 +11,7 @@ commands/cli.account-tests.js
 commands/cli.account.cert-tests.js
 commands/cli.account.environment-tests.js
 commands/cli.account.affinitygroup-tests.js
+commands/cli.help-tests.js
 commands/cli.mobile-tests.js
 commands/cli.mobile.api-tests.js
 commands/cli.mobile.appsetting-tests.js


### PR DESCRIPTION
fix https://github.com/Azure/azure-xplat-cli/issues/1915
Also I tweaked the code to get the help from the metadata file rather loading the command file. This should get several seconds of perf improvement