### PR TITLE
fix osx token test issues

### DIFF
--- a/test/util/authentication/osx-keychain-parser-tests.js
+++ b/test/util/authentication/osx-keychain-parser-tests.js
@@ -177,7 +177,7 @@ describe('Parsing output of security child process', function () {
   }
 
   function removeExpectedEntry(done) {
-    keychain.remove(testUser, testService, done);
+    keychain.remove(testUser, testService, testDescription, done);
   }
 
   it('should have entries', function () {


### PR DESCRIPTION
The test is osx specific and not covered by CI which uses linux