### PR TITLE
Fixes to DataLake* cli commands

### DIFF
--- a/lib/commands/arm/datalakeanalytics/datalakeanalytics._js
+++ b/lib/commands/arm/datalakeanalytics/datalakeanalytics._js
@@ -44,7 +44,7 @@ exports.init = function (cli) {
   
   dataLakeAnalyticsJob.command('create [accountName] [jobName] [script] [runtime] [compileMode] [compileOnly] [degreeOfParallelism] [priority] [resource-group]' )
     .description($('Submits a job to the specified Data Lake Analytics account.'))
-    .usage('[options] <accountName> <jobName> <script> <runtime> <compileMode> <compileOnly> <degreeOfParallelism> <priority> <resource-group>')
+    .usage('[options] <accountName> <jobName> <script>')
     .option('-n --accountName <accountName>', $('the Data Lake Analytics account name to execute the action on'))
     .option('-j --jobName <jobName>', $('the name for this job submission'))
     .option('-t --script <script>', $('the script to run. This can be either the script contents, a relative path or the full path to a script file'))
@@ -81,7 +81,7 @@ exports.init = function (cli) {
       
       try {
         var normalPath = path.normalize(script);
-        scriptContents = fs.readFile(normalPath, _);
+        scriptContents = fs.readFile(normalPath, 'utf8', _);
       }
       catch (err){
         // this means it is not a file, treat it as script contents, 
@@ -325,7 +325,7 @@ exports.init = function (cli) {
   dataLakeAnalyticsCatalog.command('list [accountName] [itemType] [itemPath] [resource-group]')
     .description($('Lists all of the specified catalog item types under the path or, if the full path is given, just the single catalog item at that path.'))
     .usage('[options] <accountName> <itemType> <itemPath> <resource-group>')
-    .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to perform the action on.'))
+    .option('-n --accountName <accountName>', $('The Data Lake Analytics account name to perform the action on.'))
     .option('-t --itemType <itemType>', $('The catalog item type to return. Valid values are (case insensitive): database, schema, assembly, externaldatasource, table, tablevaluedfunction or tablestatistics'))
     .option('-p --itemPath <itemPath>', $('The path to the catalog item(s) to get or list in the format: <FirstPart>.<OptionalSecondPart>.<OptionalThirdPart>.<OptionalFourthPart>.'))
     .option('-g --resource-group <resource-group>', $('the optional resource group to list the accounts in'))
@@ -355,7 +355,7 @@ exports.init = function (cli) {
   dataLakeAnalyticsCatalogSecret.command('create [accountName] [databaseName] [hostUri] [secretName] [resource-group]')
     .description($('Creates the specified secret for the specified database.'))
     .usage('[options] <accountName> <databaseName> <hostUri> <secretName> <resource-group>')
-    .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to perform the action on.'))
+    .option('-n --accountName <accountName>', $('The Data Lake Analytics account name to perform the action on.'))
     .option('-d --databaseName <databaseName>', $('The name of the database in which the secret will be created.'))
     .option('-u --hostUri <hostUri>', $('The full host URI associated with the external data source. The secret will be used with this host URI.'))
     .option('-e --secretName <secretName>', $('secret name, will prompt if not given'))
@@ -398,7 +398,7 @@ exports.init = function (cli) {
     dataLakeAnalyticsCatalogSecret.command('set [accountName] [databaseName] [hostUri] [secretName] [resource-group]')
     .description($('Updates the password and/or hostUri of the specified secret in the specified database.'))
     .usage('[options] <accountName> <databaseName> <hostUri> <secretName> <resource-group>')
-    .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to perform the action on.'))
+    .option('-n --accountName <accountName>', $('The Data Lake Analytics account name to perform the action on.'))
     .option('-d --databaseName <databaseName>', $('The name of the database in which the secret will be updated.'))
     .option('-u --hostUri <hostUri>', $('The full host URI associated with the external data source. The secret will be used with this host URI.'))
     .option('-e --secretName <secretName>', $('secret name, will prompt if not given'))
@@ -441,7 +441,7 @@ exports.init = function (cli) {
     dataLakeAnalyticsCatalogSecret.command('delete [accountName] [databaseName] [secretName] [resource-group]')
     .description($('Updates the password and/or hostUri of the specified secret in the specified database.'))
     .usage('[options] <accountName> <databaseName> <hostUri> <secretName> <resource-group>')
-    .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to perform the action on.'))
+    .option('-n --accountName <accountName>', $('The Data Lake Analytics account name to perform the action on.'))
     .option('-d --databaseName <databaseName>', $('The name of the database in which the secret(s) will be deleted.'))
     .option('-e --secretName <secretName>', $('Optional secret name to delete, if not specified will delete all secrets in the specified database'))
     .option('-q, --quiet', $('quiet mode (do not ask for delete confirmation)'))
@@ -476,7 +476,7 @@ exports.init = function (cli) {
     .description($('Commands to manage your Data Lake Analytics accounts'));
  
   dataLakeAnalyticsAccount.command('list [resource-group]')
-    .description($('List all DataLakeAnalytics accounts available for your subscription or subscription and resource group'))
+    .description($('List all Data Lake Analytics accounts available for your subscription or subscription and resource group'))
     .usage('[options] <resource-group>')
     .option('-g --resource-group <resource-group>', $('the optional resource group to list the accounts in'))
     .option('-s, --subscription <id>', $('the subscription identifier'))
@@ -487,7 +487,7 @@ exports.init = function (cli) {
     });
 
   dataLakeAnalyticsAccount.command('show [accountName] [resource-group]')
-    .description($('Shows a DataLakeAnalytics Account based on account name'))
+    .description($('Shows a Data Lake Analytics account based on account name'))
     .usage('[options] <accountName> <resource-group>')
     .option('-n --accountName <accountName>', $('the Data Lake Analytics account name to retrieve'))
     .option('-g --resource-group <resource-group>', $('the optional resource group to list the accounts in'))
@@ -509,7 +509,7 @@ exports.init = function (cli) {
     });
     
     dataLakeAnalyticsAccount.command('delete [accountName] [resource-group]')
-    .description($('Deletes a DataLakeAnalytics Account based on account name'))
+    .description($('Deletes a Data Lake Analytics Account based on account name'))
     .usage('[options] <accountName> <resource-group>')
     .option('-n --accountName <accountName>', $('the Data Lake Analytics account name to delete'))
     .option('-g --resource-group <resource-group>', $('the optional resource group to force the command to find the Data Lake Analytics account to delete in.'))
@@ -520,7 +520,7 @@ exports.init = function (cli) {
         return cli.missingArgument('accountName');
       }
       
-      if (!options.quiet && !cli.interaction.confirm(util.format($('Delete DataLakeAnalytics Account %s? [y/n] '), accountName), _)) {
+      if (!options.quiet && !cli.interaction.confirm(util.format($('Delete Data Lake Analytics Account %s? [y/n] '), accountName), _)) {
         return;
       }
       
@@ -531,19 +531,19 @@ exports.init = function (cli) {
         resourceGroup = getResrouceGroupByAccountName(subscription, resourceGroup, accountName, _);
       }
       
-      var response = client.dataLakeAnalyticsAccount.delete(resourceGroup, accountName, _);
+      var response = client.dataLakeAnalyticsAccount.deleteMethod(resourceGroup, accountName, _);
       
-      if (response.Status !== 'Succeeded') {
-        throw new Error(util.format($('DataLakeAnalytics account operation failed with the following error code: %s and message: %s', response.error.code, response.error.message)));
+      if (response.status !== 'Succeeded') {
+        throw new Error(util.format($('Data Lake Analytics account operation failed with the following error code: %s and message: %s'), response.error.code, response.error.message));
       }
       
-      log.info($('Successfully deleted the specified DataLakeAnalytics account.'));
+      log.info($('Successfully deleted the specified Data Lake Analytics Account.'));
     });
     
     dataLakeAnalyticsAccount.command('create [accountName] [location] [resource-group] [defaultDataLakeStore]')
     .description($('Creates a Data Lake Analytics Account'))
-    .usage('[options] <accountName> <location> <resource-group> <defaultGroup>')
-    .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to create'))
+    .usage('[options] <accountName> <location> <resource-group> <defaultDataLakeStore>')
+    .option('-n --accountName <accountName>', $('The Data Lake Analytics account name to create'))
     .option('-l --location <location>', $('the location the Data Lake Analytics account will be created in. Valid values are: North Central US, South Central US, Central US, West Europe, North Europe, West US, East US, East US 2, Japan East, Japan West, Brazil South, Southeast Asia, East Asia, Australia East, Australia Southeast'))
     .option('-g --resource-group <resource-group>', $('the resource group to create the account in'))
     .option('-d --defaultDataLakeStore <defaultDataLakeStore>', $('the default Data Lake Store to associate with this account.'))
@@ -561,7 +561,7 @@ exports.init = function (cli) {
     dataLakeAnalyticsAccount.command('set [accountName] [resource-group] [defaultDataLakeStore]')
     .description($('Updates the properties of an existing Data Lake Analytics Account'))
     .usage('[options] <accountName> <resource-group> <defaultDataLakeStore>')
-    .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to perform the action on.'))
+    .option('-n --accountName <accountName>', $('The Data Lake Analytics Account name to perform the action on.'))
     .option('-g --resource-group <resource-group>', $('the optional resource group to forcibly look for the account to update in'))
     .option('-g --resource-group <resource-group>', $('the optional resource group to forcibly look for the account to update in'))
     .option('-d --defaultDataLakeStore <defaultDataLakeStore>', $('the optional new default Data Lake Store account to set for this account'))
@@ -599,9 +599,9 @@ exports.init = function (cli) {
     .description($('Commands to manage your Data Lake Analytics account data sources'));
     
     dataLakeAnalyticsAccountDataSource.command('add [accountName] [dataLakeStore] [isDefaultDataLakeStore] [azureBlob] [accessKey] [resource-group]')
-    .description($('Adds an existing data source (Data Lake Store or Azure Blob) to the dataLakeAnalytics account'))
-    .usage('[options] <accountName> <dataLakeStore> <isDefaultDataLakeStore> <azureBlob> <accessKey> <resource-group>')
-    .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to perform the action on.'))
+    .description($('Adds an existing data source (Data Lake Store or Azure Blob) to the Data Lake Analytics Account'))
+    .usage('[options] <accountName>')
+    .option('-n --accountName <accountName>', $('The Data Lake Analytics Account name to perform the action on.'))
     .option('-l --dataLakeStore <dataLakeStore>', $('the Data Lake Store account to add. NOTE: this argument and --isDefaultDataLakeStore are part of a parameter set, and cannot be specified with --azureBlob and --accessKey.'))
     .option('-d --isDefaultDataLakeStore', $('the optional switch to indicate that the Data Lake being added should be the default Data Lake. NOTE: this argument and --dataLakeStore are part of a parameter set, and cannot be specified with --azureBlob and --accessKey.'))
     .option('-b --azureBlob <azureBlob>', $('the azure blob to add to the account. NOTE: this argument and --accessKey are part of a parameter set, and cannot be specified with --dataLakeStore and --isDefaultDataLakeStore.'))
@@ -657,9 +657,9 @@ exports.init = function (cli) {
     });
     
     dataLakeAnalyticsAccountDataSource.command('delete [accountName] [dataLakeStore] [azureBlob] [resource-group]')
-    .description($('removes a data source (Data Lake Store or Azure Blob) from the dataLakeAnalytics account'))
-    .usage('[options] <accountName> <dataLakeStore> <azureBlob> <resource-group>')
-    .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to perform the action on.'))
+    .description($('removes a data source (Data Lake Store or Azure Blob) from the Data Lake Analytics Account'))
+    .usage('[options] <accountName>')
+    .option('-n --accountName <accountName>', $('The Data Lake Analytics Account name to perform the action on.'))
     .option('-l --dataLakeStore <dataLakeStore>', $('the Data Lake to remove from the account. NOTE: this argument is part of a parameter set, and cannot be specified with --azureBlob.'))
     .option('-b --azureBlob <azureBlob>', $('the azure blob to remove from the account. NOTE: this argument is part of a parameter set, and cannot be specified with --dataLakeStore.'))
     .option('-g --resource-group <resource-group>', $('the optional resource group to forcibly look for the account to update in'))
@@ -681,19 +681,19 @@ exports.init = function (cli) {
       }
       
       if (dataLakeStore) {
-        client.dataLakeAnalyticsAccount.deleteDataLakeStoreAccount(resourceGroup, accountName, dataLakeStore);
+        client.dataLakeAnalyticsAccount.deleteDataLakeStoreAccount(resourceGroup, accountName, dataLakeStore, _);
       }
       else {
-        client.dataLakeAnalyticsAccount.deleteStorageAccount(resourceGroup, accountName, azureBlob);
+        client.dataLakeAnalyticsAccount.deleteStorageAccount(resourceGroup, accountName, azureBlob, _);
       }
       
       log.info($('Successfully removed the storage account specified from Data Lake Analytics account: ' + accountName));
     });
     
     dataLakeAnalyticsAccountDataSource.command('set [accountName] [dataLakeStore] [isDefaultDataLakeStore] [azureBlob] [accessKey] [resource-group]')
-    .description($('Sets an existing data source (Data Lake Store or Azure Blob) in the dataLakeAnalytics account. Typically used to set the data source as default (for Data Lake) or update the access key (for Azure Blob)'))
-    .usage('[options] <accountName> <dataLakeStore> <isDefaultDataLakeStore> <azureBlob> <accessKey> <resource-group>')
-    .option('-n --accountName <accountName>', $('The DataLakeAnalytics account name to perform the action on.'))
+    .description($('Sets an existing data source (Data Lake Store or Azure Blob) in the Data Lake Analytics Account. Typically used to set the data source as default (for Data Lake) or update the access key (for Azure Blob)'))
+    .usage('[options] <accountName>')
+    .option('-n --accountName <accountName>', $('The Data Lake Analytics Account name to perform the action on.'))
     .option('-l --dataLakeStore <dataLakeStore>', $('the Data Lake Store account to set. NOTE: this argument and --isDefaultDataLakeStore are part of a parameter set, and cannot be specified with --azureBlob and --accessKey.'))
     .option('-d --isDefaultDataLakeStore', $('the optional switch to indicate that the Data Lake being set should be the default Data Lake. NOTE: this argument and --dataLakeStore are part of a parameter set, and cannot be specified with --azureBlob and --accessKey.'))
     .option('-b --azureBlob <azureBlob>', $('the azure blob to set in the account. NOTE: this argument and --accessKey are part of a parameter set, and cannot be specified with --dataLakeStore and --isDefaultDataLakeStore.'))
@@ -783,21 +783,21 @@ exports.init = function (cli) {
           return cli.missingArgument('defaultDataLakeStore');
         }
         
-        accountParams.properties.defaultDataLakeStoreAccount = defaultDataLakeStore;
-        accountParams.properties.location = location;
+        accountParams.dataLakeAnalyticsAccount.properties.defaultDataLakeStoreAccount = defaultDataLakeStore;
+        accountParams.dataLakeAnalyticsAccount.location = location;
         
         response = client.dataLakeAnalyticsAccount.create(resourceGroup, accountParams, _);
       }
       else {
         if (defaultDataLakeStore) {
-          accountParams.properties.defaultDataLakeStoreAccount = defaultDataLakeStore;
+          accountParams.dataLakeAnalyticsAccount.properties.defaultDataLakeStoreAccount = defaultDataLakeStore;
         }
         
         response = client.dataLakeAnalyticsAccount.update(resourceGroup, accountParams, _);
       }
       
       if (response.status !== 'Succeeded') {
-        throw new Error(util.format($('DataLakeAnalytics account operation failed with the following error code: %s and message: %s', response.error.code, response.error.message)));
+        throw new Error(util.format('Data Lake Analytics Account operation failed with the following error code: %s and message: %s', response.error.code, response.error.message));
       }
       
       return client.dataLakeAnalyticsAccount.get(resourceGroup, accountName, _).dataLakeAnalyticsAccount;
@@ -1006,6 +1006,6 @@ exports.init = function (cli) {
       }
     }
     
-    throw new Error($('Could not find account: ' + name + ' in any resource group in subscription: ' + subscription ));
+    throw new Error($('Could not find account: ' + name + ' in any resource group in subscription: ' + subscription.name + ' with id: ' + subscription.id ));
   }
 };

--- a/lib/commands/arm/datalakeanalytics/datalakeanalytics._js
+++ b/lib/commands/arm/datalakeanalytics/datalakeanalytics._js
@@ -47,7 +47,7 @@ exports.init = function (cli) {
     .usage('[options] <accountName> <jobName> <script>')
     .option('-n --accountName <accountName>', $('the Data Lake Analytics account name to execute the action on'))
     .option('-j --jobName <jobName>', $('the name for this job submission'))
-    .option('-t --script <script>', $('the script to run. This can be either the script contents, a relative path or the full path to a script file'))
+    .option('-t --script <script>', $('the script to run. This can be either the script contents, a relative path or the full path to a UTF-8 encoded script file'))
     .option('-r --runtime <runtime>', $('optionally indicates the runtime to use. The default runtime is the currently deployed production runtime.' +
                                         'Use this if you have uploaded a custom runtime to your account and want job execution to go through that one instead of the one deployed by Microsoft.'))
     .option('-m --compileMode <compileMode>', $('optionally specify the type of compilation to do. Valid values are \'Semantic\', \'Full\', and \'SingleBox\' Default is Full.'))
@@ -636,11 +636,13 @@ exports.init = function (cli) {
         resourceGroup = getResrouceGroupByAccountName(subscription, resourceGroup, accountName, _);
       }
       
+      var parameters = {};
+      
       if (dataLakeStore) {
-        client.dataLakeAnalyticsAccount.addDataLakeStoreAccount(resourceGroup, accountName, dataLakeStore, _);
+        client.dataLakeAnalyticsAccount.addDataLakeStoreAccount(resourceGroup, accountName, dataLakeStore, parameters, _);
       }
       else {
-        var parameters = {
+        parameters = {
           properties: {
             accessKey: accessKey
           }

--- a/lib/commands/arm/datalakestore/datalakeStore._js
+++ b/lib/commands/arm/datalakestore/datalakeStore._js
@@ -167,6 +167,9 @@ exports.init = function (cli) {
         withProgress(util.format($('Creating file %s'), path),
         function (log, _) {
           var response = client.fileSystem.internalBeginCreate(path, accountName, parameters, _);
+          if (!value) {
+            value = '';
+          }
           client.fileSystem.create(response.location, value, _);
         }, _);
       }
@@ -175,7 +178,7 @@ exports.init = function (cli) {
     });
   
   dataLakeStoreFileSystem.command('import [accountName] [path] [destination] [force]')
-    .description($('Uploads the specified the specified file, to the target destination in an Azure Data Lake.'))
+    .description($('Uploads the specified the specified file, to the target destination in an Azure Data Lake. NOTE: Only text files are supported by this command at present.'))
     .usage('[options] <accountName> <path> <destination>')
     .option('-n --accountName <accountName>', $('the Data Lake Store account name to execute the action on'))
     .option('-p --path <path>', $('the full local path to the file to import (e.g. /someFolder/someFile.txt or C:\somefolder\someFile.txt)'))
@@ -379,7 +382,7 @@ exports.init = function (cli) {
     });
   
   dataLakeStoreFileSystem.command('export [accountName] [path] [destination] [force]')
-    .description($('Downloads the specified file to the target location.'))
+    .description($('Downloads the specified file to the target location. NOTE: Only text files are supported by this command at present.'))
     .usage('[options] <accountName> <path> <destination>')
     .option('-n --accountName <accountName>', $('the Data Lake Store account name to execute the action on'))
     .option('-p --path <path>', $('the full path in the Data Lake Store where the file should be imported to (e.g. /someFolder/someFile.txt'))
@@ -715,7 +718,7 @@ exports.init = function (cli) {
       
       var response = client.dataLakeStoreAccount.deleteMethod(resourceGroup, accountName, _);
       
-      if (response.Status !== 'Succeeded') {
+      if (response.status !== 'Succeeded') {
         throw new Error(util.format($('Data Lake Store account operation failed with the following error code: %s and message: %s', response.error.code, response.error.message)));
       }
       
@@ -843,6 +846,6 @@ exports.init = function (cli) {
       }
     }
     
-    throw new Error($('Could not find account: ' + name + ' in any resource group in subscription: ' + subscription ));
+    throw new Error($('Could not find account: ' + name + ' in any resource group in subscription: ' + subscription.name + ' with id: ' + subscription.id ));
   }
 };

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -9452,7 +9452,7 @@
                       "bool": true,
                       "short": "-t",
                       "long": "--script",
-                      "description": "the script to run. This can be either the script contents, a relative path or the full path to a script file"
+                      "description": "the script to run. This can be either the script contents, a relative path or the full path to a UTF-8 encoded script file"
                     },
                     {
                       "flags": "-r --runtime <runtime>",

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -9399,7 +9399,7 @@
                   "name": "create",
                   "description": "Submits a job to the specified Data Lake Analytics account.",
                   "fullName": "datalake analytics job create",
-                  "usage": "[options] <accountName> <jobName> <script> <runtime> <compileMode> <compileOnly> <degreeOfParallelism> <priority> <resource-group>",
+                  "usage": "[options] <accountName> <jobName> <script>",
                   "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
                   "options": [
                     {
@@ -9850,7 +9850,7 @@
                       "bool": true,
                       "short": "-n",
                       "long": "--accountName",
-                      "description": "The DataLakeAnalytics account name to perform the action on."
+                      "description": "The Data Lake Analytics account name to perform the action on."
                     },
                     {
                       "flags": "-t --itemType <itemType>",
@@ -9938,7 +9938,7 @@
                           "bool": true,
                           "short": "-n",
                           "long": "--accountName",
-                          "description": "The DataLakeAnalytics account name to perform the action on."
+                          "description": "The Data Lake Analytics account name to perform the action on."
                         },
                         {
                           "flags": "-d --databaseName <databaseName>",
@@ -10035,7 +10035,7 @@
                           "bool": true,
                           "short": "-n",
                           "long": "--accountName",
-                          "description": "The DataLakeAnalytics account name to perform the action on."
+                          "description": "The Data Lake Analytics account name to perform the action on."
                         },
                         {
                           "flags": "-d --databaseName <databaseName>",
@@ -10132,7 +10132,7 @@
                           "bool": true,
                           "short": "-n",
                           "long": "--accountName",
-                          "description": "The DataLakeAnalytics account name to perform the action on."
+                          "description": "The Data Lake Analytics account name to perform the action on."
                         },
                         {
                           "flags": "-d --databaseName <databaseName>",
@@ -10195,7 +10195,7 @@
               "commands": [
                 {
                   "name": "list",
-                  "description": "List all DataLakeAnalytics accounts available for your subscription or subscription and resource group",
+                  "description": "List all Data Lake Analytics accounts available for your subscription or subscription and resource group",
                   "fullName": "datalake analytics account list",
                   "usage": "[options] <resource-group>",
                   "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
@@ -10247,7 +10247,7 @@
                 },
                 {
                   "name": "show",
-                  "description": "Shows a DataLakeAnalytics Account based on account name",
+                  "description": "Shows a Data Lake Analytics account based on account name",
                   "fullName": "datalake analytics account show",
                   "usage": "[options] <accountName> <resource-group>",
                   "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
@@ -10308,7 +10308,7 @@
                 },
                 {
                   "name": "delete",
-                  "description": "Deletes a DataLakeAnalytics Account based on account name",
+                  "description": "Deletes a Data Lake Analytics Account based on account name",
                   "fullName": "datalake analytics account delete",
                   "usage": "[options] <accountName> <resource-group>",
                   "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
@@ -10380,7 +10380,7 @@
                   "name": "create",
                   "description": "Creates a Data Lake Analytics Account",
                   "fullName": "datalake analytics account create",
-                  "usage": "[options] <accountName> <location> <resource-group> <defaultGroup>",
+                  "usage": "[options] <accountName> <location> <resource-group> <defaultDataLakeStore>",
                   "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
                   "options": [
                     {
@@ -10415,7 +10415,7 @@
                       "bool": true,
                       "short": "-n",
                       "long": "--accountName",
-                      "description": "The DataLakeAnalytics account name to create"
+                      "description": "The Data Lake Analytics account name to create"
                     },
                     {
                       "flags": "-l --location <location>",
@@ -10503,7 +10503,7 @@
                       "bool": true,
                       "short": "-n",
                       "long": "--accountName",
-                      "description": "The DataLakeAnalytics account name to perform the action on."
+                      "description": "The Data Lake Analytics Account name to perform the action on."
                     },
                     {
                       "flags": "-g --resource-group <resource-group>",
@@ -10562,9 +10562,9 @@
                   "commands": [
                     {
                       "name": "add",
-                      "description": "Adds an existing data source (Data Lake Store or Azure Blob) to the dataLakeAnalytics account",
+                      "description": "Adds an existing data source (Data Lake Store or Azure Blob) to the Data Lake Analytics Account",
                       "fullName": "datalake analytics account datasource add",
-                      "usage": "[options] <accountName> <dataLakeStore> <isDefaultDataLakeStore> <azureBlob> <accessKey> <resource-group>",
+                      "usage": "[options] <accountName>",
                       "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
                       "options": [
                         {
@@ -10599,7 +10599,7 @@
                           "bool": true,
                           "short": "-n",
                           "long": "--accountName",
-                          "description": "The DataLakeAnalytics account name to perform the action on."
+                          "description": "The Data Lake Analytics Account name to perform the action on."
                         },
                         {
                           "flags": "-l --dataLakeStore <dataLakeStore>",
@@ -10659,9 +10659,9 @@
                     },
                     {
                       "name": "delete",
-                      "description": "removes a data source (Data Lake Store or Azure Blob) from the dataLakeAnalytics account",
+                      "description": "removes a data source (Data Lake Store or Azure Blob) from the Data Lake Analytics Account",
                       "fullName": "datalake analytics account datasource delete",
-                      "usage": "[options] <accountName> <dataLakeStore> <azureBlob> <resource-group>",
+                      "usage": "[options] <accountName>",
                       "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
                       "options": [
                         {
@@ -10696,7 +10696,7 @@
                           "bool": true,
                           "short": "-n",
                           "long": "--accountName",
-                          "description": "The DataLakeAnalytics account name to perform the action on."
+                          "description": "The Data Lake Analytics Account name to perform the action on."
                         },
                         {
                           "flags": "-l --dataLakeStore <dataLakeStore>",
@@ -10738,9 +10738,9 @@
                     },
                     {
                       "name": "set",
-                      "description": "Sets an existing data source (Data Lake Store or Azure Blob) in the dataLakeAnalytics account. Typically used to set the data source as default (for Data Lake) or update the access key (for Azure Blob)",
+                      "description": "Sets an existing data source (Data Lake Store or Azure Blob) in the Data Lake Analytics Account. Typically used to set the data source as default (for Data Lake) or update the access key (for Azure Blob)",
                       "fullName": "datalake analytics account datasource set",
-                      "usage": "[options] <accountName> <dataLakeStore> <isDefaultDataLakeStore> <azureBlob> <accessKey> <resource-group>",
+                      "usage": "[options] <accountName>",
                       "filePath": "commands/arm/datalakeanalytics/datalakeanalytics._js",
                       "options": [
                         {
@@ -10775,7 +10775,7 @@
                           "bool": true,
                           "short": "-n",
                           "long": "--accountName",
-                          "description": "The DataLakeAnalytics account name to perform the action on."
+                          "description": "The Data Lake Analytics Account name to perform the action on."
                         },
                         {
                           "flags": "-l --dataLakeStore <dataLakeStore>",
@@ -11146,7 +11146,7 @@
                 },
                 {
                   "name": "import",
-                  "description": "Uploads the specified the specified file, to the target destination in an Azure Data Lake.",
+                  "description": "Uploads the specified the specified file, to the target destination in an Azure Data Lake. NOTE: Only text files are supported by this command at present.",
                   "fullName": "datalake store filesystem import",
                   "usage": "[options] <accountName> <path> <destination>",
                   "filePath": "commands/arm/datalakestore/datalakeStore._js",
@@ -11453,7 +11453,7 @@
                 },
                 {
                   "name": "export",
-                  "description": "Downloads the specified file to the target location.",
+                  "description": "Downloads the specified file to the target location. NOTE: Only text files are supported by this command at present.",
                   "fullName": "datalake store filesystem export",
                   "usage": "[options] <accountName> <path> <destination>",
                   "filePath": "commands/arm/datalakestore/datalakeStore._js",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "azure-arm-dns": "0.10.1",
     "azure-arm-website": "0.10.0",
     "azure-arm-rediscache": "0.0.2",
-    "azure-arm-datalake-analytics": "0.1.1",
+    "azure-arm-datalake-analytics": "0.1.0",
     "azure-arm-datalake-store": "0.1.0",
     "azure-extra": "0.1.12",
     "azure-gallery": "2.0.0-pre.18",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "azure-arm-dns": "0.10.1",
     "azure-arm-website": "0.10.0",
     "azure-arm-rediscache": "0.0.2",
-    "azure-arm-datalake-analytics": "0.1.0",
+    "azure-arm-datalake-analytics": "0.1.1",
     "azure-arm-datalake-store": "0.1.0",
     "azure-extra": "0.1.12",
     "azure-gallery": "2.0.0-pre.18",


### PR DESCRIPTION
This fixes the following:
Help text for required usage
Account Creation
Adding/removing data sources
Proper casing for status properties
Including callbacks where necessary
replacing 'delete' with deleteMethod (delete is reserved)
Including help text for upload/download to indicate that only text files
are supported
Allow creation of empty files
Ensure jobs can be submitted in a file as UTF8 format (currently only
supported) format.