### PR TITLE
CLI: improved warn output to respect --json option

### DIFF
--- a/lib/util/logging.js
+++ b/lib/util/logging.js
@@ -266,6 +266,16 @@ log.listItem = function (item, indent, newLine) {
   log.data(spaces(indent) + item);
 };
 
+/**
+ * This overrides original winston warn function to work properly within --json option
+ */
+var originalWarn = log.warn;
+log.warn = function() {
+  if (!log.format().json) {
+    originalWarn.apply(this, arguments);
+  }
+};
+
 function getProperty(value, propertyName) {
   if (typeof value === 'undefined' || value === null) {
     return '';


### PR DESCRIPTION
The content to be added to Changelog is as follows:
*  CLI: improved warn output to respect --json option

Related  issue https://github.com/Azure/azure-xplat-cli/issues/2579 fixed

@yugangw-msft please review & merge

FYI: @MikhailTryakhov 
