### PR TITLE
make installer use node v0.12.7

### DIFF
--- a/tools/osx-setup/build.sh
+++ b/tools/osx-setup/build.sh
@@ -6,7 +6,7 @@
 # This script is only used at build time, it is not part of the package.
 # 
 
-CURRENT_NODE_DISTRIBUTION_VERSION=v0.10.23
+CURRENT_NODE_DISTRIBUTION_VERSION=v0.12.7
 
 # Check for Apple's PackageMaker
 # ------------------------------

--- a/tools/windows/scripts/prepareRepoClone.cmd
+++ b/tools/windows/scripts/prepareRepoClone.cmd
@@ -9,7 +9,7 @@
 :: to avoid https://github.com/npm/npm/issues/6438
 chcp 850 
 
-set NODE_VERSION=0.10.23
+set NODE_VERSION=0.12.7
 set NPM_VERSION=1.3.17
 
 :: Add Git to the path as this should be run through a .NET command prompt


### PR DESCRIPTION
we have to now, because the 0.9.6 installer included 0.12.7 through local script tweak, if we still use 0.10.23, the windows installer will be broken under upgrade scenario