### PR TITLE
Remove encoding from storage util

### DIFF
--- a/lib/util/storage.util._js
+++ b/lib/util/storage.util._js
@@ -745,7 +745,7 @@ StorageUtil.getServiceClient = function(getServiceClientFunc, options) {
 * Get a printer for speed summary
 */
 StorageUtil.getSpeedPrinter = function(summary) {
-  var clearBuffer = new Buffer(79, 'utf8');
+  var clearBuffer = new Buffer(79);
   clearBuffer.fill(' ');
   clearBuffer = clearBuffer.toString();
   var done = false;


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* Similar to #2821, removing buffer's encoding is required to work with storage blobs under Node.js version 6.