### PR TITLE
Correct variable declaration in creating service (fixes #1892)

### DIFF
--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -401,7 +401,7 @@ function createService(factoryMethod, subscription) {
       host: managementEndpoint.hostname,
       port: managementEndpoint.port,
       serializetype: 'XML'
-    }).withFilter(new utils.RequestLogFilter(log));
+    }).withFilter(new RequestLogFilter(log));
   return service;
 }
 


### PR DESCRIPTION
This looks like it has been introduced by mistake in: https://github.com/Azure/azure-xplat-cli/commit/b1c23942cd12df3e279ffea7338fff79a401ff13#diff-0261004ab0f5706809fa8fe41a29f27aL118 

when it was moved from `lib/util/profile/subscription.js` to `lib/util/utils.js` where the value of `utils` was valid in `subscription.js`