### PR TITLE
Update the storage dependency to 0.6.0 to be compatible with Nodejs 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "azure-asm-storage": "0.10.1",
     "azure-asm-subscription": "0.10.1",
     "azure-asm-website": "0.10.1",
-    "azure-storage": "0.5.0",
+    "azure-storage": "0.6.0",
     "caller-id": "0.1.x",
     "colors": "0.x.x",
     "commander": "1.0.4",


### PR DESCRIPTION
To fix the scenario breakings with Nodejs 4.x and io.js.