### PR TITLE
wire up code coverage npm task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Thumbs.db
 
 # Test Logs #
 test/output/*
+coverage

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "xmlbuilder": "0.4.x"
   },
   "devDependencies": {
+    "istanbul": "0.3.19",
     "mocha": "1.16.0",
     "jshint": "<= 2.6.0",
     "sinon": "*",
@@ -122,6 +123,7 @@
     "jshint": "jshint lib --jslint-reporter --extra-ext ._js",
     "preci": "jshint lib --reporter=checkstyle --extra-ext ._js > checkstyle-result.xml",
     "ci": "node scripts/unit.js testlist.txt -xunit",
+    "cover": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- test/util/profile test/util/authentication -R spec -t 5000",
     "extract-labels": "node scripts/extract-labels"
   },
   "bin": {

--- a/scripts/unit.js
+++ b/scripts/unit.js
@@ -18,12 +18,6 @@ var profile = require('../lib/util/profile');
 var testLogger = require('../test/framework/test-logger');
 var args = (process.ARGV || process.argv);
 
-var coverageOption = Array.prototype.indexOf.call(args, '-coverage');
-
-if (coverageOption !== -1) {
-  args.splice(coverageOption, 1);
-}
-
 var reporter = '../../../test/framework/xcli-test-reporter';
 var xunitOption = Array.prototype.indexOf.call(args, '-xunit');
 if (xunitOption !== -1) {
@@ -71,12 +65,7 @@ files.forEach(function (file) {
   }
 });
 
-if (coverageOption !== -1) {
-  args.push('-R');
-  args.push('html-cov');
-} else {
-  args.push('-R');
-  args.push(reporter);
-}
+args.push('-R');
+args.push(reporter);
 
 require('../node_modules/mocha/bin/mocha');


### PR DESCRIPTION
Use Istanbul. 
Run it on AAD login related code which contains the highest number of incoming bugs 