### PR TITLE
Added silly log report upon CLI failures

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -132,16 +132,23 @@ _.extend(AzureCli.prototype, {
     return path.join(utilsCore.azureDir(), 'azure.err');
   },
 
+  getSillyErrorFile: function () {
+    return path.join(utilsCore.azureDir(), 'azure.details.err');
+  },
+
   recordError: function (err) {
-    if (err && err.stack) {
+    if (err) {
       var errorFile = this.getErrorFile();
       try {
-        fs.writeFileSync(errorFile, (new Date()) + ':\n' +
+        var writeFileFunction = process.env.AZURE_CLI_APPEND_LOGS ? fs.appendFileSync : fs.writeFileSync;
+        writeFileFunction(errorFile, (new Date()) + ':\n' +
             util.inspect(err) + '\n' + err.stack + '\n');
         (log.format().json ? log.error : log.info)('Error information has been recorded to ' + errorFile);
       } catch (err2) {
         log.warn('Cannot save error information :' + util.inspect(err2));
       }
+
+      log.default.transports.silly.writeToFile(this.getSillyErrorFile(), process.env.AZURE_CLI_APPEND_LOGS);
     }
   },
 

--- a/lib/util/logging.js
+++ b/lib/util/logging.js
@@ -27,13 +27,15 @@ var util = require('util');
 var wrap = require('wordwrap');
 
 require('./patch-winston');
-
+require('./sillyTransport');
 // use cli output settings by default
 log.cli();
 
+log.add(log.transports.Silly);
+
 log.format = function (options) {
   for (var i in log['default'].transports) {
-    if (log['default'].transports.hasOwnProperty(i)) {
+    if (log['default'].transports.hasOwnProperty(i) && i !== 'silly') {
       var transport = log['default'].transports[i];
       if (arguments.length === 0) {
         return {

--- a/lib/util/sillyTransport.js
+++ b/lib/util/sillyTransport.js
@@ -78,8 +78,8 @@ Silly.prototype.log = function (level, msg, meta, callback) {
 
   output = common.log({
     colorize:    this.colorize,
-    json:        this.json,
-    level:       this.level,
+    json:        (level === 'data') ?  true : this.json,
+    level:       level,
     message:     msg,
     meta:        meta,
     stringify:   this.stringify,

--- a/lib/util/sillyTransport.js
+++ b/lib/util/sillyTransport.js
@@ -1,0 +1,115 @@
+//
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+var util = require('util');
+var winston = require('winston');
+var common = require('winston/lib/winston/common');
+var fs = require('fs');
+
+//
+// ### function Console (options)
+// #### @options {Object} Options for this instance.
+// Constructor function for the Console transport object responsible
+// for persisting log messages and metadata to a terminal or TTY.
+//
+var Silly = exports.Silly = function (options) {
+  winston.Transport.call(this, options);
+  options = options || {};
+
+  this.name        = 'silly';
+  this.output      = '';
+  this.json        = options.json        || false;
+  this.colorize    = options.colorize    || false;
+  this.prettyPrint = options.prettyPrint || false;
+  this.stripColors = options.stripColors || true;
+  this.timestamp   = options.timestamp   || true;
+  this.level       = options.level       || 'silly';
+
+  if (this.json) {
+    this.stringify = options.stringify || function (obj) {
+      return JSON.stringify(obj, null, 2);
+    };
+  }
+};
+
+//
+// Inherit from `winston.Transport`.
+//
+util.inherits(Silly, winston.Transport);
+
+//
+// Define a getter so that `winston.transports.Silly`
+// is available and thus backwards compatible.
+//
+winston.transports.Silly = Silly;
+
+//
+// Expose the name of this Transport on the prototype
+//
+Silly.prototype.name = 'silly';
+
+//
+// ### function log (level, msg, [meta], callback)
+// #### @level {string} Level at which to log the message.
+// #### @msg {string} Message to log
+// #### @meta {Object} **Optional** Additional metadata to attach
+// #### @callback {function} Continuation to respond to when complete.
+// Core logging method exposed to Winston. Metadata is optional.
+//
+Silly.prototype.log = function (level, msg, meta, callback) {
+  if (this.silent) {
+    return callback(null, true);
+  }
+
+  var output;
+
+  output = common.log({
+    colorize:    this.colorize,
+    json:        this.json,
+    level:       this.level,
+    message:     msg,
+    meta:        meta,
+    stringify:   this.stringify,
+    timestamp:   this.timestamp,
+    prettyPrint: this.prettyPrint,
+    raw:         this.raw
+  });
+
+  if (this.stripColors) {
+    var code = /\u001b\[(\d+(;\d+)*)?m/g;
+    this.output += output.replace(code, '');
+  } else {
+    this.output += output;
+  }
+  this.output += '\n';
+
+  //
+  // Emit the `logged` event immediately because the event loop
+  // will not exit until `process.stdout` has drained anyway.
+  //
+  this.emit('logged');
+  callback(null, true);
+};
+
+Silly.prototype.clear = function () {
+  this.output = '';
+};
+
+Silly.prototype.writeToFile = function (filename, append) {
+  var writeFileFunction = append ? fs.appendFileSync : fs.writeFileSync;
+  writeFileFunction(filename, this.output);
+  this.clear();
+};

--- a/lib/util/sillyTransport.js
+++ b/lib/util/sillyTransport.js
@@ -83,7 +83,7 @@ Silly.prototype.log = function (level, msg, meta, callback) {
     message:     msg,
     meta:        meta,
     stringify:   this.stringify,
-    timestamp:   this.timestamp,
+    timestamp:   (level === 'data') ?  false : this.timestamp,
     prettyPrint: this.prettyPrint,
     raw:         this.raw
   });

--- a/test/framework/cli-executor.js
+++ b/test/framework/cli-executor.js
@@ -58,6 +58,7 @@ function execute(cmd, cb) {
       return cb(result);
     } catch (err) {
       testLogger.logError(err);
+      testLogger.logSillyError(winston.default.transports.silly.output);
       process.nextTick(function() {
         throw err;
       });
@@ -90,6 +91,7 @@ function execute(cmd, cb) {
     }
     var cmdStr = cmd.join(" ");
     testLogger.logData(cmdStr);
+    winston.default.transports.silly.clear();
     cli.parse(cmd);
   } catch(err) {
     result.errorStack = err.stack;

--- a/test/framework/test-logger.js
+++ b/test/framework/test-logger.js
@@ -101,6 +101,11 @@ exports.logError = function(err) {
   appendContent(content);
 };
 
+exports.logSillyError = function(err) {
+  var content = '\n' + err + '\n';
+  appendContent(content);
+};
+
 exports.setCurrentTest = function(test) {
   currentTest = test;
 };


### PR DESCRIPTION
Added a new winston transport to buffer silly logs in memory & write them to azure.details.err in the event of a cli command failure.

Upon a mocha test failure the silly log for that test will be written into the test output file for that run.

I also added a check for AZURE_CLI_APPEND_LOGS environment variable, which when true will append to azure.err & azure.details.err instead of overwrite.  This can be useful if a client is experiencing problems using a script which calls multiple cli commands.