### PR TITLE
Remove custom 409 error handling from powerbi create command since it's not always accurate.

### DIFF
--- a/lib/commands/arm/powerbiembedded/powerbiembedded._js
+++ b/lib/commands/arm/powerbiembedded/powerbiembedded._js
@@ -87,16 +87,6 @@ exports.init = function (cli) {
       try {
         workspaceCollection = client.workspaceCollections.create(resourceGroup, name, workspaceCollectionCreationOptions, _);
       }
-      catch (e) {
-        if(e.statusCode === 409) {
-          log.error('Error occurred while attempting to creat workspace collection.\n' +
-          'The name: ' + name + ' is already in use.\n' +
-          'Please use a different name.');
-          return;
-        }
-        
-        throw e;
-      }
       finally {
         progress.end();
       }


### PR DESCRIPTION
The 409 can mean either name conflict with existing workspace collection or also be returned due to the subscription not having the Microsoft.Powerbi RP registered.  Removing the custom error handling and allowing the original error to be thrown will ensure proper response body / error message is displayed.