### PR TITLE
ARM: 'network dns record-set list' output improved

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,6 +7,7 @@
   "immed": true,
   "indent": 2,
   "latedef": false,
+  "loopfunc": true,
   "maxparams": false,
   "maxdepth": false,
   "maxstatements": false,

--- a/lib/commands/arm/network/dnsZone._js
+++ b/lib/commands/arm/network/dnsZone._js
@@ -390,11 +390,14 @@ __.extend(DnsZone.prototype, {
       if (outputData.length === 0) {
         self.output.warn($('No DNS records sets found'));
       } else {
-        self.output.table(outputData, function (row, recordSet) {
-          row.cell($('Name'), recordSet.name);
-          row.cell($('TTL'), recordSet.properties.ttl);
-          row.cell($('Type'), recordSetUtils.getShortType(recordSet.id));
-          row.cell($('Tags'), tagUtils.getTagsInfo(recordSet.tags) || '');
+        var printable = recordSetUtils.convertToListFormat(outputData);
+
+        self.output.table(printable, function (row, recordSet) {
+          row.cell($('Name'), recordSet.name || '');
+          row.cell($('TTL'), recordSet.ttl || '');
+          row.cell($('Type'), recordSet.type || '');
+          row.cell($('Records'), recordSet.record);
+          row.cell($('Tags'),  tagUtils.getTagsInfo(recordSet.tags) || '');
         });
       }
     });

--- a/lib/commands/arm/network/recordSetUtils._js
+++ b/lib/commands/arm/network/recordSetUtils._js
@@ -184,23 +184,6 @@ exports.convertToListFormat = function (recordSets) {
         }
       });
     }
