### PR TITLE
ARM: --no-tags option removed from all networking commands

### DIFF
--- a/lib/commands/arm/network/dnsZone._js
+++ b/lib/commands/arm/network/dnsZone._js
@@ -48,7 +48,7 @@ __.extend(DnsZone.prototype, {
     };
 
     if (options.tags) {
-      parameters.zone.tags = tagUtils.buildTagsParameter(null, options);
+      tagUtils.appendTags(parameters.zone, options);
     }
 
     var progress = self.interaction.progress(util.format($('Creating dns zone "%s"'), zoneName));
@@ -116,12 +116,11 @@ __.extend(DnsZone.prototype, {
     }
 
     if (options.tags) {
-      var tags = tagUtils.buildTagsParameter(null, options);
-      tagUtils.appendTags(dnsZone, tags);
-    }
-
-    if (options.tags === false) {
-      dnsZone.tags = {};
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(dnsZone, options);
+      } else {
+        dnsZone.tags = {};
+      }
     }
 
     self.update(resourceGroupName, zoneName, dnsZone, _);
@@ -560,12 +559,12 @@ __.extend(DnsZone.prototype, {
       recordSet.recordSet.properties.ttl = defTtl;
     }
 
-    if (options.tags === false) {
-      recordSet.recordSet.tags = {};
-    }
-
     if (options.tags) {
-      recordSet.recordSet.tags = tagUtils.buildTagsParameter(null, options);
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(recordSet.recordSet, options);
+      } else {
+        recordSet.recordSet.tags = {};
+      }
     }
   },
 

--- a/lib/commands/arm/network/expressRoute._js
+++ b/lib/commands/arm/network/expressRoute._js
@@ -212,11 +212,11 @@ __.extend(ExpressRoute.prototype, {
     }
 
     if (options.tags) {
-      circuit.tags = tagUtils.buildTagsParameter(null, options);
-    }
-
-    if (options.tags === false) {
-      circuit.tags = {};
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(circuit, options);
+      } else {
+        circuit.tags = {};
+      }
     }
 
     return circuit;

--- a/lib/commands/arm/network/loadBalancer._js
+++ b/lib/commands/arm/network/loadBalancer._js
@@ -46,7 +46,7 @@ __.extend(LoadBalancer.prototype, {
     };
 
     if (options.tags) {
-      lbProfile.tags = tagUtils.buildTagsParameter(null, options);
+      tagUtils.appendTags(lbProfile, options);
     }
 
     var progress = self.interaction.progress(util.format($('Creating load balancer "%s"'), lbName));

--- a/lib/commands/arm/network/localNetworkGateway._js
+++ b/lib/commands/arm/network/localNetworkGateway._js
@@ -207,12 +207,11 @@ __.extend(LocalNetworkGateway.prototype, {
     }
 
     if (options.tags) {
-      var tags = tagUtils.buildTagsParameter(null, options);
-      tagUtils.appendTags(parameters, tags);
-    }
-
-    if (options.tags === false) {
-      gateway.tags = {};
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(parameters, options);
+      } else {
+        parameters.tags = {};
+      }
     }
 
     return parameters;

--- a/lib/commands/arm/network/network._js
+++ b/lib/commands/arm/network/network._js
@@ -78,11 +78,10 @@ exports.init = function (cli) {
     '\n     The address prefixes in this list should not overlap with existing address prefixes in the vnet.'))
     .option('-d, --dns-servers [dns-servers]', $('the comma separated list of DNS servers IP addresses.' +
     '\n     This list will be appended to the current list of DNS server IP addresses.'))
