### PR TITLE
ARM: 'network express-route provider list' now outputs comma separated bandwidth

### DIFF
--- a/lib/commands/arm/network/expressRoute._js
+++ b/lib/commands/arm/network/expressRoute._js
@@ -243,14 +243,10 @@ __.extend(ExpressRoute.prototype, {
       }
       self.output.table(providers, function (row, provider) {
         row.cell($('Name'), provider.name);
-        var bandwidthRange = '';
-        if (provider.bandwidthsOffered.length > 1) {
-          bandwidthRange = util.format('%s-%s',
-            provider.bandwidthsOffered.shift().offerName, provider.bandwidthsOffered.pop().offerName);
-        } else if (provider.bandwidthsOffered.length == 1) {
-          bandwidthRange = provider.bandwidthsOffered.shift().offerName;
-        }
-        row.cell($('Bandwidths offered'), bandwidthRange);
+        var bandwidths = provider.bandwidthsOffered.map(function (b) {
+          return b.offerName;
+        });
+        row.cell($('Bandwidths offered'), bandwidths);
         row.cell($('Peering locations'), provider.peeringLocations.join());
       });
     });


### PR DESCRIPTION
Minor fix for https://github.com/Azure/azure-xplat-cli/issues/2281 issue