### PR TITLE
Fix #2285: truncated command json output during piping

### DIFF
--- a/lib/util/patch-winston.js
+++ b/lib/util/patch-winston.js
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-var fs = require('fs');
 var tty = require('tty');
 var winston = require('winston');
 var config = require('winston/lib/winston/config');
@@ -65,7 +64,11 @@ winston.transports.Console.prototype.log = function (level, msg, meta, callback)
   } else { /* patch: remove all colorization for file or pipe output */
     // remove any colorization
     var out = output.replace(/\x1b\[[0-9]+m/g, '') + '\n';
-    fs.writeSync(isStdErr ? 2 : 1, out);
+    if (isStdErr){
+      process.stderr.write(out);
+    } else {
+      process.stdout.write(out);
+    }
   }
   callback(null, true);
 };


### PR DESCRIPTION
"fs.writeSync" doesn't guarantee all data will be written into the pipe; rather it returns the number of bytes written, which azure-cli code just ignores. This error doesn't surface on windows or with old node versions(<=0.12.x), but our bug regardless. 
There are several options, and this PR picks the most straightforward one. 