### PR TITLE
do not set language parameter when invoke adal-node for user code 

### DIFF
--- a/lib/util/authentication/adalAuthForUser.js
+++ b/lib/util/authentication/adalAuthForUser.js
@@ -62,7 +62,7 @@ function authenticateWithUsernamePassword(authConfig, username, password, callba
 
 function acquireUserCode(authConfig, callback) {
   var context = adalAuth.createAuthenticationContext(authConfig);
-  return context.acquireUserCode(authConfig.resourceId, authConfig.clientId, 'es-mx', callback);
+  return context.acquireUserCode(authConfig.resourceId, authConfig.clientId, null, callback);
 }
 
 function authenticateWithDeviceCode(authConfig, userCodeResponse, userId, callback) {


### PR DESCRIPTION
Using "es-mx" is not a valid value. Once AAD server fixes the bug at its end, it will interpret as Spanish language and start to offer response in that language.