### PR TITLE
upgrade request version to 2.52.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "omelette": "0.1.0",
     "openssl-wrapper": "0.2.1",
     "readable-stream": "~1.0.0",
-    "request": "2.27.0",
+    "request": "2.52.0",
     "ssh-key-to-pem": "0.11.0",
     "streamline": "0.10.17",
     "streamline-streams": "0.1.5",


### PR DESCRIPTION
This version includes update on http proxy. With this change, adal-node will pick up this new version through its use of sliding version, and proxies will be respected when acquire tokens.