### PR TITLE
ARM: 'network public-ip list' now shows 'IP Address' column

### DIFF
--- a/lib/commands/arm/network/publicIp._js
+++ b/lib/commands/arm/network/publicIp._js
@@ -129,6 +129,7 @@ __.extend(PublicIp.prototype, {
           row.cell($('Resource group'), resInfo.resourceGroup);
           row.cell($('Provisioning state'), publicIp.provisioningState);
           row.cell($('Allocation method'), publicIp.publicIPAllocationMethod);
+          row.cell($('IP Address'), publicIp.ipAddress || '');
           row.cell($('Idle timeout, minutes'), publicIp.idleTimeoutInMinutes || '');
           var fqdn = publicIp.dnsSettings ? publicIp.dnsSettings.fqdn : '';
           row.cell($('FQDN'), fqdn);


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* ARM: 'azure network public-ip list' command fixed to output 'IP Address' column

Related issue https://github.com/Azure/azure-xplat-cli/issues/2649 fixed
