### PR TITLE
Fix for account creation and a couple renames

### DIFF
--- a/lib/commands/arm/datalakeanalytics/datalakeanalytics._js
+++ b/lib/commands/arm/datalakeanalytics/datalakeanalytics._js
@@ -540,27 +540,27 @@ exports.init = function (cli) {
       log.info($('Successfully deleted the specified DataLakeAnalytics account.'));
     });
     
-    dataLakeAnalyticsAccount.command('create [accountName] [location] [resource-group] [defaultDataLake] [tags]')
+    dataLakeAnalyticsAccount.command('create [accountName] [location] [resource-group] [defaultDataLakeStore]')
     .description($('Creates a Data Lake Analytics Account'))
-    .usage('[options] <accountName> <location> <resource-group> <defaultGroup> <tags>')
+    .usage('[options] <accountName> <location> <resource-group> <defaultGroup>')
     .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to create'))
     .option('-l --location <location>', $('the location the Data Lake Analytics account will be created in. Valid values are: North Central US, South Central US, Central US, West Europe, North Europe, West US, East US, East US 2, Japan East, Japan West, Brazil South, Southeast Asia, East Asia, Australia East, Australia Southeast'))
     .option('-g --resource-group <resource-group>', $('the resource group to create the account in'))
-    .option('-d --defaultDataLake <defaultDataLake>', $('the default Data Lake to associate with this account.'))
+    .option('-d --defaultDataLakeStore <defaultDataLakeStore>', $('the default Data Lake Store to associate with this account.'))
     .option('-t --tags <tags>', $('Tags to set to the the Data Lake Analytics account. Can be mutliple. ' +
             'In the format of \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
     .option('-s, --subscription <id>', $('the subscription identifier'))
-    .execute(function (accountName, location, resourceGroup, defaultDataLake, options, _) {
+    .execute(function (accountName, location, resourceGroup, defaultDataLakeStore, options, _) {
       var subscription = profile.current.getSubscription(options.subscription);
       var tags = {};
       tags = tagUtils.buildTagsParameter(tags, options);
-      var dataLakeAnalyticsAccount = createOrUpdateDataLakeAnalyticsAccount(subscription, accountName, resourceGroup, location, defaultDataLake, tags, _);
+      var dataLakeAnalyticsAccount = createOrUpdateDataLakeAnalyticsAccount(subscription, accountName, resourceGroup, location, defaultDataLakeStore, tags, _);
       dataLakeAnalyticsUtils.formatOutput(cli, log, options, dataLakeAnalyticsAccount);
     });
   
-    dataLakeAnalyticsAccount.command('set [accountName] [resource-group] [defaultDataLakeStore] [tags]')
+    dataLakeAnalyticsAccount.command('set [accountName] [resource-group] [defaultDataLakeStore]')
     .description($('Updates the properties of an existing Data Lake Analytics Account'))
-    .usage('[options] <accountName> <resource-group> <defaultDataLake> <tags>')
+    .usage('[options] <accountName> <resource-group> <defaultDataLakeStore>')
     .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to perform the action on.'))
     .option('-g --resource-group <resource-group>', $('the optional resource group to forcibly look for the account to update in'))
     .option('-g --resource-group <resource-group>', $('the optional resource group to forcibly look for the account to update in'))

--- a/lib/commands/arm/datalakeanalytics/datalakeanalytics.utils.js
+++ b/lib/commands/arm/datalakeanalytics/datalakeanalytics.utils.js
@@ -31,20 +31,27 @@ exports.showObject = function(log, object, indentationTabs) {
   var tabs = __.isNumber(indentationTabs) ? indentationTabs : 0;
   var spaces = _padSpaces(tabs);
   var recursiveCaller = function (element) { exports.showObject(log, element, tabs + 1); };
-  for (var propertyName in object) {
-    if (__.isNull(object[propertyName]) || __.isUndefined(object[propertyName])) {
-      log.data(spaces + propertyName + ':');
-    } else if (__.isArray(object[propertyName])) {
-      log.data(spaces + propertyName + ':');
-      __.each(object[propertyName], recursiveCaller);
-    } else if (!__.isFunction(object[propertyName])) { // Do not recurse if the object[propertyName] is a function
-      if (object[propertyName].toIsoString !== undefined) { // Special case for TimeGrain objects returned by server
-        log.data(spaces + propertyName + ': ' + object[propertyName].toISOString());
-      } else if (__.isObject(object[propertyName])) {
+  // Test if the object to log is just a string. If so, simply log it at the current level
+  // This works around the situation where a string object ends up being indexed one letter at a time
+  if(__.isString(object)) {
+    log.data(spaces + object);
+  }
+  else {
+    for (var propertyName in object) {
+      if (__.isNull(object[propertyName]) || __.isUndefined(object[propertyName])) {
         log.data(spaces + propertyName + ':');
-        exports.showObject(log, object[propertyName], tabs + 1);
-      } else {
-        log.data(spaces + propertyName + ': ' + object[propertyName]);
+      } else if (__.isArray(object[propertyName])) {
+        log.data(spaces + propertyName + ':');
+        __.each(object[propertyName], recursiveCaller);
+      } else if (!__.isFunction(object[propertyName])) { // Do not recurse if the object[propertyName] is a function
+        if (object[propertyName].toIsoString !== undefined) { // Special case for TimeGrain objects returned by server
+          log.data(spaces + propertyName + ': ' + object[propertyName].toIsoString());
+        } else if (__.isObject(object[propertyName])) {
+          log.data(spaces + propertyName + ':');
+          exports.showObject(log, object[propertyName], tabs + 1);
+        } else {
+          log.data(spaces + propertyName + ': ' + object[propertyName]);
+        }
       }
     }
   }

--- a/lib/commands/arm/datalakestore/datalakeStore._js
+++ b/lib/commands/arm/datalakestore/datalakeStore._js
@@ -124,8 +124,8 @@ exports.init = function (cli) {
     .option('-n --accountName <accountName>', $('the Data Lake Store account name to execute the action on'))
     .option('-p --path <path>', $('the full path to the file to add content to (e.g. /someFolder/someFile.txt)'))
     .option('-v --value <value>', $('optional indicates the contents (as a string) to create the file with. NOTE: This parameter cannot be specified with --folder (-d)'))
-    .option('-d --folder <folder>', $('optionally specify that the item being created is a folder, not a file. If this is not specified, a file will be created. NOTE: This parameter cannot be specified with --encoding (-e) or --value (-v)'))
-    .option('-f --force <force>', $('optionally indicates that the file or folder being created can overwrite the file or folder at path if it already exists (default is false). \'true\' must be passed in for the overwrite to work'))
+    .option('-d --folder', $('optionally specify that the item being created is a folder, not a file. If this is not specified, a file will be created. NOTE: This parameter cannot be specified with --encoding (-e) or --value (-v)'))
+    .option('-f --force', $('optionally indicates that the file or folder being created can overwrite the file or folder at path if it already exists (default is false). \'true\' must be passed in for the overwrite to work'))
     .option('-s, --subscription <id>', $('the subscription identifier'))
     .execute(function (accountName, path, value, folder, force, options, _) {
       if (!accountName) {
@@ -262,7 +262,7 @@ exports.init = function (cli) {
     .option('-n --accountName <accountName>', $('the Data Lake Store account name to execute the action on'))
     .option('-p --paths <paths>', $('a comma seperated list of full paths to concatenate (e.g. \'/someFolder/someFile.txt,/somefolder/somefile2.txt,/anotherFolder/newFile.txt\')'))
     .option('-d --destination <destination>', $('specify the target file that all of the files in --paths should be concatenated into (e.g /someFolder/targetFile.txt)'))
-    .option('-f --force <force>', $('optionally indicates that the file or folder being created can overwrite the file or folder at path if it already exists (default is false). \'true\' must be passed in for the overwrite to work'))
+    .option('-f --force', $('optionally indicates that the file or folder being created can overwrite the file or folder at path if it already exists (default is false). \'true\' must be passed in for the overwrite to work'))
     .option('-s, --subscription <id>', $('the subscription identifier'))
     .execute(function (accountName, paths, destination, force, options, _) {
       if (!accountName) {
@@ -309,7 +309,7 @@ exports.init = function (cli) {
     .option('-n --accountName <accountName>', $('the Data Lake Store account name to execute the action on'))
     .option('-p --path <path>', $('the path to the file or folder to move (e.g. /someFolder or /someFolder/someFile.txt)'))
     .option('-d --destination <destination>', $('specify the target location to move the file or folder to'))
-    .option('-f --force <force>', $('optionally indicates that the file or folder being created can overwrite the file or folder at path if it already exists (default is false). \'true\' must be passed in for the overwrite to work'))
+    .option('-f --force', $('optionally indicates that the file or folder being created can overwrite the file or folder at path if it already exists (default is false). \'true\' must be passed in for the overwrite to work'))
     .option('-s, --subscription <id>', $('the subscription identifier'))
     .execute(function (accountName, path, destination, force, options, _) {
       if (!accountName) {
@@ -722,9 +722,9 @@ exports.init = function (cli) {
       log.info($('Successfully deleted the specified Data Lake Store account.'));
     });
     
-    dataLakeStoreAccount.command('create [accountName] [location] [resource-group] [defaultGroup] [tags]')
+    dataLakeStoreAccount.command('create [accountName] [location] [resource-group] [defaultGroup]')
     .description($('Creates a Data Lake Store Account'))
-    .usage('[options] <accountName> <location> <resource-group> <defaultGroup> <tags>')
+    .usage('[options] <accountName> <location> <resource-group> <defaultGroup>')
     .option('-n --accountName <accountName>', $('The Data Lake Store account name to create'))
     .option('-l --location <location>', $('the location the Data Lake Store account will be created in. Valid values are: North Central US, South Central US, Central US, West Europe, North Europe, West US, East US, East US 2, Japan East, Japan West, Brazil South, Southeast Asia, East Asia, Australia East, Australia Southeast'))
     .option('-g --resource-group <resource-group>', $('the resource group to create the account in'))
@@ -740,9 +740,9 @@ exports.init = function (cli) {
       dataLakeStoreUtils.formatOutput(cli, log, options, dataLakeStoreAccount);
     });
   
-    dataLakeStoreAccount.command('set [accountName] [resource-group] [defaultGroup] [tags]')
+    dataLakeStoreAccount.command('set [accountName] [resource-group] [defaultGroup]')
     .description($('Updates the properties of an existing Data Lake Store Account'))
-    .usage('[options] <accountName> <resource-group> <defaultGroup> <tags>')
+    .usage('[options] <accountName> <resource-group> <defaultGroup>')
     .option('-n --accountName <accountName>', $('The Data Lake Store account name to update with new tags and/or default permissions group'))
     .option('-g --resource-group <resource-group>', $('the optional resource group to forcibly look for the account to update in'))
     .option('-d --defaultGroup <defaultGroup>', $('the optional default permissions group to set in the existing account'))

--- a/lib/commands/arm/datalakestore/datalakeStore.utils.js
+++ b/lib/commands/arm/datalakestore/datalakeStore.utils.js
@@ -31,20 +31,27 @@ exports.showObject = function(log, object, indentationTabs) {
   var tabs = __.isNumber(indentationTabs) ? indentationTabs : 0;
   var spaces = _padSpaces(tabs);
   var recursiveCaller = function (element) { exports.showObject(log, element, tabs + 1); };
-  for (var propertyName in object) {
-    if (__.isNull(object[propertyName]) || __.isUndefined(object[propertyName])) {
-      log.data(spaces + propertyName + ':');
-    } else if (__.isArray(object[propertyName])) {
-      log.data(spaces + propertyName + ':');
-      __.each(object[propertyName], recursiveCaller);
-    } else if (!__.isFunction(object[propertyName])) { // Do not recurse if the object[propertyName] is a function
-      if (object[propertyName].toIsoString !== undefined) { // Special case for TimeGrain objects returned by server
-        log.data(spaces + propertyName + ': ' + object[propertyName].toIsoString());
-      } else if (__.isObject(object[propertyName])) {
+  // Test if the object to log is just a string. If so, simply log it at the current level
+  // This works around the situation where a string object ends up being indexed one letter at a time
+  if(__.isString(object)) {
+    log.data(spaces + object);
+  }
+  else {
+    for (var propertyName in object) {
+      if (__.isNull(object[propertyName]) || __.isUndefined(object[propertyName])) {
         log.data(spaces + propertyName + ':');
-        exports.showObject(log, object[propertyName], tabs + 1);
-      } else {
-        log.data(spaces + propertyName + ': ' + object[propertyName]);
+      } else if (__.isArray(object[propertyName])) {
+        log.data(spaces + propertyName + ':');
+        __.each(object[propertyName], recursiveCaller);
+      } else if (!__.isFunction(object[propertyName])) { // Do not recurse if the object[propertyName] is a function
+        if (object[propertyName].toIsoString !== undefined) { // Special case for TimeGrain objects returned by server
+          log.data(spaces + propertyName + ': ' + object[propertyName].toIsoString());
+        } else if (__.isObject(object[propertyName])) {
+          log.data(spaces + propertyName + ':');
+          exports.showObject(log, object[propertyName], tabs + 1);
+        } else {
+          log.data(spaces + propertyName + ': ' + object[propertyName]);
+        }
       }
     }
   }

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -10380,7 +10380,7 @@
                   "name": "create",
                   "description": "Creates a Data Lake Analytics Account",
                   "fullName": "datalake analytics account create",
-                  "usage": "[options] <accountName> <location> <resource-group> <defaultGroup> <tags>",
+                  "usage": "[options] <accountName> <location> <resource-group> <defaultGroup>",
                   "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
                   "options": [
                     {
@@ -10436,13 +10436,13 @@
                       "description": "the resource group to create the account in"
                     },
                     {
-                      "flags": "-d --defaultDataLake <defaultDataLake>",
-                      "required": -22,
+                      "flags": "-d --defaultDataLakeStore <defaultDataLakeStore>",
+                      "required": -27,
                       "optional": 0,
                       "bool": true,
                       "short": "-d",
-                      "long": "--defaultDataLake",
-                      "description": "the default Data Lake to associate with this account."
+                      "long": "--defaultDataLakeStore",
+                      "description": "the default Data Lake Store to associate with this account."
                     },
                     {
                       "flags": "-t --tags <tags>",
@@ -10468,7 +10468,7 @@
                   "name": "set",
                   "description": "Updates the properties of an existing Data Lake Analytics Account",
                   "fullName": "datalake analytics account set",
-                  "usage": "[options] <accountName> <resource-group> <defaultDataLake> <tags>",
+                  "usage": "[options] <accountName> <resource-group> <defaultDataLakeStore>",
                   "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
                   "options": [
                     {
@@ -11116,8 +11116,8 @@
                       "description": "optional indicates the contents (as a string) to create the file with. NOTE: This parameter cannot be specified with --folder (-d)"
                     },
                     {
-                      "flags": "-d --folder <folder>",
-                      "required": -13,
+                      "flags": "-d --folder",
+                      "required": 0,
                       "optional": 0,
                       "bool": true,
                       "short": "-d",
@@ -11125,8 +11125,8 @@
                       "description": "optionally specify that the item being created is a folder, not a file. If this is not specified, a file will be created. NOTE: This parameter cannot be specified with --encoding (-e) or --value (-v)"
                     },
                     {
-                      "flags": "-f --force <force>",
-                      "required": -12,
+                      "flags": "-f --force",
+                      "required": 0,
                       "optional": 0,
                       "bool": true,
                       "short": "-f",
@@ -11283,8 +11283,8 @@
                       "description": "specify the target file that all of the files in --paths should be concatenated into (e.g /someFolder/targetFile.txt)"
                     },
                     {
-                      "flags": "-f --force <force>",
-                      "required": -12,
+                      "flags": "-f --force",
+                      "required": 0,
                       "optional": 0,
                       "bool": true,
                       "short": "-f",
@@ -11362,8 +11362,8 @@
                       "description": "specify the target location to move the file or folder to"
                     },
                     {
-                      "flags": "-f --force <force>",
-                      "required": -12,
+                      "flags": "-f --force",
+                      "required": 0,
                       "optional": 0,
                       "bool": true,
                       "short": "-f",
@@ -12204,7 +12204,7 @@
                   "name": "create",
                   "description": "Creates a Data Lake Store Account",
                   "fullName": "datalake store account create",
-                  "usage": "[options] <accountName> <location> <resource-group> <defaultGroup> <tags>",
+                  "usage": "[options] <accountName> <location> <resource-group> <defaultGroup>",
                   "filePath": "commands/arm/datalakestore/datalakeStore._js",
                   "options": [
                     {
@@ -12292,7 +12292,7 @@
                   "name": "set",
                   "description": "Updates the properties of an existing Data Lake Store Account",
                   "fullName": "datalake store account set",
-                  "usage": "[options] <accountName> <resource-group> <defaultGroup> <tags>",
+                  "usage": "[options] <accountName> <resource-group> <defaultGroup>",
                   "filePath": "commands/arm/datalakestore/datalakeStore._js",
                   "options": [
                     {


### PR DESCRIPTION
remove 'tags' from help and syntax, which resulted in parsing issues
when generating the commands.

Account creation is now functional again and tags show up properly under
options.

Also missed a couple datalake -> datalakestore renames, those are now included.

Finally, made --force and --folder actual switches, instead of having them require a value.