### PR TITLE
ASM: NSG Rule create command fixed

### DIFF
--- a/lib/commands/asm/network/nsg._js
+++ b/lib/commands/asm/network/nsg._js
@@ -291,12 +291,13 @@ __.extend(Nsg.prototype, {
   },
 
   _validatePortRange: function (port, paramName) {
-    if (port === '*' || port === '"*"') {
+    if (port === '*' || port === '"*"' || !isNaN(port)) {
       return port;
     }
-    port = utils.parseInt(port);
-    if (isNaN(port) || port < constants.nsg.portMin || port > constants.nsg.portMax) {
-      throw new Error(util.format($('%s parameter must be an integer between %s and %s. Asterisk can be used also.'),
+    var rangePattern = /^[\d]+\s*-\s*[\d]+$/;
+    var match = rangePattern.test(port);
+    if (!match) {
+      throw new Error(util.format($('%s parameter must be a valid port or port range between %s and %s. Asterisk can be used also. Example: 80, 80-81, *'),
         paramName, constants.nsg.portMin, constants.nsg.portMax));
     }
     return port;


### PR DESCRIPTION
This PR includes minor fix for `azure nsg rule create` command in `ASM` and brings port-range support for `--source-port-range` and `--destination-port-range` options, related https://github.com/Azure/azure-xplat-cli/issues/2177 issue fixed

@yugangw-msft can this be merged to `release-0.9.10` branch?