### PR TITLE
fix network vnet delete when there is only one network

### DIFF
--- a/lib/commands/asm/network/virtualNetwork._js
+++ b/lib/commands/asm/network/virtualNetwork._js
@@ -177,7 +177,7 @@ __.extend(VirtualNetwork.prototype, {
     var vnetConfig = networkConfig.VirtualNetworkConfiguration;
 
     var index = utils.indexOfCaseIgnore(vnetConfig.VirtualNetworkSites, {Name: vnetName});
-    if (index) {
+    if (index != null) {
       if (!options.quiet && !self.interaction.confirm(util.format($('Delete a virtual network "%s"? [y/n] '), vnetName), _)) {
         return;
       }

--- a/lib/commands/asm/network/virtualNetwork._js
+++ b/lib/commands/asm/network/virtualNetwork._js
@@ -177,7 +177,7 @@ __.extend(VirtualNetwork.prototype, {
     var vnetConfig = networkConfig.VirtualNetworkConfiguration;
 
     var index = utils.indexOfCaseIgnore(vnetConfig.VirtualNetworkSites, {Name: vnetName});
-    if (index != null) {
+    if (index !== null) {
       if (!options.quiet && !self.interaction.confirm(util.format($('Delete a virtual network "%s"? [y/n] '), vnetName), _)) {
         return;
       }


### PR DESCRIPTION
the command network vnet delete network-name does not work when there is only one existing network