### PR TITLE
fix #1923 (use SPDX for license expression)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,7 @@
   "engines": {
     "node": ">= 0.8.26"
   },
-  "licenses": [
-    {
-      "type": "Apache",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ],
+  "license": "Apache-2.0",
   "dependencies": {
     "adal-node": "0.1.13",
     "async": "0.2.7",


### PR DESCRIPTION
npm starts to push for this since 2.10.0, so we follow. 
(https://github.com/npm/npm/releases/tag/v2.10.0)
