### PR TITLE
Fix for buffer under node v6

### DIFF
--- a/lib/util/interaction._js
+++ b/lib/util/interaction._js
@@ -38,7 +38,7 @@ __.extend(Interactor.prototype, {
     self.progressChars = ['-', '\\', '|', '/'];
     self.progressIndex = 0;
 
-    self.clearBuffer = new Buffer(79, 'utf8');
+    self.clearBuffer = new Buffer(79);
     self.clearBuffer.fill(' ');
     self.clearBuffer = self.clearBuffer.toString();
   },


### PR DESCRIPTION
Fixes #2820 by removing buffer's encoding. Not required and defaults to `utf-8`