### PR TITLE
Parsing the strings to ints to fix errors when using custom ports

### DIFF
--- a/lib/commands/arm/network/appGateway._js
+++ b/lib/commands/arm/network/appGateway._js
@@ -73,7 +73,7 @@ __.extend(AppGateways.prototype, {
       }],
       frontendPorts: [{
         name: parameters.frontendPortName,
-        port: parameters.frontendPort
+        port: parseInt(parameters.frontendPort)
       }],
       backendAddressPools: [{
         name: parameters.addressPoolName,
@@ -83,7 +83,7 @@ __.extend(AppGateways.prototype, {
       backendHttpSettingsCollection: [{
         name: parameters.httpSettingsName,
         protocol: parameters.httpSettingsProtocol,
-        port: parameters.httpSettingsPort,
+        port: parseInt(parameters.httpSettingsPort),
         cookieBasedAffinity: parameters.httpSettingsCookieBasedAffinity
       }],
       httpListeners: [{


### PR DESCRIPTION
The content to be added to Changelog is as follows:
Fixes #2768 - ARM: Application gateway with custom backend port