### PR TITLE
Fixed shorthand flag conflict in 'keyvault secret set'

### DIFF
--- a/lib/commands/arm/keyvault/keyvault.secret._js
+++ b/lib/commands/arm/keyvault/keyvault.secret._js
@@ -157,7 +157,7 @@ exports.init = function(cli) {
     .usage('[--vault-name] <vault-name> [--secret-name] <secret-name> [--value] <secret-value> [options]')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-s, --secret-name <secret-name>', $('name of the secret to be created; if already exists, a new secret version is created'))
-    .option('-s, --value <secret-value>', $('the secret value'))
+    .option('-w, --value <secret-value>', $('the secret value'))
     .option('--enabled <boolean>', $('tells if the secret should be enabled; valid values: [false, true]; default is true'))
     .option('-e, --expires <datetime>', $('expiration time of secret, in UTC format'))
     .option('-n, --not-before <datetime>', $('time before which secret cannot be used, in UTC format'))


### PR DESCRIPTION
Modified shorthand flag -s to -w in order to fix conflict in 'keyvault secret set' command.