### PR TITLE
remove useless ._js file before create installer so to shrink the download size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ targets/*
 
 # Visual Studio #
 .settings/
+.vs/
+.vscode/
 /app.js
 /xPlat.sln
 *.suo

--- a/tools/osx-setup/scripts/createTarball.sh
+++ b/tools/osx-setup/scripts/createTarball.sh
@@ -95,6 +95,7 @@ pushd /tmp/azureInstallerTemporary
 node node_modules/streamline/bin/_node --verbose -c lib
 node node_modules/streamline/bin/_node --verbose -c node_modules/streamline/lib/streams
 node node_modules/streamline/bin/_node --verbose -c node_modules/streamline-streams/lib
+find lib/ -name "*._js" -delete
 popd
 
 # generate command metadata file

--- a/tools/windows/scripts/prepareRepoClone.cmd
+++ b/tools/windows/scripts/prepareRepoClone.cmd
@@ -130,6 +130,9 @@ for %%i in (
     )
 )
 
+cd lib
+del /Q /S *._js 
+
 echo.
 popd
 


### PR DESCRIPTION
There are useless as compiled *.js stay right beside