### PR TITLE
Surface the error when azure-cli fails to remove token from windows secure storage

### DIFF
--- a/lib/util/authentication/win-token-storage.js
+++ b/lib/util/authentication/win-token-storage.js
@@ -155,14 +155,19 @@ _.extend(CredTokenStorage.prototype, {
   removeEntries: function (entriesToRemove, entriesToKeep, callback) {
     function removeEntry(entry, removeCb) {
       var targetName = encoding.encodeObject(_.omit(entry, ['accessToken', 'refreshToken']));
+      var err1, err2;
       async.series([
         function (done) {
-          credStore.remove(targetName, function () { done(); });
+          credStore.remove(targetName, function (err) { err1 = err; done(); });
         },
         function (done) {
-          credStore.remove(targetName + '--*', function () { done(); });
+          credStore.remove(targetName + '--*', function (err) { err2 = err; done(); });
         }
-      ], removeCb);
+      ], function () {
+        //2 'remove' sceanrios are exclusive, so only surface if both both fail 
+        var overallErr = (err1 && err2) ? err1 + require('os').EOL + err2 : null;
+        return removeCb(overallErr);
+      });
     }
     
     async.eachSeries(entriesToRemove, removeEntry, callback);


### PR DESCRIPTION
Till now azure-cli just silently swallows any error on removing, which is sort of bad, because old tokens will likely fail adal later for multiple token matches and 'azure login' will get stuck. So let us surface it and at least we will know what was the real error.   