### PR TITLE
[cli-osx]: get account clear work with bad service principal items cached in the keychain

### DIFF
--- a/lib/util/authentication/osx-keychain.js
+++ b/lib/util/authentication/osx-keychain.js
@@ -103,14 +103,20 @@ function set(userName, service, description, password, callback) {
 *
 * @param {string} userName
 * @param {string} service
+* @param {string} description
 * @param {function (err)} callback called on completion
 */
-function remove(userName, service, callback) {
-  var args = [
-    'delete-generic-password',
-    '-a', userName,
-    '-s', service
-  ];
+function remove(userName, service, description, callback) {
+  var args = ['delete-generic-password'];
+  if (userName) {
+    args = args.concat(['-a', userName]);
+  }
+  if (service) {
+    args = args.concat(['-s', service]);
+  }
+  if (description) {
+    args = args.concat(['-D', description]); 
+  }
 
   childProcess.execFile(securityPath, args, function (err, stdout, stderr) {
     if (err) {

--- a/lib/util/authentication/osx-token-storage.js
+++ b/lib/util/authentication/osx-token-storage.js
@@ -64,7 +64,7 @@ _.extend(KeychainTokenStorage.prototype, {
   removeEntries: function (entriesToRemove, entriesToKeep, callback) {
     function removeEntry(entry, callback) {
       var key = encoding.encodeObject(_.omit(entry, ['accessToken', 'refreshToken']));
-      keychain.remove(key, entry.resource, callback);
+      keychain.remove(key, entry.resource, null, callback);
     }
     
     async.eachSeries(entriesToRemove, removeEntry, callback);
@@ -83,7 +83,11 @@ _.extend(KeychainTokenStorage.prototype, {
   clear: function (callback) {
     var self = this;
     self.loadEntries(function(err, entries) {
-      self.removeEntries(entries, [], callback);
+      if (err) return callback(err);
+      function clearEntry(entry, callback) {
+        keychain.remove(null, null, description, callback);
+      }
+      async.eachSeries(entries, clearEntry, callback);
     });
   },
 });


### PR DESCRIPTION
Those bad entries were the leftovers by the issus #1958 