### PR TITLE
Silly Log Truncation

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -148,7 +148,7 @@ _.extend(AzureCli.prototype, {
         log.warn('Cannot save error information :' + util.inspect(err2));
       }
 
-      log.default.transports.silly.writeToFile(this.getSillyErrorFile(), process.env.AZURE_CLI_APPEND_LOGS);
+      log.writeCapturedSillyLogs(this.getSillyErrorFile(), process.env.AZURE_CLI_APPEND_LOGS);
     }
   },
 

--- a/lib/util/logging.js
+++ b/lib/util/logging.js
@@ -31,7 +31,9 @@ require('./sillyTransport');
 // use cli output settings by default
 log.cli();
 
-log.add(log.transports.Silly);
+log.add(log.transports.Silly, {
+  silent: process.env.AZURE_CLI_DISABLE_LOG_CAPTURE
+});
 
 log.format = function (options) {
   for (var i in log['default'].transports) {
@@ -283,6 +285,14 @@ log.createLogFilter = function () {
       callback(err, response, body);
     });
   };
+};
+
+log.getCapturedSillyLogs = function () {
+  return log.default.transports.silly.output;
+};
+
+log.writeCapturedSillyLogs = function (file, append) {
+  log.default.transports.silly.writeToFile(file, append);
 };
 
 module.exports = log;

--- a/lib/util/sillyTransport.js
+++ b/lib/util/sillyTransport.js
@@ -61,6 +61,8 @@ winston.transports.Silly = Silly;
 //
 Silly.prototype.name = 'silly';
 
+Silly.prototype._truncated = false;
+
 //
 // ### function log (level, msg, [meta], callback)
 // #### @level {string} Level at which to log the message.
@@ -70,13 +72,11 @@ Silly.prototype.name = 'silly';
 // Core logging method exposed to Winston. Metadata is optional.
 //
 Silly.prototype.log = function (level, msg, meta, callback) {
-  if (this.silent) {
+  if (this.silent || this._truncated) {
     return callback(null, true);
   }
 
-  var output;
-
-  output = common.log({
+  var incomingLog = common.log({
     colorize:    this.colorize,
     json:        (level === 'data') ?  true : this.json,
     level:       level,
@@ -88,11 +88,17 @@ Silly.prototype.log = function (level, msg, meta, callback) {
     raw:         this.raw
   });
 
+  if (this._shouldTruncate(incomingLog)) {
+    this.output += '\n...truncated...';
+    this._truncated = true;
+    return callback(null, true);
+  }
+
   if (this.stripColors) {
     var code = /\u001b\[(\d+(;\d+)*)?m/g;
-    this.output += output.replace(code, '');
+    this.output += incomingLog.replace(code, '');
   } else {
-    this.output += output;
+    this.output += incomingLog;
   }
   this.output += '\n';
 
@@ -106,10 +112,19 @@ Silly.prototype.log = function (level, msg, meta, callback) {
 
 Silly.prototype.clear = function () {
   this.output = '';
+  this._truncated = false;
 };
 
 Silly.prototype.writeToFile = function (filename, append) {
   var writeFileFunction = append ? fs.appendFileSync : fs.writeFileSync;
   writeFileFunction(filename, this.output);
   this.clear();
+};
+
+Silly.prototype._shouldTruncate = function (incomingLog) {
+  var length = this.output.length;
+  if (incomingLog) {
+    length += incomingLog.length;
+  }
+  return length > 1024 * 1024;
 };

--- a/lib/util/sillyTransport.js
+++ b/lib/util/sillyTransport.js
@@ -37,6 +37,7 @@ var Silly = exports.Silly = function (options) {
   this.stripColors = options.stripColors || true;
   this.timestamp   = options.timestamp   || true;
   this.level       = options.level       || 'silly';
+  this.silent      = options.silent      || false;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {

--- a/test/framework/cli-executor.js
+++ b/test/framework/cli-executor.js
@@ -58,7 +58,7 @@ function execute(cmd, cb) {
       return cb(result);
     } catch (err) {
       testLogger.logError(err);
-      testLogger.logSillyError(winston.default.transports.silly.output);
+      testLogger.logSillyError(winston.getCapturedSillyLogs());
       process.nextTick(function() {
         throw err;
       });


### PR DESCRIPTION
Added truncation by default to the silly log capture after 1MB of logs has been captured.

Added a AZURE_CLI_DISABLE_LOG_CAPTURE environment variable which allows silly log capturing to be disabled.