### PR TITLE
Remove streamline temp folder at postinstall

### DIFF
--- a/cli.njsproj
+++ b/cli.njsproj
@@ -52,6 +52,7 @@
     <Compile Include="scripts\filter-testresults.js" />
     <Compile Include="scripts\harvest-cmds.js" />
     <Compile Include="scripts\link-to-sdk.js" />
+    <Compile Include="scripts\remove-streamline-files.js" />
     <Compile Include="scripts\unit.js" />
     <Content Include="test\testlist.txt" />
     <Content Include="test\testlistarm.txt" />

--- a/cli.njsproj
+++ b/cli.njsproj
@@ -53,6 +53,7 @@
     <Compile Include="scripts\harvest-cmds.js" />
     <Compile Include="scripts\link-to-sdk.js" />
     <Compile Include="scripts\remove-streamline-files.js" />
+    <Compile Include="scripts\rimraf.js" />
     <Compile Include="scripts\unit.js" />
     <Content Include="test\testlist.txt" />
     <Content Include="test\testlistarm.txt" />

--- a/lib/util/utilsCore.js
+++ b/lib/util/utilsCore.js
@@ -35,7 +35,7 @@ exports.ignoreCaseEquals = function (a, b) {
 
 exports.azureDir = function () {
   var dir = process.env.AZURE_CONFIG_DIR ||
-    path.join(homeFolder(), '.azure');
+    path.join(exports.homeFolder(), '.azure');
   
   if (!exports.pathExistsSync(dir)) {
     fs.mkdirSync(dir, 502); // 0766
@@ -44,7 +44,7 @@ exports.azureDir = function () {
   return dir;
 };
 
-function homeFolder() {
+exports.homeFolder = function () {
   if (process.env.HOME !== undefined) {
     return process.env.HOME;
   }
@@ -54,7 +54,7 @@ function homeFolder() {
   }
   
   throw new Error('No HOME path available');
-}
+};
 
 exports.stringStartsWith = function (text, prefix, ignoreCase) {
   if (_.isNull(prefix)) {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "wordwrap": "0.0.2",
     "xml2js": "0.1.x",
     "xmlbuilder": "0.4.x",
-    "rimraf": "2.4.3"
+    "glob": "^5.0.14"
   },
   "devDependencies": {
     "istanbul": "0.3.19",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "winston": "0.6.x",
     "wordwrap": "0.0.2",
     "xml2js": "0.1.x",
-    "xmlbuilder": "0.4.x"
+    "xmlbuilder": "0.4.x",
+    "rimraf": "2.4.3"
   },
   "devDependencies": {
     "istanbul": "0.3.19",
@@ -124,7 +125,8 @@
     "preci": "jshint lib --reporter=checkstyle --extra-ext ._js > checkstyle-result.xml",
     "ci": "node scripts/unit.js testlist.txt -xunit",
     "cover": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- test/util/profile test/util/authentication -R spec -t 5000",
-    "extract-labels": "node scripts/extract-labels"
+    "extract-labels": "node scripts/extract-labels",
+    "postinstall": "node scripts/remove-streamline-files.js" 
   },
   "bin": {
     "azure": "./bin/azure"

--- a/scripts/remove-streamline-files.js
+++ b/scripts/remove-streamline-files.js
@@ -1,0 +1,28 @@
+﻿// 
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// 
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var path = require('path'); 
+var rimraf = require('rimraf');
+
+var getHomeFolder = require('../lib/util/utilsCore').homeFolder;
+var streamLineFolder = path.join(getHomeFolder(), '.streamline');
+
+//if needed, we can filter&delete subfolders with namelike '*azure-cli*';
+//otherwise, it's safe to clean up other apps' files, which are temp files anyway.
+rimraf(streamLineFolder, function (er) {
+  if (er) {
+    throw er;
+  }
+});

--- a/scripts/remove-streamline-files.js
+++ b/scripts/remove-streamline-files.js
@@ -13,16 +13,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var path = require('path'); 
-var rimraf = require('rimraf');
+var path = require('path');
+var rimraf = require('./rimraf.js');
 
 var getHomeFolder = require('../lib/util/utilsCore').homeFolder;
 var streamLineFolder = path.join(getHomeFolder(), '.streamline');
 
 //if needed, we can filter&delete subfolders with namelike '*azure-cli*';
 //otherwise, it's safe to clean up other apps' files, which are temp files anyway.
-rimraf(streamLineFolder, function (er) {
-  if (er) {
-    throw er;
-  }
-});
+console.log('@@Start to clean:' + streamLineFolder);
+setTimeout(cleanup(), 180000000);
+
+function cleanup() {
+  rimraf(streamLineFolder, function (er) {
+    if (er) {
+      throw new Error('@@error and error:' + JSON.stringify(er));
+    //throw er;
+    }
+  })
+}
+

--- a/scripts/rimraf.js
+++ b/scripts/rimraf.js
@@ -1,0 +1,342 @@
+module.exports = rimraf
+rimraf.sync = rimrafSync
+
+var assert = require("assert")
+var path = require("path")
+var fs = require("fs")
+var glob = require("glob")
+
+var globOpts = {
+  nosort: true,
+  nocomment: true,
+  nonegate: true,
+  silent: true
+}
+
+// for EMFILE handling
+var timeout = 0
+
+var isWindows = (process.platform === "win32")
+
+function defaults (options) {
+  var methods = [
+    'unlink',
+    'chmod',
+    'stat',
+    'lstat',
+    'rmdir',
+    'readdir'
+  ]
+  methods.forEach(function(m) {
+    options[m] = options[m] || fs[m]
+    m = m + 'Sync'
+    options[m] = options[m] || fs[m]
+  })
+
+  options.maxBusyTries = options.maxBusyTries || 3
+  options.emfileWait = options.emfileWait || 1000
+  options.disableGlob = options.disableGlob || false
+}
+
+function rimraf (p, options, cb) {
+  if (typeof options === 'function') {
+    cb = options
+    options = {}
+  }
+
+  assert(p, 'rimraf: missing path')
+  assert.equal(typeof p, 'string', 'rimraf: path should be a string')
+  assert(options, 'rimraf: missing options')
+  assert.equal(typeof options, 'object', 'rimraf: options should be object')
+  assert.equal(typeof cb, 'function', 'rimraf: callback function required')
+
+  defaults(options)
+
+  var busyTries = 0
+  var errState = null
+  var n = 0
+
+  if (options.disableGlob || !glob.hasMagic(p))
+    return afterGlob(null, [p])
+
+  fs.lstat(p, function (er, stat) {
+    if (!er)
+      return afterGlob(null, [p])
+
+    glob(p, globOpts, afterGlob)
+  })
+
+  function next (er) {
+    errState = errState || er
+    if (--n === 0)
+      cb(errState)
+  }
+
+  function afterGlob (er, results) {
+    if (er)
+      return cb(er)
+
+    n = results.length
+    if (n === 0)
+      return cb()
+
+    results.forEach(function (p) {
+      rimraf_(p, options, function CB (er) {
+        if (er) {
+          if (isWindows && (er.code === "EBUSY" || er.code === "ENOTEMPTY" || er.code === "EPERM") &&
+              busyTries < options.maxBusyTries) {
+            busyTries ++
+            var time = busyTries * 100
+            // try again, with the same exact callback as this one.
+            return setTimeout(function () {
+              rimraf_(p, options, CB)
+            }, time)
+          }
+
+          // this one won't happen if graceful-fs is used.
+          if (er.code === "EMFILE" && timeout < options.emfileWait) {
+            return setTimeout(function () {
+              rimraf_(p, options, CB)
+            }, timeout ++)
+          }
+
+          // already gone
+          if (er.code === "ENOENT") er = null
+        }
+
+        timeout = 0
+        next(er)
+      })
+    })
+  }
+}
+
+// Two possible strategies.
+// 1. Assume it's a file.  unlink it, then do the dir stuff on EPERM or EISDIR
+// 2. Assume it's a directory.  readdir, then do the file stuff on ENOTDIR
+//
+// Both result in an extra syscall when you guess wrong.  However, there
+// are likely far more normal files in the world than directories.  This
+// is based on the assumption that a the average number of files per
+// directory is >= 1.
+//
+// If anyone ever complains about this, then I guess the strategy could
+// be made configurable somehow.  But until then, YAGNI.
+function rimraf_ (p, options, cb) {
+  assert(p)
+  assert(options)
+  assert(typeof cb === 'function')
+
+  // sunos lets the root user unlink directories, which is... weird.
+  // so we have to lstat here and make sure it's not a dir.
+  options.lstat(p, function (er, st) {
+    if (er && er.code === "ENOENT")
+      return cb(null)
+
+    if (st && st.isDirectory())
+      return rmdir(p, options, er, cb)
+
+    options.unlink(p, function (er) {
+      if (er) {
+        console.log('@BAD:' + JSON.stringify(er));
+        if (er.code === "ENOENT")
+          return cb(null)
+        if (er.code === "EPERM")
+          return (isWindows)
+            ? fixWinEPERM(p, options, er, cb)
+            : rmdir(p, options, er, cb)
+        if (er.code === "EISDIR")
+          return rmdir(p, options, er, cb)
+      } else {
+        console.log('@GOOD:' + JSON.stringify(p));
+      }
+      return cb(er)
+    })
+  })
+}
+
+function fixWinEPERM (p, options, er, cb) {
+  assert(p)
+  assert(options)
+  assert(typeof cb === 'function')
+  if (er)
+    assert(er instanceof Error)
+
+  options.chmod(p, 666, function (er2) {
+    if (er2)
+      cb(er2.code === "ENOENT" ? null : er)
+    else
+      options.stat(p, function(er3, stats) {
+        if (er3)
+          cb(er3.code === "ENOENT" ? null : er)
+        else if (stats.isDirectory())
+          rmdir(p, options, er, cb)
+        else
+          options.unlink(p, cb)
+      })
+  })
+}
+
+function fixWinEPERMSync (p, options, er) {
+  assert(p)
+  assert(options)
+  if (er)
+    assert(er instanceof Error)
+
+  try {
+    options.chmodSync(p, 666)
+  } catch (er2) {
+    if (er2.code === "ENOENT")
+      return
+    else
+      throw er
+  }
+
+  try {
+    var stats = options.statSync(p)
+  } catch (er3) {
+    if (er3.code === "ENOENT")
+      return
+    else
+      throw er
+  }
+
+  if (stats.isDirectory())
+    rmdirSync(p, options, er)
+  else
+    options.unlinkSync(p)
+}
+
+function rmdir (p, options, originalEr, cb) {
+  assert(p)
+  assert(options)
+  if (originalEr)
+    assert(originalEr instanceof Error)
+  assert(typeof cb === 'function')
+
+  // try to rmdir first, and only readdir on ENOTEMPTY or EEXIST (SunOS)
+  // if we guessed wrong, and it's not a directory, then
+  // raise the original error.
+  options.rmdir(p, function (er) {
+    if (er && (er.code === "ENOTEMPTY" || er.code === "EEXIST" || er.code === "EPERM" || er.code === 'EACCES'))
+      rmkids(p, options, cb)
+    else if (er && er.code === "ENOTDIR")
+      cb(originalEr)
+    else {
+      if (!er) {
+        console.log('@GOOD: removed directory ' + JSON.stringify(p));
+      }
+      cb(er);
+    }
+  })
+}
+
+function rmkids(p, options, cb) {
+  assert(p)
+  assert(options)
+  assert(typeof cb === 'function')
+
+  options.readdir(p, function (er, files) {
+    if (er)
+      return cb(er)
+    var n = files.length
+    if (n === 0)
+      return options.rmdir(p, cb)
+    var errState
+    files.forEach(function (f) {
+      rimraf(path.join(p, f), options, function (er) {
+        if (errState)
+          return
+        if (er)
+          return cb(errState = er)
+        if (--n === 0) {
+          options.rmdir(p, cb);
+          console.log('@REMOVE DIR:' + JSON.stringify(p));
+        }
+      })
+    })
+  })
+}
+
+// this looks simpler, and is strictly *faster*, but will
+// tie up the JavaScript thread and fail on excessively
+// deep directory trees.
+function rimrafSync (p, options) {
+  options = options || {}
+  defaults(options)
+
+  assert(p, 'rimraf: missing path')
+  assert.equal(typeof p, 'string', 'rimraf: path should be a string')
+  assert(options, 'rimraf: missing options')
+  assert.equal(typeof options, 'object', 'rimraf: options should be object')
+
+  var results
+
+  if (options.disableGlob || !glob.hasMagic(p)) {
+    results = [p]
+  } else {
+    try {
+      fs.lstatSync(p)
+      results = [p]
+    } catch (er) {
+      results = glob.sync(p, globOpts)
+    }
+  }
+
+  if (!results.length)
+    return
+
+  for (var i = 0; i < results.length; i++) {
+    var p = results[i]
+
+    try {
+      var st = options.lstatSync(p)
+    } catch (er) {
+      if (er.code === "ENOENT")
+        return
+    }
+
+    try {
+      // sunos lets the root user unlink directories, which is... weird.
+      if (st && st.isDirectory())
+        rmdirSync(p, options, null)
+      else
+        options.unlinkSync(p)
+    } catch (er) {
+      if (er.code === "ENOENT")
+        return
+      if (er.code === "EPERM")
+        return isWindows ? fixWinEPERMSync(p, options, er) : rmdirSync(p, options, er)
+      if (er.code !== "EISDIR")
+        throw er
+      rmdirSync(p, options, er)
+    }
+  }
+}
+
+function rmdirSync (p, options, originalEr) {
+  assert(p)
+  assert(options)
+  if (originalEr)
+    assert(originalEr instanceof Error)
+
+  try {
+    options.rmdirSync(p)
+  } catch (er) {
+    if (er.code === "ENOENT")
+      return
+    if (er.code === "ENOTDIR")
+      throw originalEr
+    if (er.code === "ENOTEMPTY" || er.code === "EEXIST" || er.code === "EPERM")
+      rmkidsSync(p, options)
+  }
+}
+
+function rmkidsSync (p, options) {
+  assert(p)
+  assert(options)
+  options.readdirSync(p).forEach(function (f) {
+    rimrafSync(path.join(p, f), options)
+  })
+  options.rmdirSync(p, options)
+}


### PR DESCRIPTION
We have received at least 5 reports, that stale streamline files caused weird azure-cli errors. So we just remove the folder. 