### PR TITLE
Clean up test run output by not emitting out errors to the console

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -227,9 +227,9 @@ _.extend(AzureCli.prototype, {
 
       function callback(err) {
         if (err) {
-          // Exceptions should always be logged to the console
+          // Exceptions should always be logged to the console unless overturned by test run
           var noConsole = false;
-          if (!log['default'].transports.console) {
+          if (!process.env.AZURE_NO_ERROR_ON_CONSOLE && !log['default'].transports.console) {
             noConsole = true;
             self.output.add(self.output.transports.Console);
           }

--- a/test/commands/arm/rediscache/arm.rediscache-tests.js
+++ b/test/commands/arm/rediscache/arm.rediscache-tests.js
@@ -71,7 +71,7 @@ describe('arm', function () {
       cacheName = suite.generateId(cachePrefix, knownNames);
       newCacheName = suite.generateId(cachePrefix, knownNames);
 
-      suite.execute('group create %s --location %s', testResourceGroup, testLocation, function () {
+      suite.execute('group create %s --location %s --json', testResourceGroup, testLocation, function () {
         done();
       });
     });
@@ -79,7 +79,7 @@ describe('arm', function () {
 
 
   after(function (done) {
-    suite.execute('group delete %s --quiet', testResourceGroup, function () {
+    suite.execute('group delete %s --quiet --json', testResourceGroup, function () {
       suite.teardownSuite(done);
     });
   });
@@ -140,7 +140,7 @@ describe('arm', function () {
       suite.execute('rediscache list-keys --name %s --resource-group %s --json', cacheName, testResourceGroup, function (result) {
         result.exitStatus.should.be.equal(0);
         var cacheJson = JSON.parse(result.text);
-        console.log('res : ' + util.inspect(cacheJson));
+        //console.log('res : ' + util.inspect(cacheJson));
         cacheJson.primaryKey.should.not.be.null;
         done();
       });

--- a/test/commands/cli-auto-complete.tests.js
+++ b/test/commands/cli-auto-complete.tests.js
@@ -19,14 +19,14 @@ var fs = require('fs');
 var path = require('path');
 var sinon = require('sinon');
 
-var utilsCore = require('../lib/util/utilsCore');
+var utilsCore = require('../../lib/util/utilsCore');
 
 function wrap(sinonObj, obj, functionName, setup) {
   var original = obj[functionName];
   return sinonObj.stub(obj, functionName, setup(original));
 }
 
-var AutoComplete = require('../lib/autocomplete');
+var AutoComplete = require('../../lib/autocomplete');
 
 describe('cli', function(){
   var sandbox;

--- a/test/commands/cli.mobile.table-tests.js
+++ b/test/commands/cli.mobile.table-tests.js
@@ -398,8 +398,8 @@ function tableTests(service) {
   it('table delete nonexisting table', function (done) {
     suite.execute('mobile table delete %s table1 -q --json', servicename, function (result) {
       result.exitStatus.should.equal(1);
-      console.log(result.text);
-      console.log(result.errorText);
+      //console.log(result.text);
+      //console.log(result.errorText);
       result.errorText.should.include('The table \'table1\' was not found');
       done();
     });

--- a/test/framework/cli-test.js
+++ b/test/framework/cli-test.js
@@ -34,6 +34,8 @@ var nockHelper = require('./nock-helper');
 
 exports = module.exports = CLITest;
 
+process.env.AZURE_NO_ERROR_ON_CONSOLE = true;
+
 /**
  * @class
  * Initializes a new instance of the CLITest class.

--- a/test/testlist.txt
+++ b/test/testlist.txt
@@ -6,7 +6,7 @@
 # Disabling, do not want this run in automated test runs
 # commands/cli.mobile.migration-tests.js
 # TODO: This suite uses custom recording
-cli-tests.js
+commands/cli-auto-complete.tests.js
 commands/cli.account-tests.js
 commands/cli.account.cert-tests.js
 commands/cli.account.environment-tests.js


### PR DESCRIPTION
When the test run finishes, test framework will always dump out the error to the console. So nothing gets lost
This PR mainly gets rid of the useless errors produced by negative tests.