### PR TITLE
CLI: table output improved

### DIFF
--- a/lib/util/logging.js
+++ b/lib/util/logging.js
@@ -224,6 +224,14 @@ log.table = function (level, data, transform) {
       }
     }
 
+    for (var i in table.lines) {
+      for (var column in table.columns) {
+        if (!table.lines[i].hasOwnProperty(column)) {
+            table.lines[i][column] = '';
+        }
+      }
+    }
+
     var lines = table.toString();
     lines.substring(0, lines.length - 1).split('\n').forEach(function (line) {
       log.log(level, line);


### PR DESCRIPTION
This improvement should allow to avoid constructions like `row.cell('cell', value || '');` as `''` will be substituted automatically

@amarzavery @yugangw-msft please merge