### PR TITLE
ARM: Network list commands improved

### DIFF
--- a/lib/commands/arm/network/network._js
+++ b/lib/commands/arm/network/network._js
@@ -86,12 +86,13 @@ exports.init = function (cli) {
       virtualNetwork.set(resourceGroup, name, options, _);
     });
 
-  vnet.command('list')
+  vnet.command('list [resource-group]')
     .description('Get all virtual networks')
-    .usage('[options]')
+    .usage('[options] [resource-group]')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
-    .execute(function (options, _) {
+    .execute(function (resourceGroup, options, _) {
+      options.resourceGroup = resourceGroup;
       var networkManagementClient = getNetworkManagementClient(options);
       var virtualNetwork = new VirtualNetwork(cli, networkManagementClient);
       virtualNetwork.list(options, _);
@@ -267,12 +268,13 @@ exports.init = function (cli) {
       loadBalancer.set(resourceGroup, name, options, _);
     });
 
-  lb.command('list')
+  lb.command('list [resource-group]')
     .description($('Get all load balancers'))
-    .usage('[options]')
+    .usage('[options] [resource-group]')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
-    .execute(function (options, _) {
+    .execute(function (resourceGroup, options, _) {
+      options.resourceGroup = resourceGroup;
       var networkManagementClient = getNetworkManagementClient(options);
       var loadBalancer = new LoadBalancer(cli, networkManagementClient);
       loadBalancer.list(options, _);
@@ -837,12 +839,13 @@ exports.init = function (cli) {
       publicip.set(resourceGroup, name, options, _);
     });
 
-  publicip.command('list')
+  publicip.command('list [resource-group]')
     .description($('Get all public ip addresses'))
-    .usage('[options]')
+    .usage('[options] [resource-group]')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
-    .execute(function (options, _) {
+    .execute(function (resourceGroup, options, _) {
+      options.resourceGroup = resourceGroup;
       var networkManagementClient = getNetworkManagementClient(options);
       var publicip = new PublicIp(cli, networkManagementClient);
       publicip.list(options, _);
@@ -958,14 +961,15 @@ exports.init = function (cli) {
       nic.set(resourceGroup, name, options, _);
     });
 
-  nic.command('list')
+  nic.command('list [resource-group]')
     .description($('Get all network interfaces'))
-    .usage('[options]')
+    .usage('[options] [resource-group]')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-m, --virtual-machine-scale-set-name <virtual-machine-scale-set-name>', $('the name of the virtual machine scale set'))
     .option('-i, --virtual-machine-index <virtual-machine-index>', $('the index of the virtual machine in scale set'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
-    .execute(function (options, _) {
+    .execute(function (resourceGroup, options, _) {
+      options.resourceGroup = resourceGroup;
       var networkManagementClient = getNetworkManagementClient(options);
       var nic = new Nic(cli, networkManagementClient);
       nic.list(options, _);
@@ -1131,12 +1135,13 @@ exports.init = function (cli) {
       nsg.set(resourceGroup, name, options, _);
     });
 
-  nsg.command('list')
+  nsg.command('list [resource-group]')
     .description($('Get all network security groups'))
-    .usage('[options]')
+    .usage('[options] [resource-group]')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
-    .execute(function (options, _) {
+    .execute(function (resourceGroup, options, _) {
+      options.resourceGroup = resourceGroup;
       var networkManagementClient = getNetworkManagementClient(options);
       var nsg = new Nsg(cli, networkManagementClient);
       nsg.list(options, _);
@@ -1659,12 +1664,13 @@ exports.init = function (cli) {
       trafficManager.setProfile(resourceGroup, name, options, _);
     });
 
-  trafficManagerProfile.command('list')
+  trafficManagerProfile.command('list [resource-group]')
     .description($('Get all Traffic Manager profiles'))
-    .usage('[options]')
+    .usage('[options] [resource-group]')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
-    .execute(function (options, _) {
+    .execute(function (resourceGroup, options, _) {
+      options.resourceGroup = resourceGroup;
       var trafficManagerProviderClient = getTrafficManagementClient(options);
       var trafficManager = new TrafficManager(cli, trafficManagerProviderClient);
       trafficManager.listProfiles(options, _);
@@ -1869,12 +1875,13 @@ exports.init = function (cli) {
       routeTable.set(resourceGroup, name, options, _);
     });
 
-  routeTable.command('list')
+  routeTable.command('list [resource-group]')
     .description($('Get all Route Tables'))
-    .usage('[options]')
+    .usage('[options] [resource-group]')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
-    .execute(function (options, _) {
+    .execute(function (resourceGroup, options, _) {
+      options.resourceGroup = resourceGroup;
       var networkManagementClient = getNetworkManagementClient(options);
       var routeTable = new RouteTable(cli, networkManagementClient);
       routeTable.list(options, _);
@@ -2399,12 +2406,13 @@ exports.init = function (cli) {
       expressRoute.setCircuit(resourceGroup, name, options, _);
     });
 
-  expressRouteCircuit.command('list')
+  expressRouteCircuit.command('list [resource-group]')
     .description($('Get all express route circuits'))
-    .usage('[options]')
+    .usage('[options] [resource-group]')
     .option('-g, --resource-group <resource-group>', $('the name of the resource group'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
-    .execute(function (options, _) {
+    .execute(function (resourceGroup, options, _) {
+      options.resourceGroup = resourceGroup;
       var networkManagementClient = getNetworkManagementClient(options);
       var expressRoute = new ExpressRoute(cli, networkManagementClient);
       expressRoute.listCircuits(options, _);

--- a/lib/commands/arm/network/trafficManager._js
+++ b/lib/commands/arm/network/trafficManager._js
@@ -18,6 +18,7 @@ var util = require('util');
 var utils = require('../../../util/utils');
 var $ = utils.getLocaleString;
 var constants = require('./constants');
+var resourceUtils = require('../resource/resourceUtils');
 var tagUtils = require('../tag/tagUtils');
 
 function TrafficManager(cli, trafficManagerManagementClient) {
@@ -100,6 +101,8 @@ __.extend(TrafficManager.prototype, {
       } else {
         self.output.table(profiles, function (row, profile) {
           row.cell($('Name'), profile.name);
+          var resInfo = resourceUtils.getResourceInformation(profile.id);
+          row.cell($('Resource group'), resInfo.resourceGroup);
           row.cell($('Status'), profile.properties.profileStatus);
           row.cell($('DNS name'), profile.properties.dnsConfig.relativeName);
           row.cell($('TTL'), profile.properties.dnsConfig.ttl);

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -18418,7 +18418,7 @@
               "name": "list",
               "description": "Get all virtual networks",
               "fullName": "network vnet list",
-              "usage": "[options]",
+              "usage": "[options] [resource-group]",
               "filePath": "commands/arm/network/network._js",
               "options": [
                 {
@@ -19211,7 +19211,7 @@
               "name": "list",
               "description": "Get all load balancers",
               "fullName": "network lb list",
-              "usage": "[options]",
+              "usage": "[options] [resource-group]",
               "filePath": "commands/arm/network/network._js",
               "options": [
                 {
@@ -21854,7 +21854,7 @@
               "name": "list",
               "description": "Get all public ip addresses",
               "fullName": "network public-ip list",
-              "usage": "[options]",
+              "usage": "[options] [resource-group]",
               "filePath": "commands/arm/network/network._js",
               "options": [
                 {
@@ -22412,7 +22412,7 @@
               "name": "list",
               "description": "Get all network interfaces",
               "fullName": "network nic list",
-              "usage": "[options]",
+              "usage": "[options] [resource-group]",
               "filePath": "commands/arm/network/network._js",
               "options": [
                 {
@@ -23163,7 +23163,7 @@
               "name": "list",
               "description": "Get all network security groups",
               "fullName": "network nsg list",
-              "usage": "[options]",
+              "usage": "[options] [resource-group]",
               "filePath": "commands/arm/network/network._js",
               "options": [
                 {
@@ -25547,7 +25547,7 @@
                   "name": "list",
                   "description": "Get all Traffic Manager profiles",
                   "fullName": "network traffic-manager profile list",
-                  "usage": "[options]",
+                  "usage": "[options] [resource-group]",
                   "filePath": "commands/arm/network/network._js",
                   "options": [
                     {
@@ -26386,7 +26386,7 @@
               "name": "list",
               "description": "Get all Route Tables",
               "fullName": "network route-table list",
-              "usage": "[options]",
+              "usage": "[options] [resource-group]",
               "filePath": "commands/arm/network/network._js",
               "options": [
                 {
@@ -28712,7 +28712,7 @@
                   "name": "list",
                   "description": "Get all express route circuits",
                   "fullName": "network express-route circuit list",
-                  "usage": "[options]",
+                  "usage": "[options] [resource-group]",
                   "filePath": "commands/arm/network/network._js",
                   "options": [
                     {


### PR DESCRIPTION
The content to be added to Changelog is as follows:

* ARM: network `vnet/lb/publicip/nic/nsg/traffic-manager profile/express-route circuit` **list** commands now supports `--resource-group` as optional parameter for backward compatibility.

@amarzavery please merge
@jtuliani for visibility
