### PR TITLE
Put a warning on existing streamline files

### DIFF
--- a/cli.njsproj
+++ b/cli.njsproj
@@ -147,6 +147,7 @@
     <Compile Include="lib\util\profile\profile.js" />
     <Compile Include="lib\util\profile\publishSettings.js" />
     <Compile Include="lib\util\profile\subscription.js" />
+    <Compile Include="scripts\warn-existing-streamline-files.js" />
     <Compile Include="test\commands\cli.account-tests.js" />
     <Compile Include="test\commands\cli.account.affinitygroup-tests.js">
       <TestFramework>Mocha</TestFramework>

--- a/lib/util/utilsCore.js
+++ b/lib/util/utilsCore.js
@@ -35,7 +35,7 @@ exports.ignoreCaseEquals = function (a, b) {
 
 exports.azureDir = function () {
   var dir = process.env.AZURE_CONFIG_DIR ||
-    path.join(homeFolder(), '.azure');
+    path.join(exports.homeFolder(), '.azure');
   
   if (!exports.pathExistsSync(dir)) {
     fs.mkdirSync(dir, 502); // 0766
@@ -44,7 +44,7 @@ exports.azureDir = function () {
   return dir;
 };
 
-function homeFolder() {
+exports.homeFolder = function () {
   if (process.env.HOME !== undefined) {
     return process.env.HOME;
   }
@@ -54,7 +54,7 @@ function homeFolder() {
   }
   
   throw new Error('No HOME path available');
-}
+};
 
 exports.stringStartsWith = function (text, prefix, ignoreCase) {
   if (_.isNull(prefix)) {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "winston": "0.6.x",
     "wordwrap": "0.0.2",
     "xml2js": "0.1.x",
-    "xmlbuilder": "0.4.x"
+    "xmlbuilder": "0.4.x",
+    "npmlog": "1.2.1"
   },
   "devDependencies": {
     "istanbul": "0.3.19",
@@ -124,7 +125,8 @@
     "preci": "jshint lib --reporter=checkstyle --extra-ext ._js > checkstyle-result.xml",
     "ci": "node scripts/unit.js testlist.txt -xunit",
     "cover": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- test/util/profile test/util/authentication -R spec -t 5000",
-    "extract-labels": "node scripts/extract-labels"
+    "extract-labels": "node scripts/extract-labels",
+    "postinstall": "node scripts/warn-existing-streamline-files.js"
   },
   "bin": {
     "azure": "./bin/azure"

--- a/scripts/warn-existing-streamline-files.js
+++ b/scripts/warn-existing-streamline-files.js
@@ -1,0 +1,30 @@
+﻿// 
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// 
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var fs = require('fs');
+var path = require('path');
+var util = require('util');
+var npmlog = require('npmlog');
+
+var getHomeFolder = require('../lib/util/utilsCore').homeFolder;
+var streamLineFolder = path.join(getHomeFolder(), '.streamline');
+
+if (fs.existsSync(streamLineFolder)) {
+  var error = 'Installation of \'azure-cli\' is complete. It is highly recommended ' +
+    'to remove the folder of \'%s\' to get rid of stale streamlined files.' +
+    require('os').EOL;
+
+  npmlog.warn(util.format(error, streamLineFolder));
+}


### PR DESCRIPTION
This is to workaround possible stale streamline precompiled files, whose fix could take a while to sort out.