### PR TITLE
ARM RouteTable Route: add support for 'None' next hop type

### DIFF
--- a/lib/commands/arm/network/constants._js
+++ b/lib/commands/arm/network/constants._js
@@ -61,7 +61,7 @@ module.exports = {
   vnetGatewaySizes: ['G1', 'G2', 'G3'],
 
   route: {
-    nextHopType: ['VirtualAppliance', 'VirtualNetworkGateway', 'VNETLocal', 'Internet', 'Null']
+    nextHopType: ['VirtualAppliance', 'VirtualNetworkGateway', 'VNETLocal', 'Internet', 'None']
   },
 
   toRange: function (array) {


### PR DESCRIPTION
This PR contains minor fix and brings support for `None` next hop type for Route in ARM

https://github.com/MSOpenTech/azure-xplat-cli/issues/433 fixed