### PR TITLE
Graph: Add the includeDirectoryObjectReferences flag to the GetObjectsByObjectIds call 

### DIFF
--- a/lib/commands/arm/ad/adUtils._js
+++ b/lib/commands/arm/ad/adUtils._js
@@ -34,7 +34,7 @@ exports.getObjectId = function (principal, graphClient, throwIfNoOption, shouldR
   if (principal.objectId) {
     // get object type if requested
     if (shouldRetrieveObjectType) {
-      var objects = graphClient.objects.getObjectsByObjectIds({ ids: new Array(principal.objectId) }, _).aADObject;
+      var objects = graphClient.objects.getObjectsByObjectIds({ ids: new Array(principal.objectId), includeDirectoryObjectReferences: true }, _).aADObject;
       if (objects && objects.length > 0) {
         objectType.value = objects[0].objectType;
       }

--- a/lib/commands/arm/role/roleAssignments._js
+++ b/lib/commands/arm/role/roleAssignments._js
@@ -80,7 +80,7 @@ underscore.extend(RoleAssignments.prototype, {
           throw new Error($('includeClassicAdministrators option is only supported for a user principal. Given principal is a ' + objectType.value));
         }
 
-        var objects = this.graphClient.objects.getObjectsByObjectIds({ ids: new Array (principalId) }, _).aADObject;
+        var objects = this.graphClient.objects.getObjectsByObjectIds({ ids: new Array (principalId), includeDirectoryObjectReferences: true }, _).aADObject;
         
         if (objects && objects.length > 0) {
           adminsAsAssignments = adminsAsAssignments.filter(function(r) {
@@ -191,7 +191,7 @@ getAssignmentsListForScope: function (scope, parameter, _) {
       var objects = [];
 
       try {
-        objects = this.graphClient.objects.getObjectsByObjectIds({ ids: allIds }, _).aADObject;
+        objects = this.graphClient.objects.getObjectsByObjectIds({ ids: allIds, includeDirectoryObjectReferences: true }, _).aADObject;
       } catch (ex) {
         graphCallSucceeded = false;
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "azure-arm-dns": "0.10.1",
     "azure-arm-website": "0.10.0",
     "azure-arm-rediscache": "0.0.2",
-    "azure-extra": "0.1.11",
+    "azure-extra": "0.1.12",
     "azure-gallery": "2.0.0-pre.18",
     "azure-keyvault": "0.10.1",
     "azure-asm-compute": "0.11.0",


### PR DESCRIPTION
This will also search for object ids in the partner tenant (artemis/CSP scenario)