-    .option('-t, --tags <tags>', $('the tags set on this virtual network.' +
+    .option('-t, --tags [tags]', $('the tags set on this virtual network.' +
     '\n     Can be multiple. In the format of "name=value".' +
     '\n     Name is required and value is optional. For example, -t "tag1=value1;tag2".' +
     '\n     Existing tag values will be replaced by the values specified.'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, location, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
@@ -819,12 +818,11 @@ exports.init = function (cli) {
     .option('-a, --allocation-method <allocation-method>', $('the allocation method [Static][Dynamic]'))
     .option('-i, --idletimeout <idletimeout>', $('the idle timeout specified in minutes'))
     .option('-f, --reverse-fqdn [reverse-fqdn]', $('the reverse fqdn'))
-    .option('-t, --tags <tags>', $('the list of tags.' +
+    .option('-t, --tags [tags]', $('the list of tags.' +
     '\n     Can be multiple. In the format of "name=value".' +
     '\n     Name is required and value is optional.' +
     '\n     Existing tag values will be replaced by the values specified.' +
     '\n     For example, -t "tag1=value1;tag2"'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
@@ -950,12 +948,11 @@ exports.init = function (cli) {
     '\n     e.g. /subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.Network/loadbalancers/<lb-name>/inboundNatRules/<nat-rule-name>'))
     .option('-r, --internal-dns-name-label <internal-dns-name-label>', $('the internal DNS name label'))
     .option('-f, --enable-ip-forwarding <enable-ip-forwarding>', $('the ip forwarding, valid values are [true, false]'))
-    .option('-t, --tags <tags>', $('the list of tags.' +
+    .option('-t, --tags [tags]', $('the list of tags.' +
     '\n     Can be multiple. In the format of "name=value".' +
     '\n     Name is required and value is optional.' +
     '\n     Existing tag values will be replaced by the values specified.' +
     '\n     For example, -t "tag1=value1;tag2"'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
@@ -1134,12 +1131,11 @@ exports.init = function (cli) {
     .usage('[options] <resource-group> <name>')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-n, --name <name>', $('the name of the network security group'))
-    .option('-t, --tags <tags>', $('the list of tags.' +
+    .option('-t, --tags [tags]', $('the list of tags.' +
     '\n     Can be multiple. In the format of "name=value".' +
     '\n     Name is required and value is optional.' +
     '\n     Existing tag values will be replaced by the values specified.' +
     '\n     For example, -t "tag1=value1;tag2"'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
@@ -1329,12 +1325,11 @@ exports.init = function (cli) {
     .usage('[options] <resource-group> <name>')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-n, --name <name>', $('the name of the DNS zone'))
-    .option('-t, --tags <tags>', $('the list of tags.' +
+    .option('-t, --tags [tags]', $('the list of tags.' +
     '\n     Can be multiple. In the format of "name=value".' +
     '\n     Name is required and value is optional.' +
     '\n     Existing tag values will be replaced by the values specified.' +
     '\n     For example, -t "tag1=value1;tag2"'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
@@ -1466,12 +1461,11 @@ exports.init = function (cli) {
     .option('-y, --type <type>', $('the type of the record set.' +
     '\n     Valid values are [A, AAAA, CNAME, MX, NS, SOA, SRV, TXT, PTR]'))
     .option('-l, --ttl <ttl>', $('time to live specified in seconds'))
-    .option('-t, --tags <tags>', $('the tags set on this virtual network.' +
+    .option('-t, --tags [tags]', $('the tags set on this virtual network.' +
     '\n     Can be multiple. In the format of "name=value".' +
     '\n     Name is required and value is optional.' +
     '\n     Existing tag values will be replaced by the values specified.' +
     '\n     For example, -t "tag1=value1;tag2"'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, dnsZoneName, name, type, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
@@ -1688,12 +1682,11 @@ exports.init = function (cli) {
     '\n     [%s], default is %s'), constants.trafficManager.protocols, constants.trafficManager.protocols[0]))
     .option('-o, --monitor-port <monitor-port>', $('the monitoring port'))
     .option('-a, --monitor-path <monitor-path>', $('the monitoring path'))
-    .option('-t, --tags <tags>', $('the tags set on this profile. Can be ' +
+    .option('-t, --tags [tags]', $('the tags set on this profile. Can be ' +
     '\n     multiple, in the format of \'name=value\'.' +
     '\n     Name is required and value is optional. ' +
     '\n     Existing tag values will be replaced by the values specified.' +
     '\n     For example, -t "tag1=value1;tag2"'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
@@ -2079,11 +2072,10 @@ exports.init = function (cli) {
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-n, --name <name>', $('the name of the local network'))
     .option('-a, --address-space <address-space>', $('the local network site address space'))
-    .option('-t, --tags <tags>', $('the tags set on this local network gateway.' +
+    .option('-t, --tags [tags]', $('the tags set on this local network gateway.' +
     '\n     Can be multiple. In the format of "name=value".' +
     '\n     Name is required and value is optional. For example, -t "tag1=value1;tag2".' +
     '\n     Existing tag values will be replaced by the values specified.'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
@@ -2191,11 +2183,10 @@ exports.init = function (cli) {
     .usage('[options] <resource-group> <name>')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-n, --name <name>', $('the name of the virtual network gateway'))
-    .option('-t, --tags <tags>', $('the tags set on this virtual network gateway.' +
+    .option('-t, --tags [tags]', $('the tags set on this virtual network gateway.' +
     '\n     Can be multiple. In the format of "name=value".' +
     '\n     Name is required and value is optional. For example, -t "tag1=value1;tag2".' +
     '\n     Existing tag values will be replaced by the values specified.'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
@@ -2365,11 +2356,10 @@ exports.init = function (cli) {
     .option('-b, --bandwidth-in-mbps <bandwidth-in-mbps>', $('the bandwidth in Mbps'))
     .option('-e, --sku-tier <sku-tier>', $('the sku tier'))
     .option('-f, --sku-family <sku-family>', $('the sku family'))
-    .option('-t, --tags <tags>', $('the tags set on express route.' +
+    .option('-t, --tags [tags]', $('the tags set on express route.' +
     '\n   Can be multiple, in the format of "name=value".' +
     '\n   Name is required and value is optional.' +
     '\n   For example, -t tag1=value1;tag2'))
-    .option('--no-tags', $('remove all existing tags'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);

--- a/lib/commands/arm/network/nic._js
+++ b/lib/commands/arm/network/nic._js
@@ -123,11 +123,11 @@ __.extend(Nic.prototype, {
     }
 
     if (options.tags) {
-      tagUtils.appendTags(nic, nicProfile.tags);
-    }
-
-    if (options.tags === false) {
-      nic.tags = {};
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(nic, options);
+      } else {
+        nic.tags = {};
+      }
     }
 
     self.update(resourceGroupName, nicName, nic, _);
@@ -572,7 +572,11 @@ __.extend(Nic.prototype, {
     }
 
     if (options.tags) {
-      nicProfile.tags = tagUtils.buildTagsParameter(null, options);
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(nicProfile, options);
+      } else {
+        nicProfile.tags = {};
+      }
     }
 
     return nicProfile;

--- a/lib/commands/arm/network/nsg._js
+++ b/lib/commands/arm/network/nsg._js
@@ -44,7 +44,7 @@ __.extend(Nsg.prototype, {
     };
 
     if (options.tags) {
-      nsgProfile.tags = tagUtils.buildTagsParameter(null, options);
+      tagUtils.appendTags(nsgProfile, options);
     }
 
     var progress = self.interaction.progress(util.format($('Creating a network security group "%s"'), nsgName));
@@ -65,10 +65,11 @@ __.extend(Nsg.prototype, {
     }
 
     if (options.tags) {
-      tagUtils.appendTags(nsg, tagUtils.buildTagsParameter(null, options));
-    }
-    if (options.tags === false) {
-      nsg.tags = {};
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(nsg, options);
+      } else {
+        nsg.tags = {};
+      }
     }
 
     var progress = self.interaction.progress(util.format($('Setting a network security group "%s"'), nsgName));

--- a/lib/commands/arm/network/publicIp._js
+++ b/lib/commands/arm/network/publicIp._js
@@ -78,11 +78,11 @@ __.extend(PublicIp.prototype, {
     }
 
     if (options.tags) {
-      tagUtils.appendTags(publicip, publicipProfile.tags);
-    }
-
-    if (options.tags === false) {
-      publicip.tags = {};
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(publicip, options);
+      } else {
+        publicip.tags = {};
+      }
     }
 
     self.update(resourceGroupName, name, publicip, _);
@@ -232,7 +232,11 @@ __.extend(PublicIp.prototype, {
     }
 
     if (options.tags) {
-      publicipProfile.tags = tagUtils.buildTagsParameter(null, options);
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(publicipProfile, options);
+      } else {
+        publicipProfile.tags = {};
+      }
     }
 
     if (options.location) {

--- a/lib/commands/arm/network/routeTable._js
+++ b/lib/commands/arm/network/routeTable._js
@@ -295,7 +295,7 @@ __.extend(RouteTable.prototype, {
     }
 
     if (options.tags) {
-      parameters.tags = tagUtils.buildTagsParameter(null, options);
+      tagUtils.appendTags(parameters, options);
     }
     return parameters;
   },

--- a/lib/commands/arm/network/trafficManager._js
+++ b/lib/commands/arm/network/trafficManager._js
@@ -345,11 +345,11 @@ __.extend(TrafficManager.prototype, {
     }
 
     if (options.tags) {
-      profile.tags = tagUtils.buildTagsParameter(null, options);
-    }
-
-    if (options.tags === false) {
-      profile.tags = {};
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(profile, options);
+      } else {
+        profile.tags = {};
+      }
     }
 
     var parameters = {

--- a/lib/commands/arm/network/virtualNetwork._js
+++ b/lib/commands/arm/network/virtualNetwork._js
@@ -37,7 +37,7 @@ __.extend(VirtualNetwork.prototype, {
       throw new Error(util.format($('Virtual network "%s" already exists in resource group "%s"'), name, resourceGroupName));
     }
 
-    var requestBody = {
+    vnet = {
       name: name,
       location: location,
       addressSpace: {
@@ -49,29 +49,26 @@ __.extend(VirtualNetwork.prototype, {
     };
 
     if (options.addressPrefixes) {
-      self._addAddressPrefixes(options, requestBody);
+      self._addAddressPrefixes(options, vnet);
     } else {
       var defaultAddressPrefix = self.vnetUtil.defaultAddressSpaceInfo().ipv4Cidr;
       self.output.verbose(util.format($('Using default address prefix: %s'), defaultAddressPrefix));
-      requestBody.addressSpace.addressPrefixes.push(defaultAddressPrefix);
+      vnet.addressSpace.addressPrefixes.push(defaultAddressPrefix);
     }
 
     if (options.dnsServers) {
-      self._addDnsServers(options, requestBody);
+      self._addDnsServers(options, vnet);
     } else {
       self.output.verbose($('No DNS server specified'));
     }
 
     if (options.tags) {
-      var tags = tagUtils.buildTagsParameter(null, options);
-      requestBody.tags = tags;
-    } else {
-      self.output.verbose($('No tags specified'));
+      tagUtils.appendTags(vnet, options);
     }
 
     var progress = self.interaction.progress(util.format($('Creating virtual network "%s"'), name));
     try {
-      self.networkResourceProviderClient.virtualNetworks.createOrUpdate(resourceGroupName, name, requestBody, _);
+      self.networkResourceProviderClient.virtualNetworks.createOrUpdate(resourceGroupName, name, vnet, _);
     } finally {
       progress.end();
     }
@@ -101,14 +98,11 @@ __.extend(VirtualNetwork.prototype, {
       }
     }
 
-    if (options.tags === false) {
-      vnet.tags = {};
-    }
-
     if (options.tags) {
-      var tags = tagUtils.buildTagsParameter(vnet.tags, options);
-      for (var key in tags) {
-        vnet.tags[key] = tags[key];
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(vnet, options);
+      } else {
+        vnet.tags = {};
       }
     }
 

--- a/lib/commands/arm/network/virtualNetworkGateway._js
+++ b/lib/commands/arm/network/virtualNetworkGateway._js
@@ -367,15 +367,6 @@ __.extend(VirtualNetworkGateway.prototype, {
       parameters.location = options.location;
     }
 
-    if (options.tags) {
-      var tags = tagUtils.buildTagsParameter(null, options);
-      tagUtils.appendTags(parameters, tags);
-    }
-
-    if (options.tags === false) {
-      gateway.tags = {};
-    }
-
     if (options.publicIpId) {
       if (options.publicIpName) {
         self.output.warn($('--public-ip-name parameter will be ignored because --public-ip-id and --public-ip-name are mutually exclusive'));
@@ -403,6 +394,14 @@ __.extend(VirtualNetworkGateway.prototype, {
           throw new Error(util.format($('A subnet with name "%s" not found in the resource group "%s"'), options.subnetName, resourceGroupName));
         }
         parameters.ipConfigurations[0].subnet.id = subnet.id;
+      }
+    }
+
+    if (options.tags) {
+      if (utils.argHasValue(options.tags)) {
+        tagUtils.appendTags(parameters, options);
+      } else {
+        parameters.tags = {};
       }
     }
 

--- a/lib/commands/arm/tag/tagUtils.js
+++ b/lib/commands/arm/tag/tagUtils.js
@@ -42,10 +42,20 @@ exports.buildTagsParameter = function (existingTags, options) {
   return tagsParameter;
 };
 
-exports.appendTags = function (obj, tagsToAppend) {
-  if (!obj.hasOwnProperty('tags')) obj.tags = {};
-  for (var key in tagsToAppend) {
-    obj.tags[key] = tagsToAppend[key];
+exports.appendTags = function (obj, options) {
+  if (!obj.hasOwnProperty('tags')) {
+    obj.tags = {};
+  }
+
+  if (options.tags) {
+    options.tags.split(';').forEach(function (chunk) {
+      var fields = chunk.split('=');
+      if (fields.length === 2) {
+        var tagName = fields[0];
+        var tagValue = fields[1];
+        obj.tags[tagName] = tagValue;
+      }
+    });
   }
 };
 

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -18577,21 +18577,13 @@
                   "description": "the comma separated list of DNS servers IP addresses.\n     This list will be appended to the current list of DNS server IP addresses."
                 },
                 {
-                  "flags": "-t, --tags <tags>",
-                  "required": -12,
-                  "optional": 0,
+                  "flags": "-t, --tags [tags]",
+                  "required": 0,
+                  "optional": -12,
                   "bool": true,
                   "short": "-t",
                   "long": "--tags",
                   "description": "the tags set on this virtual network.\n     Can be multiple. In the format of \"name=value\".\n     Name is required and value is optional. For example, -t \"tag1=value1;tag2\".\n     Existing tag values will be replaced by the values specified."
-                },
-                {
-                  "flags": "--no-tags",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": false,
-                  "long": "--no-tags",
-                  "description": "remove all existing tags"
                 },
                 {
                   "flags": "-s, --subscription <subscription>",
@@ -21933,21 +21925,13 @@
                   "description": "the reverse fqdn"
                 },
                 {
-                  "flags": "-t, --tags <tags>",
-                  "required": -12,
-                  "optional": 0,
+                  "flags": "-t, --tags [tags]",
+                  "required": 0,
+                  "optional": -12,
                   "bool": true,
                   "short": "-t",
                   "long": "--tags",
                   "description": "the list of tags.\n     Can be multiple. In the format of \"name=value\".\n     Name is required and value is optional.\n     Existing tag values will be replaced by the values specified.\n     For example, -t \"tag1=value1;tag2\""
-                },
-                {
-                  "flags": "--no-tags",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": false,
-                  "long": "--no-tags",
-                  "description": "remove all existing tags"
                 },
                 {
                   "flags": "-s, --subscription <subscription>",
@@ -22499,21 +22483,13 @@
                   "description": "the ip forwarding, valid values are [true, false]"
                 },
                 {
-                  "flags": "-t, --tags <tags>",
-                  "required": -12,
-                  "optional": 0,
+                  "flags": "-t, --tags [tags]",
+                  "required": 0,
+                  "optional": -12,
                   "bool": true,
                   "short": "-t",
                   "long": "--tags",
                   "description": "the list of tags.\n     Can be multiple. In the format of \"name=value\".\n     Name is required and value is optional.\n     Existing tag values will be replaced by the values specified.\n     For example, -t \"tag1=value1;tag2\""
-                },
-                {
-                  "flags": "--no-tags",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": false,
-                  "long": "--no-tags",
-                  "description": "remove all existing tags"
                 },
                 {
                   "flags": "-s, --subscription <subscription>",
@@ -23249,21 +23225,13 @@
                   "description": "the name of the network security group"
                 },
                 {
-                  "flags": "-t, --tags <tags>",
-                  "required": -12,
-                  "optional": 0,
+                  "flags": "-t, --tags [tags]",
+                  "required": 0,
+                  "optional": -12,
                   "bool": true,
                   "short": "-t",
                   "long": "--tags",
                   "description": "the list of tags.\n     Can be multiple. In the format of \"name=value\".\n     Name is required and value is optional.\n     Existing tag values will be replaced by the values specified.\n     For example, -t \"tag1=value1;tag2\""
-                },
-                {
-                  "flags": "--no-tags",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": false,
-                  "long": "--no-tags",
-                  "description": "remove all existing tags"
                 },
                 {
                   "flags": "-s, --subscription <subscription>",
@@ -24121,21 +24089,13 @@
                       "description": "the name of the DNS zone"
                     },
                     {
-                      "flags": "-t, --tags <tags>",
-                      "required": -12,
-                      "optional": 0,
+                      "flags": "-t, --tags [tags]",
+                      "required": 0,
+                      "optional": -12,
                       "bool": true,
                       "short": "-t",
                       "long": "--tags",
                       "description": "the list of tags.\n     Can be multiple. In the format of \"name=value\".\n     Name is required and value is optional.\n     Existing tag values will be replaced by the values specified.\n     For example, -t \"tag1=value1;tag2\""
-                    },
-                    {
-                      "flags": "--no-tags",
-                      "required": 0,
-                      "optional": 0,
-                      "bool": false,
-                      "long": "--no-tags",
-                      "description": "remove all existing tags"
                     },
                     {
                       "flags": "-s, --subscription <subscription>",
@@ -24689,21 +24649,13 @@
                       "description": "time to live specified in seconds"
                     },
                     {
-                      "flags": "-t, --tags <tags>",
-                      "required": -12,
-                      "optional": 0,
+                      "flags": "-t, --tags [tags]",
+                      "required": 0,
+                      "optional": -12,
                       "bool": true,
                       "short": "-t",
                       "long": "--tags",
                       "description": "the tags set on this virtual network.\n     Can be multiple. In the format of \"name=value\".\n     Name is required and value is optional.\n     Existing tag values will be replaced by the values specified.\n     For example, -t \"tag1=value1;tag2\""
-                    },
-                    {
-                      "flags": "--no-tags",
-                      "required": 0,
-                      "optional": 0,
-                      "bool": false,
-                      "long": "--no-tags",
-                      "description": "remove all existing tags"
                     },
                     {
                       "flags": "-s, --subscription <subscription>",
@@ -25657,21 +25609,13 @@
                       "description": "the monitoring path"
                     },
                     {
-                      "flags": "-t, --tags <tags>",
-                      "required": -12,
-                      "optional": 0,
+                      "flags": "-t, --tags [tags]",
+                      "required": 0,
+                      "optional": -12,
                       "bool": true,
                       "short": "-t",
                       "long": "--tags",
                       "description": "the tags set on this profile. Can be \n     multiple, in the format of 'name=value'.\n     Name is required and value is optional. \n     Existing tag values will be replaced by the values specified.\n     For example, -t \"tag1=value1;tag2\""
-                    },
-                    {
-                      "flags": "--no-tags",
-                      "required": 0,
-                      "optional": 0,
-                      "bool": false,
-                      "long": "--no-tags",
-                      "description": "remove all existing tags"
                     },
                     {
                       "flags": "-s, --subscription <subscription>",
@@ -27218,21 +27162,13 @@
                   "description": "the local network site address space"
                 },
                 {
-                  "flags": "-t, --tags <tags>",
-                  "required": -12,
-                  "optional": 0,
+                  "flags": "-t, --tags [tags]",
+                  "required": 0,
+                  "optional": -12,
                   "bool": true,
                   "short": "-t",
                   "long": "--tags",
                   "description": "the tags set on this local network gateway.\n     Can be multiple. In the format of \"name=value\".\n     Name is required and value is optional. For example, -t \"tag1=value1;tag2\".\n     Existing tag values will be replaced by the values specified."
-                },
-                {
-                  "flags": "--no-tags",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": false,
-                  "long": "--no-tags",
-                  "description": "remove all existing tags"
                 },
                 {
                   "flags": "-s, --subscription <subscription>",
@@ -27640,21 +27576,13 @@
                   "description": "the name of the virtual network gateway"
                 },
                 {
-                  "flags": "-t, --tags <tags>",
-                  "required": -12,
-                  "optional": 0,
+                  "flags": "-t, --tags [tags]",
+                  "required": 0,
+                  "optional": -12,
                   "bool": true,
                   "short": "-t",
                   "long": "--tags",
                   "description": "the tags set on this virtual network gateway.\n     Can be multiple. In the format of \"name=value\".\n     Name is required and value is optional. For example, -t \"tag1=value1;tag2\".\n     Existing tag values will be replaced by the values specified."
-                },
-                {
-                  "flags": "--no-tags",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": false,
-                  "long": "--no-tags",
-                  "description": "remove all existing tags"
                 },
                 {
                   "flags": "-s, --subscription <subscription>",
@@ -28388,21 +28316,13 @@
                   "description": "the sku family"
                 },
                 {
-                  "flags": "-t, --tags <tags>",
-                  "required": -12,
-                  "optional": 0,
+                  "flags": "-t, --tags [tags]",
+                  "required": 0,
+                  "optional": -12,
                   "bool": true,
                   "short": "-t",
                   "long": "--tags",
                   "description": "the tags set on express route.\n   Can be multiple, in the format of \"name=value\".\n   Name is required and value is optional.\n   For example, -t tag1=value1;tag2"
-                },
-                {
-                  "flags": "--no-tags",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": false,
-                  "long": "--no-tags",
-                  "description": "remove all existing tags"
                 },
                 {
                   "flags": "-s, --subscription <subscription>",
@@ -29029,7 +28949,7 @@
               "bool": true,
               "short": "-c",
               "long": "--redis-configuration",
-              "description": "Redis Configuration. Enter a JSON formatted string of configuration keys and values here."
+              "description": "Redis Configuration. Enter a JSON formatted string of configuration keys and values here. Format:\"{\"<key1>\":\"<value1>\",\"<key2>\":\"<value2>\"}\""
             },
             {
               "flags": "-f, --redis-configuration-file <redisConfigurationFile>",
@@ -29038,7 +28958,7 @@
               "bool": true,
               "short": "-f",
               "long": "--redis-configuration-file",
-              "description": "Redis Configuration. Enter the path of a file containing configuration keys and values here.",
+              "description": "Redis Configuration. Enter the path of a file containing configuration keys and values here. Format for the file entry: {\"<key1>\":\"<value1>\",\"<key2>\":\"<value2>\"}",
               "fileRelatedOption": true
             },
             {

--- a/lib/plugins.asm.json
+++ b/lib/plugins.asm.json
@@ -27550,6 +27550,15 @@
                   "description": "delete chef config files during update/uninstall extension"
                 },
                 {
+                  "flags": "-v, --bootstrap-version <number>",
+                  "required": -25,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--bootstrap-version",
+                  "description": "chef-client version to be installed"
+                },
+                {
                   "flags": "-b, --disable",
                   "required": 0,
                   "optional": 0,

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -1280,6 +1280,10 @@ exports.getOptionalArg = function (argument) {
   return optionalArg;
 };
 
+exports.argHasValue = function (argument) {
+  return (argument !== true && argument !== '\'\'');
+};
+
 exports.trimTrailingChar = function (str, charToTrim) {
   while (str.length > 0 && str.charAt(str.length - 1) == charToTrim) {
     str = str.substr(0, str.length - 1);

--- a/test/commands/arm/network/arm-network-express-route-circuit-tests.js
+++ b/test/commands/arm/network/arm-network-express-route-circuit-tests.js
@@ -72,7 +72,7 @@ describe('arm', function() {
         });
       });
       it('set should modify express-route', function(done) {
-        var cmd = util.format('network express-route set %s %s -b %s --no-tags --json', groupName, expressRCPrefix, bandwidth2).split(' ');
+        var cmd = util.format('network express-route set %s %s -b %s --json', groupName, expressRCPrefix, bandwidth2).split(' ');
         testUtils.executeCommand(suite, retry, cmd, function(result) {
           result.exitStatus.should.equal(0);
           done();

--- a/test/commands/arm/network/arm.network.nic-tests.js
+++ b/test/commands/arm/network/arm.network.nic-tests.js
@@ -142,7 +142,7 @@ describe('arm', function() {
         });
       });
       it('set should modify nic', function(done) {
-        var cmd = util.format('network nic set %s %s -t %s -w %s -o %s -a %s -u %s -k %s -d %s -e %s --no-tags -r %s -f %s --json', groupName, nicPrefix, tagValN, networkTestUtil.nsgId, 'NoSuchNSGExists', privateIP2, networkTestUtil.subnetId, 'NoSuchSubnetExists', networkTestUtil.lbaddresspoolId, networkTestUtil.lbinboundruleId, internalDnsLabelN, enableIpForwardingN).split(' ');
+        var cmd = util.format('network nic set %s %s -t %s -w %s -o %s -a %s -u %s -k %s -d %s -e %s -r %s -f %s --json', groupName, nicPrefix, tagValN, networkTestUtil.nsgId, 'NoSuchNSGExists', privateIP2, networkTestUtil.subnetId, 'NoSuchSubnetExists', networkTestUtil.lbaddresspoolId, networkTestUtil.lbinboundruleId, internalDnsLabelN, enableIpForwardingN).split(' ');
         testUtils.executeCommand(suite, retry, cmd, function(result) {
           result.exitStatus.should.equal(0);
           done();

--- a/test/commands/arm/network/arm.network.nsg-tests.js
+++ b/test/commands/arm/network/arm.network.nsg-tests.js
@@ -74,7 +74,7 @@ describe('arm', function() {
         });
       });
       it('set with no tags should remove tags from nsg ', function(done) {
-        var cmd = util.format('network nsg set %s %s --no-tags --json', groupName, nsgName).split(' ');
+        var cmd = util.format('network nsg set %s %s --json', groupName, nsgName).split(' ');
         testUtils.executeCommand(suite, retry, cmd, function(result) {
           result.exitStatus.should.equal(0);
           done();

--- a/test/commands/arm/network/arm.network.publicip-tests.js
+++ b/test/commands/arm/network/arm.network.publicip-tests.js
@@ -95,7 +95,7 @@ describe('arm', function() {
         });
       });
       it('set with new set of params should pass', function(done) {
-        var cmd = util.format('network public-ip set -g %s -n %s -d %s -a %s -i %s --no-tags --json', groupName, publicipName, dnsPrefix, 'Static', '6').split(' ');
+        var cmd = util.format('network public-ip set -g %s -n %s -d %s -a %s -i %s --json', groupName, publicipName, dnsPrefix, 'Static', '6').split(' ');
         testUtils.executeCommand(suite, retry, cmd, function(result) {
           result.exitStatus.should.equal(0);
           done();

--- a/test/commands/arm/network/arm.network.vnet-tests.js
+++ b/test/commands/arm/network/arm.network.vnet-tests.js
@@ -74,7 +74,7 @@ describe('arm', function() {
       });
       it('set should modify vnet', function(done) {
 
-        var cmd = util.format('network vnet set %s %s -d %s --no-tags --json', groupName, vnetPrefix, dnsAdd1).split(' ');
+        var cmd = util.format('network vnet set %s %s -d %s --json', groupName, vnetPrefix, dnsAdd1).split(' ');
         testUtils.executeCommand(suite, retry, cmd, function(result) {
           result.exitStatus.should.equal(0);
           done();


### PR DESCRIPTION
This PR contains improvement related to `tags` in ARM networking commands.

No need to use separate option `--no-tags` to remove tags from existing resource. Now tags can be unset in one of the following native manner:

* `-t ""`
* `-t ''`
* `-t`
