### PR TITLE
fix regression issue

### DIFF
--- a/lib/commands/arm/group/groupUtils._js
+++ b/lib/commands/arm/group/groupUtils._js
@@ -358,8 +358,8 @@ function getTemplateParams(cli, subscription, options, _)
 }
 
 exports.getFailedDeploymentOperations = function (subscription, resourceGroup, deploymentName, _) {
-  var client = utils.createResourceClient(subscription);
-
+  var currentSubscription = profile.current.getSubscription(subscription);
+  var client = utils.createResourceClient(currentSubscription);
   var operations = client.deploymentOperations.list(resourceGroup, deploymentName, _).operations;
   var failedOperations = getFailedNestedOperations(client, resourceGroup, operations, _);
   return failedOperations;


### PR DESCRIPTION
If the subscription is not defined, it results in the following error. Hence, instantiating the current subscription value before calling createClient

verbose: TypeError: Cannot read property 'resourceManagerEndpointUrl' of undefined
  <<< async stack >>>
    at _createArmClient (a:\newGit2\azure-xplat-cli\lib\util\utils.js:107:36)
    at Object.exports.createResourceClient (a:\newGit2\azure-xplat-cli\lib\util\utils.js:262:10)
    at exports_getFailedDeploymentOperations__3 (a:\newGit2\azure-xplat-cli\lib\commands\arm\group\groupUtils._js:484:20)
  at __1 (a:\newGit2\azure-xplat-cli\lib\commands\arm\group\group.deployment._js:78:47)
  at __1 (a:\newGit2\azure-xplat-cli\lib\commands\arm\group\group.deployment._js:67:25)
  <<< raw stack >>>
    at _createArmClient (a:\newGit2\azure-xplat-cli\lib\util\utils.js:107:36)
    at Object.exports.createResourceClient (a:\newGit2\azure-xplat-cli\lib\util\utils.js:262:10)
    at __$exports_getFailedDeploymentOperations__3 (a:\newGit2\azure-xplat-cli\lib\commands\arm\group\groupUtils._js:484:20)
    at __func (a:\newGit2\azure-xplat-cli\node_modules\streamline\lib\callbacks\runtime.js:47:5)
    at Object.exports_getFailedDeploymentOperations__3 [as getFailedDeploymentOperations] (a:\newGit2\azure-xplat-cli\lib\commands\arm\group\groupUtils._js:483:10)
    at __$__1 (a:\newGit2\azure-xplat-cli\lib\commands\arm\group\group.deployment._js:92:45)
    at __$__1 (a:\newGit2\azure-xplat-cli\lib\commands\arm\group\group.deployment._js:112:25)
    at __$__1 (a:\newGit2\azure-xplat-cli\lib\commands\arm\group\group.deployment._js:80:27)
    at ___ (a:\newGit2\azure-xplat-cli\node_modules\streamline\lib\callbacks\runtime.js:111:13)
    at __$__1 (a:\newGit2\azure-xplat-cli\lib\commands\arm\group\group.deployment._js:73:33)
