### PR TITLE
ARM: --resource-group now optional for 'azure network traffic-manager profile list'

### DIFF
--- a/lib/commands/arm/network/network._js
+++ b/lib/commands/arm/network/network._js
@@ -1659,17 +1659,15 @@ exports.init = function (cli) {
       trafficManager.setProfile(resourceGroup, name, options, _);
     });
 
-  trafficManagerProfile.command('list [resource-group]')
+  trafficManagerProfile.command('list')
     .description($('Get all Traffic Manager profiles'))
-    .usage('[options] <resource-group>')
+    .usage('[options]')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
-    .execute(function (resourceGroup, options, _) {
-      resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
-
+    .execute(function (options, _) {
       var trafficManagerProviderClient = getTrafficManagementClient(options);
       var trafficManager = new TrafficManager(cli, trafficManagerProviderClient);
-      trafficManager.listProfiles(resourceGroup, options, _);
+      trafficManager.listProfiles(options, _);
     });
 
   trafficManagerProfile.command('show [resource-group] [name]')

--- a/lib/commands/arm/network/trafficManager._js
+++ b/lib/commands/arm/network/trafficManager._js
@@ -79,13 +79,17 @@ __.extend(TrafficManager.prototype, {
     self._showProfile(resourceGroupName, profile.profile);
   },
 
-  listProfiles: function (resourceGroupName, options, _) {
+  listProfiles: function (options, _) {
     var self = this;
 
     var progress = self.interaction.progress($('Getting Traffic Manager profiles'));
     var profiles = null;
     try {
-      profiles = self.trafficManagerManagementClient.profiles.listAllInResourceGroup(resourceGroupName, _);
+      if (options.resourceGroup) {
+        profiles = self.trafficManagerManagementClient.profiles.listAllInResourceGroup(options.resourceGroup, _);
+      } else {
+        profiles = self.trafficManagerManagementClient.profiles.listAll(_);
+      }
     } finally {
       progress.end();
     }

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -25845,7 +25845,7 @@
                   "name": "list",
                   "description": "Get all Traffic Manager profiles",
                   "fullName": "network traffic-manager profile list",
-                  "usage": "[options] <resource-group>",
+                  "usage": "[options]",
                   "filePath": "commands/arm/network/network._js",
                   "options": [
                     {


### PR DESCRIPTION
The content to be added to Changelog is as follows:
*  `--resource-group` now optional for `azure network traffic-manager profile list`

@amarzavery please merge,
@jtuliani for visilivlity.