### PR TITLE
random value generation that is production and test playback safe

### DIFF
--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -1250,6 +1250,16 @@ exports.uuidGen = function () {
   return uuid.v4();
 };
 
+//Provides a random string starting with the given (string) prefix. If prefix is not provided 
+//then it provides a random alphanumeric string
+exports.getRandomString = function (prefix) {
+  var randomStr = Math.random().toString(36).substr(2, 12);
+  if (prefix !== null && prefix !== undefined && typeof prefix.valueOf() === 'string') {
+    return prefix + randomStr;
+  }
+  return randomStr;
+};
+
 exports.toLowerCaseAndRemoveSpace = function (str) {
   if (!str) {
     return str;

--- a/test/framework/cli-test.js
+++ b/test/framework/cli-test.js
@@ -682,13 +682,13 @@ _.extend(CLITest.prototype, {
     }
 
     CLITest.wrap(sinon, utils, 'getRandomString', function (originalGetRandomString) {
-      return function (prefix, length) {
+      return function (prefix) {
         var str;
         if (self.isMocked) {
           if (!self.isRecording) {
             str = self.randomStringsGenerated[self.currentRandomString++]; 
           } else {
-            str = originalGetRandomString(prefix, length);
+            str = originalGetRandomString(prefix);
             self.randomStringsGenerated.push(str);
           }
         }

--- a/test/framework/cli-test.js
+++ b/test/framework/cli-test.js
@@ -88,6 +88,10 @@ function CLITest(mochaSuiteObject, testPrefix, env, forceMocked) {
   this.uuidsGenerated = [];
   this.currentUuid = 0;
 
+  //track & restore generated random strings that are used internally by any command
+  this.randomStringsGenerated = [];
+  this.currentRandomString = 0;
+
   // disable telemetry in test
   telemetry.init(false);
 
@@ -188,12 +192,14 @@ _.extend(CLITest.prototype, {
 
     if (this.isMocked){
       this.stubOutUuidGen(sinon);
+      this.stubOutGetRandomString(sinon);
     }
 
     executeCommand(cmd, function (result) {
       utilsCore.readConfig.restore();
       if (this.isMocked){
         utils.uuidGen.restore();
+        utils.getRandomString.restore();
       }
       callback(result);
     });
@@ -222,6 +228,10 @@ _.extend(CLITest.prototype, {
 
       if (nocked.uuidsGenerated) {
         this.uuidsGenerated = nocked.uuidsGenerated();
+      }
+
+      if (nocked.randomStringsGenerated) {
+        this.randomStringsGenerated = nocked.randomStringsGenerated();
       }
 
       if (nocked.getMockedProfile) {
@@ -256,6 +266,7 @@ _.extend(CLITest.prototype, {
       this.writeRecordingHeader(this.getSuiteRecordingsFile());
       fs.appendFileSync(this.getSuiteRecordingsFile(), '];\n');
       this.writeGeneratedUuids(this.getSuiteRecordingsFile());
+      this.writeGeneratedRandomStrings(this.getSuiteRecordingsFile());
       this.writeGeneratedRandomTestIds(this.getSuiteRecordingsFile());
     }
   },
@@ -302,6 +313,10 @@ _.extend(CLITest.prototype, {
 
       if (nocked.uuidsGenerated) {
         this.uuidsGenerated = nocked.uuidsGenerated();
+      }
+
+      if (nocked.randomStringsGenerated) {
+        this.randomStringsGenerated = nocked.randomStringsGenerated();
       }
 
       if (nocked.getMockedProfile) {
@@ -375,6 +390,7 @@ _.extend(CLITest.prototype, {
         scope += ']];';
         fs.appendFileSync(this.getTestRecordingsFile(), scope);
         this.writeGeneratedUuids();
+        this.writeGeneratedRandomStrings();
         this.writeGeneratedRandomTestIds();
         nockHelper.nock.recorder.clear();
       } else {
@@ -479,6 +495,22 @@ _.extend(CLITest.prototype, {
       filename = filename || this.getTestRecordingsFile();
       fs.appendFileSync(filename, content);
       this.uuidsGenerated.length = 0;
+    }
+  },
+
+  /**
+  * Writes the generated random strings to the specified file.
+  *
+  * @param {string} filename        (Optional) The file name to which the random strings need to be added
+  *                                 If the filename is not provided then it will get the current test recording file.
+  */
+  writeGeneratedRandomStrings: function (filename) {
+    if (this.randomStringsGenerated.length > 0) {
+      var randomStrings = this.randomStringsGenerated.map(function (str) { return '\'' + str + '\''; }).join(',');
+      var content = util.format('\n exports.randomStringsGenerated = function() { return [%s];};', randomStrings);
+      filename = filename || this.getTestRecordingsFile();
+      fs.appendFileSync(filename, content);
+      this.randomStringsGenerated.length = 0;
     }
   },
   
@@ -636,6 +668,31 @@ _.extend(CLITest.prototype, {
           }
         }
         return uuid;
+      };
+    });
+  },
+
+  /**
+  * Record any generated hashes which get created while executing a command and restore then in playback mode
+  */
+  stubOutGetRandomString: function () {
+    var self = this;
+    if (utils.getRandomString.restore) {
+      utils.getRandomString.restore();
+    }
+
+    CLITest.wrap(sinon, utils, 'getRandomString', function (originalGetRandomString) {
+      return function (prefix, length) {
+        var str;
+        if (self.isMocked) {
+          if (!self.isRecording) {
+            str = self.randomStringsGenerated[self.currentRandomString++]; 
+          } else {
+            str = originalGetRandomString(prefix, length);
+            self.randomStringsGenerated.push(str);
+          }
+        }
+        return str;
       };
     });
   },


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* ability to generate random values within a command; record them if a test runs that command and retrieve them from the recording file if the test for that command is being run in playback mode
