### PR TITLE
Authorization:bug fix in role assignment list to filter classic admins if user principal has been provided

### DIFF
--- a/lib/commands/arm/role/roleAssignments._js
+++ b/lib/commands/arm/role/roleAssignments._js
@@ -72,6 +72,23 @@ underscore.extend(RoleAssignments.prototype, {
     if (shouldIncludeClassicAdmins) {
       var admins = this.authzClient.classicAdministrators.list(_);
       var adminsAsAssignments = this.convertAdminsToAssignments(admins, subscription);
+
+      // Filter by principal name if provided
+      if (this.optionIsSet(principal) && principalId) {
+        if (objectType.value && !utils.ignoreCaseEquals(objectType.value, 'user')) {
+          throw new Error($('includeClassicAdministrators option is only supported for a user principal. Given principal is a ' + objectType.value));
+        }
+
+        var objects = this.graphClient.objects.getObjectsByObjectIds({ ids: new Array (principalId) }, _).aADObject;
+        
+        if (objects && objects.length > 0) {
+          adminsAsAssignments = adminsAsAssignments.filter(function(r) {
+            return utils.ignoreCaseEquals(r.properties.aADObject.displayName, objects[0].signInName);
+          });
+        } else { // Display warning and do not filter
+          console.log('Warning: failed to retrieve graph object details for principal:%s. Falling back to non-filtered list of classic administrators.', principalId);
+        }
+      }
       assignments = assignments.concat(adminsAsAssignments);
     }
 


### PR DESCRIPTION
If both upn and --includeClassicAdmins options have been provided, the list of classic admins should be filtered by the given user principal.