### PR TITLE
Add an option to avoid deployment validation

### DIFF
--- a/lib/commands/arm/group/group.deployment._js
+++ b/lib/commands/arm/group/group.deployment._js
@@ -41,6 +41,7 @@ exports.init = function (cli) {
     .option('-p --parameters <parameters>', $('a JSON-formatted string containing parameters'))
     .fileRelatedOption('-e --parameters-file <parametersFile>', $('a file containing parameters'))
     .option('--nowait', $('does not wait for the deployment to complete. Returns as soon as the deployment is created'))
+    .option('--novalidate', $('do not validate deployment'))
     .option('--subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {
       if (!resourceGroup) {

--- a/lib/commands/arm/group/groupUtils._js
+++ b/lib/commands/arm/group/groupUtils._js
@@ -81,7 +81,9 @@ exports.createDeployment = function (cli, resourceGroup, name, options, _) {
 
   var result = cli.interaction.withProgress($('Creating a deployment'),
     function (log, _) {
-      client.deployments.validate(resourceGroup, name, templateParameters, _);
+      if (!options.novalidate) {
+        client.deployments.validate(resourceGroup, name, templateParameters, _);
+      }
       var createResponse = client.deployments.createOrUpdate(resourceGroup, name, templateParameters, _);
       return createResponse;
     }, _);

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -9964,6 +9964,14 @@
                   "description": "does not wait for the deployment to complete. Returns as soon as the deployment is created"
                 },
                 {
+                  "flags": "--novalidate",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--novalidate",
+                  "description": "do not validate deployment"
+                },
+                {
                   "flags": "--subscription <subscription>",
                   "required": -16,
                   "optional": 0,


### PR DESCRIPTION
The Azure API apparently prevents some roles (e.g. VM contributor) from
validating deployments, even when they can perfectly execute them. This patch
simply adds an options the supresses the deployment validation step to work
around this problem.