### PR TITLE
Fix graph url endpoint for AzureChinaCloud environment

### DIFF
--- a/lib/util/profile/environment.js
+++ b/lib/util/profile/environment.js
@@ -175,7 +175,7 @@ Environment.publicEnvironments = [
     galleryEndpointUrl: 'https://gallery.chinacloudapi.cn/',
     activeDirectoryEndpointUrl: 'https://login.chinacloudapi.cn',
     activeDirectoryResourceId: 'https://management.core.chinacloudapi.cn/',
-    activeDirectoryGraphResourceId: 'https://graph.windows.net/',
+    activeDirectoryGraphResourceId: 'https://graph.chinacloudapi.cn/',
     activeDirectoryGraphApiVersion: '2013-04-05',
     storageEndpointSuffix: '.core.chinacloudapi.cn',
     keyVaultDnsSuffix: '.vault.azure.cn'


### PR DESCRIPTION
graph url should point to the China instance of graph, not public.

This causes tokens from the issuer to be invalid when presented to graph.