### PR TITLE
replace dashes in vmName for bootStorageName since a storage account …

### DIFF
--- a/lib/commands/arm/vm/vmProfile._js
+++ b/lib/commands/arm/vm/vmProfile._js
@@ -105,7 +105,7 @@ __.extend(VMProfile.prototype, {
             // The storage type does not support boot diagnostics.
             // Generate hash code for dependent resource naming
             var hash = utils.getHash(this.resourceGroupName + this.params.location + this.params.imageUrn);
-            var bootStorageName = ('clisto' + hash + this.params.vmName).slice(0, 24).toLowerCase();
+            var bootStorageName = ('clisto' + hash + this.params.vmName.replace("-", "")).slice(0, 24).toLowerCase();
             var createRequestProfile = {
               sku: { name: 'Standard_LRS' },
               kind: 'Storage',

--- a/lib/commands/arm/vm/vmProfile._js
+++ b/lib/commands/arm/vm/vmProfile._js
@@ -105,7 +105,7 @@ __.extend(VMProfile.prototype, {
             // The storage type does not support boot diagnostics.
             // Generate hash code for dependent resource naming
             var hash = utils.getHash(this.resourceGroupName + this.params.location + this.params.imageUrn);
-            var bootStorageName = ('clisto' + hash + this.params.vmName.replace("-", "")).slice(0, 24).toLowerCase();
+            var bootStorageName = ('clisto' + hash + this.params.vmName.replace('-', '')).slice(0, 24).toLowerCase();
             var createRequestProfile = {
               sku: { name: 'Standard_LRS' },
               kind: 'Storage',


### PR DESCRIPTION
…doesn't allow dashes

The content to be added to Changelog is as follows:
* replace dashes in vmName for bootStorageName since a storage account doesn't allow dashes

I use dashes in my vm names, but vm creation fails on creating the "clisto" storage account.