### PR TITLE
fix #2529, #2530, #1913 about confusions on cred shareing between asm and arm mode

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -624,6 +624,10 @@ _.extend(AzureCli.prototype, {
   isAsmMode: function () {
     return utilsCore.ignoreCaseEquals(this._mode, 'asm');
   },
+  
+  isArmMode: function () {
+    return utilsCore.ignoreCaseEquals(this._mode, 'arm');
+  },
 
   checkVersion: function () {
     // Uploading VHD needs 0.6.15 on Windows

--- a/lib/commands/account._js
+++ b/lib/commands/account._js
@@ -107,6 +107,11 @@ exports.init = function (cli) {
       log.info(util.format($('Setting subscription to "%s" with id "%s".'), 
         newSubscription.name, newSubscription.id));
       log.info($('Changes saved'));
+      if (cli.isArmMode() && newSubscription.wasCreatedFromPublishSettingsFile()) {
+        log.warn($('Your current subscription was likely created from a publishsettings file ' +
+          'and will not work under arm mode. You can fix it by running either \'azure login\' ' +
+          'or \'azure accout set\''));
+      }
     });
 
   account.command('clear')

--- a/lib/commands/login._js
+++ b/lib/commands/login._js
@@ -119,6 +119,7 @@ exports.init = function (cli) {
           }
         }
         var newSubscriptions = result.subscriptions;
+
         if (newSubscriptions.length > 0) {
           newSubscriptions.forEach(function (s) {
             profile.current.addOrUpdateSubscription(s);
@@ -127,8 +128,16 @@ exports.init = function (cli) {
 
           var defaultSubscription = profile.current.currentSubscription;
           if (!defaultSubscription) {
-            defaultSubscription  = newSubscriptions[0];
+            defaultSubscription = newSubscriptions[0];
             log.info(util.format($('Setting subscription "%s" as default'), defaultSubscription.name));
+          } else {
+            //try to stick to the existing selected one if it is just being refreshed.
+            var duped = newSubscriptions.filter(function (s) { return s.id === defaultSubscription.id; });
+            if (duped.length === 0) {
+              defaultSubscription.isDefault = false;
+              defaultSubscription = newSubscriptions[0];
+              log.info(util.format($('Setting subscription "%s" as default'), defaultSubscription.name));
+            }
           }
 
           defaultSubscription.isDefault = true;

--- a/lib/util/profile/profile.js
+++ b/lib/util/profile/profile.js
@@ -137,7 +137,8 @@ _.extend(Profile.prototype, {
 
     // Helper functions to define process of logout
     function usernameMatches(subscription) {
-      return utils.ignoreCaseEquals(subscription.user.name, username);
+      var user = subscription.user;
+      return user && utils.ignoreCaseEquals(user.name, username);
     }
 
     function defaultGoesLast(subscription) {

--- a/lib/util/profile/subscription.js
+++ b/lib/util/profile/subscription.js
@@ -160,6 +160,10 @@ _.extend(Subscription.prototype, {
 
     throw new Error($('No Azure AD credentials or management certificate, cannot create credentials'));
   },
+  
+  wasCreatedFromPublishSettingsFile: function () {
+    return this.managementCertificate && !this.user;
+  },
 
   toJSON: function () {
     return _.extend(

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -74,6 +74,7 @@ exports.createClient = function (factoryMethod, credentials, endpoint, options) 
 };
 
 exports.createAutoRestClient = function (FactoryMethod, subscription) {
+  ensureAADBackedSubscription(subscription);
   var credentials = subscription._createCredentials();
   var subscriptionId = subscription.id;
   var baseUri = exports.stringTrimEnd(subscription.resourceManagerEndpointUrl, '/');
@@ -99,6 +100,7 @@ function _createAsmClient(factoryMethod, subscription) {
 }
 
 function _createArmClient(factoryMethod, subscription, options) {
+  ensureAADBackedSubscription(subscription);
   if(!options) {
     options = {};
   }
@@ -111,6 +113,14 @@ function _createArmClient(factoryMethod, subscription, options) {
     subscription._createCredentials(),
     options.endpoint,
     options);
+}
+
+function ensureAADBackedSubscription(subscription) {
+  if (subscription.wasCreatedFromPublishSettingsFile()) {
+    throw new Error('The current cmdlet requires you to log in using Azure Active Directory account, ' + 
+      'not from a .publishsettings file. Please run \'azure login\' or use \'azure account set\' ' + 
+      'to select a correct subscription.');
+  }
 }
 
 exports.getHDInsightClusterManagementClient = function (cloudServiceName, subscription) {

--- a/test/util/utils-tests.js
+++ b/test/util/utils-tests.js
@@ -18,7 +18,7 @@ var assert = require('assert');
 
 // Test includes
 var testutil = require('./util');
-
+var Subscription = testutil.libRequire('util/profile/subscription')
 // Lib includes
 var util = testutil.libRequire('util/utils');
 
@@ -98,5 +98,29 @@ suite('util-tests', function() {
     assert.equal(util.escapeFilePath('lpT9'), 'lpT9 (1)');
     assert.equal(util.escapeFilePath('LPT9?'), 'LPT9%3f');
     done();
+  });
+
+  test('create arm clients with a cert based subscription should fail', function () {
+    var data = {
+      managementCertificate : "some certifcate"
+    }
+
+    var subscription = new Subscription(data, {});
+
+    try {
+      util.createAutoRestClient('somefactory', subscription);
+      assert.fail('no exception was thrown when creating autorest client ' + 
+        'with a cert based subscription.');
+    } catch (ex) {
+      assert.ok(ex.message.indexOf('current cmdlet requires you to log in') > 0);
+    }
+
+    try {
+      util.createComputeResourceProviderClient(subscription);
+      assert.fail('no exception was thrown when creating arm compute client ' + 
+        'with a cert based subscription.');
+    } catch (ex) {
+      assert.ok(ex.message.indexOf('current cmdlet requires you to log in') > 0);
+    }
   });
 });


### PR DESCRIPTION
This improved the experiences in such aspects
1. If your current subscription is backed by certificated from a publish settings file, "azure logout" will not throw with null ref, rather tell you are not really logged in 
2. If you logged in using cert, and switch to "arm",  you will get a warning with reasonable suggestion to either run "azure login" or "azure account set"
3. If you go ahead to run arm cmdlets anyway, you will get the error with similar text
4. If you logged in under asm, and switch to arm, I verified the credential should just work to run cmdlets. 
5. If you logged in successfully, azure-cli will guarantee to select one of its subscriptions. Before, it might stick to an existing unrelated subscription, which is confusing