### PR TITLE
Collect basic metrics when enabling vm diagnostics

### DIFF
--- a/lib/commands/arm/vm/vm._js
+++ b/lib/commands/arm/vm/vm._js
@@ -383,7 +383,8 @@ exports.init = function (cli) {
     .option('-g, --resource-group <resource-group>', $('the resource group name'))
     .option('-n, --name <name>', $('the virtual machine name'))
     .option('-a, --storage-account-name <name>', $('the storage account name'))
-    .option('-c, --config-file <path>', $('path for WadCfg config file'))
+    .option('-c, --config-file <path>', $('path for WadCfg config file' +
+      ' (collect basic metrics if not specified)'))
     .option('-e, --extension-version <version>', util.format($('Version of Diagnostics extension. Default values are [%s] for Windows and [%s] for Linux.'), vmConstants.EXTENSIONS.IAAS_DIAG_VERSION, vmConstants.EXTENSIONS.LINUX_DIAG_VERSION))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .execute(function (resourceGroup, name, options, _) {

--- a/lib/commands/arm/vm/vmExtensionProfile._js
+++ b/lib/commands/arm/vm/vmExtensionProfile._js
@@ -145,8 +145,12 @@ __.extend(VMExtensionProfile.prototype, {
     } else {
       if (this.params.osType === 'Windows') {
         this.cli.output.verbose($('--config-file is not specified, using default one.'));
-        config.xmlCfg = new Buffer(this._generateDefaultXmlCfg(this.params.vmID)).toString('base64');
+        config.xmlCfg = new Buffer(this._generateDefaultWindowsXmlCfg(this.params.vmID)).toString('base64');
+      } else if (this.params.osType === 'Linux') {
+        this.cli.output.verbose($('--config-file is not specified, using default one.'));
+        config.xmlCfg = new Buffer(this._generateDefaultLinuxXmlCfg(this.params.vmID)).toString('base64');
       } else {
+
         return null;
       }
     }
@@ -156,33 +160,402 @@ __.extend(VMExtensionProfile.prototype, {
     return config;
   },
 
-  _generateDefaultXmlCfg: function(vmID) {
+  _generateDefaultWindowsXmlCfg: function (vmID) {
     var wadCfg = {
       DiagnosticMonitorConfiguration: {
         '@': {
-          overallQuotaInMB: '25000'
+          overallQuotaInMB: '4096'
+        },
+        DiagnosticInfrastructureLogs: {
+          '@': {
+            scheduledTransferPeriod: 'PT1M',
+            scheduledTransferLogLevelFilter: 'Warning'
+          }
         },
         PerformanceCounters: {
           '@': {
             scheduledTransferPeriod: 'PT1M'
           },
-          PerformanceCounterConfiguration: {
-            '@': {
-              counterSpecifier: '\\\Processor(_Total)\\\% Processor Time',
-              sampleRate: 'PT1M',
-              unit: 'percent'
+          PerformanceCounterConfiguration: [
+            {
+              '@': {
+                counterSpecifier: '\\Processor(_Total)\\% Processor Time',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU utilization',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor(_Total)\\% Privileged Time',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU privileged time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor(_Total)\\% User Time',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU user time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor' +
+                ' Information(_Total)\\Processor Frequency',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU frequency',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\System\\Processes',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Processes',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Process(_Total)\\Thread Count',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Threads',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Process(_Total)\\Handle Count',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Handles',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\% Committed Bytes In Use',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory usage',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\Available Bytes',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory available',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\Committed Bytes',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory committed',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\Commit Limit',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory commit limit',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\Pool Paged Bytes',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory paged pool',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\Pool Nonpaged Bytes',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory non-paged pool',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\% Disk Time',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk active time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\% Disk Read Time',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk active read time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\% Disk Write Time',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk active write time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\Disk Transfers/sec',
+                sampleRate: 'PT15S',
+                unit: 'CountPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk operations',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\Disk Reads/sec',
+                sampleRate: 'PT15S',
+                unit: 'CountPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk read operations',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\Disk Writes/sec',
+                sampleRate: 'PT15S',
+                unit: 'CountPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk write operations',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\Disk Bytes/sec',
+                sampleRate: 'PT15S',
+                unit: 'BytesPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk speed',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\Disk Read Bytes/sec',
+                sampleRate: 'PT15S',
+                unit: 'BytesPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk read speed',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\Disk Write' +
+                ' Bytes/sec',
+                sampleRate: 'PT15S',
+                unit: 'BytesPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk write speed',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\Avg. Disk Queue' +
+                ' Length',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk average queue length',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\Avg. Disk Read' +
+                ' Queue Length',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk average read queue length',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk(_Total)\\Avg. Disk Write' +
+                ' Queue Length',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk average write queue length',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\LogicalDisk(_Total)\\% Free Space',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk free space (percentage)',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\LogicalDisk(_Total)\\Free Megabytes',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk free space (MB)',
+                  locale: 'en-us'
+                }
+              }
             }
-          }
+          ]
         },
         WindowsEventLog: {
           '@': {
             scheduledTransferPeriod: 'PT1M'
           },
-          DataSource: {
-            '@': {
-              name: 'System!*'
+          DataSource: [
+            {
+              '@': {
+                name: 'Application!*[System[(Level = 1 or Level = 2)]]'
+              }
+            },
+            {
+              '@': {
+                name: 'Security!*[System[(Level = 1 or Level = 2)]'
+              }
+            },
+            {
+              '@': {
+                name: 'System!*[System[(Level = 1 or Level = 2)]]'
+              }
             }
-          }
+          ]
         },
         Metrics: {
           '@': {
@@ -204,9 +577,527 @@ __.extend(VMExtensionProfile.prototype, {
       }
     };
 
-    var options = { declaration: { include: false }, prettyPrinting: { enabled: false } };
-    var xmlCfg = js2xmlparser('WadCfg', wadCfg, options);
-    return xmlCfg;
+    var options = {
+      declaration: {include: false},
+      prettyPrinting: {enabled: false}
+    };
+
+    return js2xmlparser('WadCfg', wadCfg, options);
+  },
+
+  _generateDefaultLinuxXmlCfg: function (vmID) {
+    var wadCfg = {
+      DiagnosticMonitorConfiguration: {
+        '@': {
+          overallQuotaInMB: '4096'
+        },
+        DiagnosticInfrastructureLogs: {
+          '@': {
+            scheduledTransferPeriod: 'PT1M',
+            scheduledTransferLogLevelFilter: 'Warning'
+          }
+        },
+        PerformanceCounters: {
+          '@': {
+            scheduledTransferPeriod: 'PT1M'
+          },
+          PerformanceCounterConfiguration: [
+            {
+              '@': {
+                counterSpecifier: '\\Processor\\PercentProcessorTime',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU utilization',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor\\PercentIdleTime',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU idle time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor\\PercentPrivilegedTime',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU privileged time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor\\PercentInterruptTime',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU interrupt time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor\\PercentDPCTime',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU DPC time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor\\PercentUserTime',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU user time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor\\PercentNiceTime',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU nice time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Processor\\PercentIOWaitTime',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'CPU IO wait time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\PercentUsedMemory',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory used',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\UsedMemory',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory used (bytes)',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\PercentAvailableMemory',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory available',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\AvailableMemory',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory available (bytes)',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\PercentUsedByCache',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory cached',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\PercentUsedSwap',
+                sampleRate: 'PT15S',
+                unit: 'Percent'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory swap used',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\UsedSwap',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory swap used (bytes)',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\AvailableSwap',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory swap available (bytes)',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\PagesPerSec',
+                sampleRate: 'PT15S',
+                unit: 'CountPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory pages',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\PagesReadPerSec',
+                sampleRate: 'PT15S',
+                unit: 'CountPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory page reads',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\Memory\\PagesWrittenPerSec',
+                sampleRate: 'PT15S',
+                unit: 'CountPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Memory page writes',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk\\AverageTransferTime',
+                sampleRate: 'PT15S',
+                unit: 'Seconds'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk active time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk\\AverageReadTime',
+                sampleRate: 'PT15S',
+                unit: 'Seconds'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk active read time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk\\AverageWriteTime',
+                sampleRate: 'PT15S',
+                unit: 'Seconds'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk active write time',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk\\TransfersPerSecond',
+                sampleRate: 'PT15S',
+                unit: 'CountPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk operations',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk\\ReadsPerSecond',
+                sampleRate: 'PT15S',
+                unit: 'CountPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk read operations',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk\\WritesPerSecond',
+                sampleRate: 'PT15S',
+                unit: 'CountPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk write operations',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk\\BytesPerSecond',
+                sampleRate: 'PT15S',
+                unit: 'BytesPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk speed',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk\\WriteBytesPerSecond',
+                sampleRate: 'PT15S',
+                unit: 'BytesPerSecond'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk write speed',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\PhysicalDisk\\AverageDiskQueueLength',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Disk average queue length',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\NetworkInterface\\BytesTotal',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Network bytes',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\NetworkInterface\\BytesTransmitted',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Network bytes sent',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\NetworkInterface\\BytesReceived',
+                sampleRate: 'PT15S',
+                unit: 'Bytes'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Network bytes received',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\NetworkInterface\\PacketsTransmitted',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Network packets sent',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\NetworkInterface\\PacketsReceived',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Network packets received',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\NetworkInterface\\TotalRxErrors',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Network packets received errors',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\NetworkInterface\\TotalTxErrors',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Network packets sent errors',
+                  locale: 'en-us'
+                }
+              }
+            },
+            {
+              '@': {
+                counterSpecifier: '\\NetworkInterface\\TotalCollisions',
+                sampleRate: 'PT15S',
+                unit: 'Count'
+              },
+              annotation: {
+                '@': {
+                  displayName: 'Network collisions',
+                  locale: 'en-us'
+                }
+              }
+            }
+          ]
+        },
+        Metrics: {
+          '@': {
+            resourceId: vmID
+          },
+          MetricAggregation: [
+            {
+              '@': {
+                scheduledTransferPeriod: 'PT1H'
+              }
+            },
+            {
+              '@': {
+                scheduledTransferPeriod: 'PT1M'
+              }
+            }
+          ]
+        }
+      }
+    };
+
+    var options = {
+      declaration: {include: false},
+      prettyPrinting: {enabled: false}
+    };
+
+    return js2xmlparser('WadCfg', wadCfg, options);
   },
 
   _createDiagPrivateConfiguration: function(_) {

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -32864,7 +32864,7 @@
               "bool": true,
               "short": "-c",
               "long": "--config-file",
-              "description": "path for WadCfg config file"
+              "description": "path for WadCfg config file (collect basic metrics if not specified)"
             },
             {
               "flags": "-e, --extension-version <version>",
@@ -32873,7 +32873,7 @@
               "bool": true,
               "short": "-e",
               "long": "--extension-version",
-              "description": "Version of Diagnostics extension. Default values are [1.4] for Windows and [2.0] for Linux."
+              "description": "Version of Diagnostics extension. Default values are [1.5] for Windows and [2.2] for Linux."
             },
             {
               "flags": "-s, --subscription <subscription>",

--- a/lib/util/vmConstants.js
+++ b/lib/util/vmConstants.js
@@ -20,12 +20,12 @@ var VMConstants = {
   EXTENSIONS: {
     TYPE: 'Microsoft.Compute/virtualMachines/extensions',
 
-    IAAS_DIAG_VERSION: '1.4',
-    LINUX_DIAG_VERSION: '2.0',
     LINUX_DIAG_NAME: 'LinuxDiagnostic',
-    IAAS_DIAG_NAME: 'IaaSDiagnostics',
     LINUX_DIAG_PUBLISHER: 'Microsoft.OSTCExtensions',
+    LINUX_DIAG_VERSION: '2.2',
+    IAAS_DIAG_NAME: 'IaaSDiagnostics',
     IAAS_DIAG_PUBLISHER: 'Microsoft.Azure.Diagnostics',
+    IAAS_DIAG_VERSION: '1.5',
 
     DOCKER_PORT: 2376,
     DOCKER_VERSION_ARM: '1.0',


### PR DESCRIPTION
With this patch, enabling diagnostics with `azure vm enable-diag` without specifying a `wadcfg` file (with `--config-file`) will use a default generated `wadcfg` config file that will collect basic metrics.
You can have a preview in the attached zip file on what default wadcfg looks like on Windows and what it looks like on Linux; this is not something I invented: this is the default configuration that is set when you enable the diagnostics from the new portal. With this, you will be able to collect and see `basic metrics` and view charts from the new portal and you will be able to use Azure Insights. 

I have also updated the default Windows and Linux extension to the latest version available (Windows 1.5 and Linux 2.2).

Linux:
<img width="298" alt="linux_basic_metrics" src="https://cloud.githubusercontent.com/assets/2183293/11987009/c575bec0-a9d7-11e5-89e5-1d732ec14103.png">

Windows:
<img width="301" alt="windows_basic_metrics" src="https://cloud.githubusercontent.com/assets/2183293/11987012/d2a1a5aa-a9d7-11e5-96d8-5c3c5af377d7.png">

Default wadcfg files:
[linux_windows_basic_metrics_wadcfg.zip](https://github.com/Azure/azure-xplat-cli/files/71358/linux_windows_basic_metrics_wadcfg.zip)

I did a quick test on latest images currently available (and supported by Azure) and it seems all ok (Ubuntu, Debian, CentOS, Oracle Linux, OpenSuse and Windows Server; I managed to make it work even on CoreOS but this OS is not currently supported by the diagnostics extension).

I noticed that there is some sort of confusion in the code about the `name` of the extension and the the `type` of the extension. Currently in the code there is no distinction between these. We are using the `extensionType` as the `extensionName`. This is something to be fixed up to me (I can work on it), problems can arise cause of this.
As an example: when you enable the diagnostics extension from the new portal, the extension given name is `Microsoft.Insights.VMDiagnosticsSettings` both on Windows and Linux. If you first enable the diagnostics extension from the portal, you will be not able to update because of "Multiple VMExtensions per handler not supported"; you have to remove and then reinstall the extension to update. The same is happening if you first enable from the cli: updating from the portal won't work. See attached files. This is due to the fact that when we install or update the extension from the cli, the given name for the extension is the same name of the extension type (on Windows this is `Microsoft.Azure.Diagnostics.IaaSDiagnostics` and on Linux `Microsoft.OSTCExtensions.LinuxDiagnostic`). We should let the user set extension name in both `azure vm enable-diag` and `azure vm extension set` commands and set default diagnostics extension name as the portal set: `Microsoft.Insights.VMDiagnosticsSettings`. In the code there is already some unused `--reference-name` option and I can guess what it was meant to be - this seems to be used on asm mode only.

When you enable from the portal, extension name is `Microsoft.Insights.VMDiagnosticsSettings`:
<img width="1074" alt="microsoft_insights_vmdiagnosticssettings" src="https://cloud.githubusercontent.com/assets/2183293/11987057/b4628e6e-a9d8-11e5-8f30-949b23c52d5f.png">

This happens when you try to update:
<img width="570" alt="diag_extension_name_portal" src="https://cloud.githubusercontent.com/assets/2183293/11987058/b9a26b1a-a9d8-11e5-93f2-c0ec2a820e6f.png">