-    if (!__.isEmpty(recordSet.properties.mxRecords)) {
-      __.each(recordSet.properties.mxRecords, function (rec, index) {
-        if (index === 0) {
-          items.push({
-            name: recordSet.name,
-            ttl: recordSet.properties.ttl,
-            type: exports.getShortType(recordSet.id),
-            tags: recordSet.tags,
-            record: util.format('%s %s', rec.preference, rec.exchange)
-          });
-        } else {
-          items.push({
-            record: util.format('%s %s', rec.preference, rec.exchange)
-          });
-        }
-      });
-    }
     if (!__.isEmpty(recordSet.properties.ptrRecords)) {
       __.each(recordSet.properties.ptrRecords, function (rec, index) {
         if (index === 0) {

--- a/lib/commands/arm/network/recordSetUtils._js
+++ b/lib/commands/arm/network/recordSetUtils._js
@@ -19,7 +19,7 @@ var util = require('util');
 var utils = require('../../../util/utils');
 var resourceUtils = require('../resource/resourceUtils');
 
-function covertToAzureFormat(recordSet) {
+exports.covertToAzureFormat = function (recordSet) {
   var parameters = {
     recordSet: {
       name: recordSet.name,
@@ -60,17 +60,193 @@ function covertToAzureFormat(recordSet) {
       break;
   }
   return parameters;
-}
+};
 
-function getShortType(id) {
+exports.getShortType = function (id) {
   var resourceInfo = resourceUtils.getResourceInformation(id);
   return resourceInfo.resourceType.split('/')[2];
-}
+};
+
+exports.convertToListFormat = function (recordSets) {
+  var printable = [];
+
+  for (var i = 0; i < recordSets.length; i++) {
+    var recordSet = recordSets[i];
+    var items = [];
+
+    if (!__.isEmpty(recordSet.properties.soaRecord)) {
+      var soaRecord = recordSet.properties.soaRecord;
+      items.push({
+        name: recordSet.name,
+        ttl: recordSet.properties.ttl,
+        type: exports.getShortType(recordSet.id),
+        tags: recordSet.tags,
+        record: 'host:    ' + soaRecord.host
+      });
+      items.push({record: 'email:   ' + soaRecord.email});
+      items.push({record: 'refresh: ' + soaRecord.refreshTime});
+      items.push({record: 'retry:   ' + soaRecord.retryTime});
+      items.push({record: 'expire:  ' + soaRecord.expireTime});
+      items.push({record: 'minimum: ' + soaRecord.minimumTtl});
+    }
+    if (!__.isEmpty(recordSet.properties.cnameRecord)) {
+      var cnameRecord = recordSet.properties.cnameRecord;
+      items.push({
+        name: recordSet.name,
+        ttl: recordSet.properties.ttl,
+        type: exports.getShortType(recordSet.id),
+        tags: recordSet.tags,
+        record: cnameRecord.cname
+      });
+    }
+    if (!__.isEmpty(recordSet.properties.aRecords)) {
+      __.each(recordSet.properties.aRecords, function (rec, index) {
+        if (index === 0) {
+          items.push({
+            name: recordSet.name,
+            ttl: recordSet.properties.ttl,
+            type: exports.getShortType(recordSet.id),
+            tags: recordSet.tags,
+            record: rec.ipv4Address
+          });
+        } else {
+          items.push({
+            record: rec.ipv4Address
+          });
+        }
+      });
+    }
+    if (!__.isEmpty(recordSet.properties.aaaaRecords)) {
+      __.each(recordSet.properties.aaaaRecords, function (rec, index) {
+        if (index === 0) {
+          items.push({
+            name: recordSet.name,
+            ttl: recordSet.properties.ttl,
+            type: exports.getShortType(recordSet.id),
+            tags: recordSet.tags,
+            record: rec.ipv6Address
+          });
+        } else {
+          items.push({
+            record: rec.ipv6Address
+          });
+        }
+      });
+    }
+    if (!__.isEmpty(recordSet.properties.nsRecords)) {
+      __.each(recordSet.properties.nsRecords, function (rec, index) {
+        if (index === 0) {
+          items.push({
+            name: recordSet.name,
+            ttl: recordSet.properties.ttl,
+            type: exports.getShortType(recordSet.id),
+            tags: recordSet.tags,
+            record: rec.nsdname
+          });
+        } else {
+          items.push({
+            record: rec.nsdname
+          });
+        }
+      });
+    }
+    if (!__.isEmpty(recordSet.properties.srvRecords)) {
+      __.each(recordSet.properties.srvRecords, function (rec, index) {
+        if (index === 0) {
+          items.push({
+            name: recordSet.name,
+            ttl: recordSet.properties.ttl,
+            type: exports.getShortType(recordSet.id),
+            tags: recordSet.tags,
+            record: util.format('%s %s %s %s', rec.priority, rec.weight, rec.port, rec.target)
+          });
+        } else {
+          items.push({
+            record: util.format('%s %s %s %s', rec.priority, rec.weight, rec.port, rec.target)
+          });
+        }
+      });
+    }
+    if (!__.isEmpty(recordSet.properties.mxRecords)) {
+      __.each(recordSet.properties.mxRecords, function (rec, index) {
+        if (index === 0) {
+          items.push({
+            name: recordSet.name,
+            ttl: recordSet.properties.ttl,
+            type: exports.getShortType(recordSet.id),
+            tags: recordSet.tags,
+            record: util.format('%s %s', rec.preference, rec.exchange)
+          });
+        } else {
+          items.push({
+            record: util.format('%s %s', rec.preference, rec.exchange)
+          });
+        }
+      });
+    }
+    if (!__.isEmpty(recordSet.properties.mxRecords)) {
+      __.each(recordSet.properties.mxRecords, function (rec, index) {
+        if (index === 0) {
+          items.push({
+            name: recordSet.name,
+            ttl: recordSet.properties.ttl,
+            type: exports.getShortType(recordSet.id),
+            tags: recordSet.tags,
+            record: util.format('%s %s', rec.preference, rec.exchange)
+          });
+        } else {
+          items.push({
+            record: util.format('%s %s', rec.preference, rec.exchange)
+          });
+        }
+      });
+    }
+    if (!__.isEmpty(recordSet.properties.ptrRecords)) {
+      __.each(recordSet.properties.ptrRecords, function (rec, index) {
+        if (index === 0) {
+          items.push({
+            name: recordSet.name,
+            ttl: recordSet.properties.ttl,
+            type: exports.getShortType(recordSet.id),
+            tags: recordSet.tags,
+            record: rec.ptrdname
+          });
+        } else {
+          items.push({
+            record: rec.ptrdname
+          });
+        }
+      });
+    }
+    if (!__.isEmpty(recordSet.properties.txtRecords)) {
+      var maxLength = 20;
+      __.each(recordSet.properties.txtRecords, function (rec, index) {
+        if (index === 0) {
+          items.push({
+            name: recordSet.name,
+            ttl: recordSet.properties.ttl,
+            type: exports.getShortType(recordSet.id),
+            tags: recordSet.tags,
+            record: rec.value.length > maxLength ? rec.value.substr(0, maxLength) + '...' : rec.value
+          });
+        } else {
+          items.push({
+            record: rec.value.length > maxLength ? rec.value.substr(0, maxLength) + '...' : rec.value
+          });
+        }
+      });
+    }
+
+    printable = printable.concat(items);
+  }
+
+  return printable;
+};
 
 /**
  * This method is used as workaround to delete a xxxRecords objects if empty
  */
-function removeEmptyRecords(recordSet) {
+exports.removeEmptyRecords = function (recordSet) {
   if (!recordSet.properties) return;
   var fields = ['aRecords', 'aaaaRecords', 'nsRecords', 'mxRecords', 'srvRecords', 'txtRecords', 'soaRecord', 'ptrRecords'];
   for (var i = 0; i < fields.length; i++) {
@@ -78,10 +254,56 @@ function removeEmptyRecords(recordSet) {
       delete recordSet.properties[fields[i]];
     }
   }
-}
+};
+
+exports.merge = function (rs1, rs2, type, options, output) {
+  var self = this;
+  if (options.debug) {
+    console.log('\nExisting Record Set:  %j \n', rs2);
+    console.log('\nNew Record Set:  %j \n', rs1);
+  }
+
+  switch (type) {
+    case 'SOA' :
+      mergeSOA(rs1, rs2);
+      break;
+    case 'NS' :
+      mergeNS(rs1, rs2);
+      break;
+    case 'CNAME' :
+      mergeCNAME(rs1, rs2, output);
+      break;
+    case 'A' :
+      mergeA(rs1, rs2);
+      break;
+    case 'AAAA' :
+      mergeAAAA(rs1, rs2);
+      break;
+    case 'MX' :
+      mergeMX(rs1, rs2);
+      break;
+    case 'TXT' :
+      mergeTXT(rs1, rs2);
+      break;
+    case 'SRV' :
+      mergeSRV(rs1, rs2);
+      break;
+    case 'PTR' :
+      mergePTR(rs1, rs2);
+      break;
+  }
+
+  // to override existing set after merge
+  rs2.ifNoneMatch = undefined;
+  self.removeEmptyRecords(rs2.recordSet);
+
+  if (options.debug) {
+    console.log('\nAfter merge:  %j \n', rs2);
+  }
+  return rs2;
+};
 
 function mergeSOA(rs1, rs2) {
-  // сохраняем host
   var host = rs2.recordSet.properties.soaRecord.host;
   rs2.recordSet.properties.soaRecord = rs1.recordSet.properties.soaRecord;
   rs2.recordSet.properties.soaRecord.host = host;
@@ -158,57 +380,3 @@ function mergePTR(rs1, rs2) {
     }
   }
 }
-
-function merge(rs1, rs2, type, options, output) {
-  var self = this;
-  if (options.debug) {
-    console.log('\nExisting Record Set:  %j \n', rs2);
-    console.log('\nNew Record Set:  %j \n', rs1);
-  }
-
-  switch (type) {
-    case 'SOA' :
-      mergeSOA(rs1, rs2);
-      break;
-    case 'NS' :
-      mergeNS(rs1, rs2);
-      break;
-    case 'CNAME' :
-      mergeCNAME(rs1, rs2, output);
-      break;
-    case 'A' :
-      mergeA(rs1, rs2);
-      break;
-    case 'AAAA' :
-      mergeAAAA(rs1, rs2);
-      break;
-    case 'MX' :
-      mergeMX(rs1, rs2);
-      break;
-    case 'TXT' :
-      mergeTXT(rs1, rs2);
-      break;
-    case 'SRV' :
-      mergeSRV(rs1, rs2);
-      break;
-    case 'PTR' :
-      mergePTR(rs1, rs2);
-      break;
-  }
-
-  // to override existing set after merge
-  rs2.ifNoneMatch = undefined;
-  self.removeEmptyRecords(rs2.recordSet);
-
-  if (options.debug) {
-    console.log('\nAfter merge:  %j \n', rs2);
-  }
-  return rs2;
-}
-
-module.exports = {
-  merge: merge,
-  removeEmptyRecords: removeEmptyRecords,
-  covertToAzureFormat: covertToAzureFormat,
-  getShortType: getShortType
-};


### PR DESCRIPTION
Minor changes which brings output of `azure network dns record-set list` command in next level with human-friendly table format:

```
data:    Name                TTL   Type   Records                           Tags
data:    ------------------  ----  -----  --------------------------------  -----------------
data:    *                   3600  A      192.168.17.22                     tag1=hhh;tag3=ccc
data:                                     192.168.17.23
data:    @                   3600  SOA    host:    ns1-04.azure-dns.com.
data:                                     email:   hostmaster.example.com.
data:                                     refresh: 43200
data:                                     retry:   900
data:                                     expire:  1814400
data:                                     minimum: 10800
data:    @                   3600  NS     ns1-04.azure-dns.com.             tag1=hhh;tag3=ccc
data:                                     ns2-04.azure-dns.net.
data:                                     ns3-04.azure-dns.org.
data:                                     ns4-04.azure-dns.info.
data:    _sip._tcp           3600  SRV    10 20 30 foo.com.                 tag1=hhh;tag3=ccc
data:                                     40 50 60 bar.com
data:    d1                  3600  A      12.1.2.3                          tag1=hhh;tag3=ccc
data:                                     12.2.3.4
data:                                     12.3.4.5
data:                                     12.4.5.6
data:    d1                  3600  NS     hood.com.
data:    d1                  3600  TXT    fishfishfish
data:    f1.d1               3600  A      11.1.2.3
data:                                     11.2.3.3
data:    f2.d1               3600  A      11.2.3.4
data:    f2                  3600  A      11.5.6.7
data:    mail                3600  MX     100 mail.test.com.                tag1=hhh;tag3=ccc
data:                                     200 foo.target.com
data:    seta                3600  A      192.168.17.18
data:    test-a              3600  A      1.2.3.4
data:    test-aaaa           3600  AAAA   2001:cafe:130::100
data:                                     2001:cafe:130::200
data:    test-cname          3600  CNAME  target.com.
data:    test-mx             3600  MX     10 mail.com.
data:    test-ns             3600  NS     ns1.com.
data:    _sip._tcp.test-srv  3600  SRV    1 2 3 target.com.
data:    test-txt            3600  TXT    string 1
data:    txt1                3600  TXT    string 1 only                     tag1=hhh;tag3=ccc
data:                                     hellowworldagainhell...
data:    txt2                3600  TXT    string1string2
data:    txt3                3600  TXT    Lorem ipsum dolor si...

```
For visibility: @jtuliani ,

@yugangw-msft @amarzavery please merge