### PR TITLE
cli: fall back to use process.exit

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -165,14 +165,21 @@ _.extend(AzureCli.prototype, {
   },
   
   exitProcess: function (exitCode) {
+    //use 'exit' (brutal stop) here, because unknown number of cmdlets don't 
+    //clear progress information on errors, thus the cli process hangs forever. 
+    //'brutal stop' has the side effect that file log might not get drained. 
+    //As few people use the file log, we will live with that.
+    process.exit(exitCode);
+    
+    //The following code is correct, but we can't use:
     //for nice exiting, particularly the winston async logging, we try not to
     //use "process.exit()", unless there's non-zero exit code we must return.  
-    if (exitCode) {
-      //Ensure winton log fully flushed.
-      //https://github.com/winstonjs/winston/issues/228
-      //https://github.com/nodejs/node-v0.x-archive/commit/36815e4
-      process.on('exit', function () { process.exit(exitCode); });
-    }
+    //if (exitCode) {
+    //  //Ensure winton log fully flushed.
+    //  //https://github.com/winstonjs/winston/issues/228
+    //  //https://github.com/nodejs/node-v0.x-archive/commit/36815e4
+    //  process.on('exit', function () { process.exit(exitCode); });
+    //}
   },
 
   normalizeAuthorizationError: function (msg) {


### PR DESCRIPTION
This is not the right code, but appears *correct *under the context that we do have [cmdlet code](https://github.com/Azure/azure-xplat-cli/blob/dev/lib/util/storage.util._js#L369) failed to clean up the progress on exception and leave azure-cli hang there. A little worse, we have no clear idea of how many those cmdlets we have. With that, I will bring back the sync version of "shutdonw"