### PR TITLE
Add tenant parameter for new Key Vault

### DIFF
--- a/lib/commands/arm/keyvault/keyvault._js
+++ b/lib/commands/arm/keyvault/keyvault._js
@@ -118,6 +118,7 @@ exports.init = function(cli) {
     .option('-x, --sku <sku>', util.format($('SKU setting, one of: [%s]'), SKU_TYPE.join(', ')))
     .option('-t, --tags <tags>', $('Tags to set on the vault. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
+    .option('-n, --tenant <tenant>', $('The AAD tenant identifier to create the Key Vault in. Uses the subscription\'s default tenant if not specified.'))
     .execute(function(vaultName, options, _) {
 
       ///////////////////////
@@ -179,7 +180,7 @@ exports.init = function(cli) {
           family: 'A',
           name: options.sku
         },
-        tenantId: subscription.tenantId,
+        tenantId: options.tenant || subscription.tenantId,
         accessPolicies: [{
           // Default policy for the creator.
           tenantId: subscription.tenantId,


### PR DESCRIPTION
The [Key Vault REST API](https://msdn.microsoft.com/en-us/library/azure/mt620025.aspx) allows you to specify a `tenantId`.  This is important, as you might want to create a Key Vault in a specific AAD tenant that is not necessarily the same one as your sign in.

Currently, both the Powershell and X-Plat CLI don't allow you to supply the Tenant ID.   When you go through the [Getting started with Azure Key Vault](https://azure.microsoft.com/en-us/documentation/articles/key-vault-get-started/) documentation, there's a warning half-way through that says:

> Important:
> To complete the tutorial, your account, the vault, and the application that you will register in this step must all be in the same Azure directory.

Unfortunately, if the user's account belongs to a different AD, then it is impossible to continue.  This is especially problematic for co-admins with an MSA  (hotmail.com, etc.)

Allowing the `tenant` to be an optional parameter will solve the problem.


(Apologies in advance, but I couldn't figure out where to add unit tests for this change.)
