### PR TITLE
Fix port range validation to allow dash-delimited port range

### DIFF
--- a/lib/commands/arm/network/nsg._js
+++ b/lib/commands/arm/network/nsg._js
@@ -436,10 +436,21 @@ __.extend(Nsg.prototype, {
       return port;
     }
 
-    port = utils.parseInt(port);
-    var portRange = constants.portBounds;
-    if (isNaN(port) || port < portRange[0] || port > portRange[1]) {
-      throw new Error(util.format($('%s port parameter must be an integer between %s and %s'), portType, portRange[0], portRange[1]));
+    function validatePort(port){
+      port = utils.parseInt(port);
+      var portRange = constants.portBounds;
+      if (isNaN(port) || port < portRange[0] || port > portRange[1]) {
+        throw new Error(util.format($('%s port parameter must be an integer or port range between %s and %s'), portType, portRange[0], portRange[1]));
+      }
+    }
+
+    var match = /^(\d+)\s*-\s*(\d+)$/.exec(port);
+    if (match) {
+      validatePort(match[1]);
+      validatePort(match[2]);
+    }
+    else {
+      validatePort(port);
     }
 
     return port;


### PR DESCRIPTION
Proposed fix for #2238 , works for me with both single ports and ranges. 