### PR TITLE
Key Vault: Add support for certificates, move to auto-rest based node SK

### DIFF
--- a/lib/commands/arm/keyvault/keyvault._js
+++ b/lib/commands/arm/keyvault/keyvault._js
@@ -32,6 +32,7 @@ var RESOURCE_TYPE = 'Microsoft.KeyVault/vaults';
 var SKU_TYPE = ['Standard', 'Premium'];
 var KEY_PERMS = ['all', 'create', 'import', 'update', 'delete', 'get', 'list', 'backup', 'restore', 'sign', 'verify', 'encrypt', 'decrypt', 'wrapKey', 'unwrapKey'];
 var SECRET_PERMS = ['all', 'set', 'get', 'list', 'delete'];
+var CERTIFICATE_PERMS = ['all', 'get', 'list', 'delete', 'create', 'import', 'update', 'managecontacts', 'getissuers', 'listissuers', 'setissuers', 'deleteissuers'];
 
 exports.init = function(cli) {
 
@@ -220,7 +221,9 @@ exports.init = function(cli) {
               // Typical permissions for 'key manager' role - cannot sign, decrypt, etc. This default is same of Powershell.
               keys: ['get', 'create', 'delete', 'list', 'update', 'import', 'backup', 'restore'],
               // Typical permissions for 'secret manager' role. This default is same of Powershell.
-              secrets: ['all']
+              secrets: ['all'],
+              // Typical permissions for 'certificate manager' role. This default is same of Powershell.
+              certificates: ['all']
             }
           }];
 
@@ -488,6 +491,7 @@ exports.init = function(cli) {
     .option('--upn <user-principal-name>', $('name of a user principal that will receive permissions'))
     .option('--perms-to-keys <perms-to-keys>', util.format($('JSON-encoded array of strings representing key operations; each string can be one of [%s]'), KEY_PERMS.join(', ')))
     .option('--perms-to-secrets <perms-to-secrets>', util.format($('JSON-encoded array of strings representing secret operations; each string can be one of [%s]'), SECRET_PERMS.join(', ')))
+    .option('--perms-to-certificates <perms-to-certificates>', util.format($('JSON-encoded array of strings representing certificate operations; each string can be one of [%s]'), CERTIFICATE_PERMS.join(', ')))
     .option('--enabled-for-deployment <boolean>', $('specifies whether the Azure Compute resource provider can access secrets'))
     .option('--enabled-for-template-deployment <boolean>', $('specifies whether Azure Resource Manager can access secrets'))
     .option('--enabled-for-disk-encryption <boolean>', $('specifies whether Azure Disk Encryption can access secrets'))
@@ -511,21 +515,23 @@ exports.init = function(cli) {
 
       options.permsToKeys = kvUtils.parseArrayArgument('perms-to-keys', options.permsToKeys, KEY_PERMS, null);
       options.permsToSecrets = kvUtils.parseArrayArgument('perms-to-secrets', options.permsToSecrets, SECRET_PERMS, null);
+      options.permsToCertificates = kvUtils.parseArrayArgument('perms-to-certificates', options.permsToCertificates, CERTIFICATE_PERMS, null);
       options.enabledForDeployment = kvUtils.parseBooleanArgument('enabled-for-deployment', options.enabledForDeployment);
       options.enabledForTemplateDeployment = kvUtils.parseBooleanArgument('enabled-for-template-deployment', options.enabledForTemplateDeployment);
       options.enabledForDiskEncryption = kvUtils.parseBooleanArgument('enabled-for-disk-encryption', options.enabledForDiskEncryption);
 
-      if (!options.permsToKeys && !options.permsToSecrets && __.isUndefined(options.enabledForDeployment) && __.isUndefined(options.enabledForTemplateDeployment) && __.isUndefined(options.enabledForDiskEncryption)) {
+      if (!options.permsToKeys && !options.permsToSecrets && !options.permsToCertificates && __.isUndefined(options.enabledForDeployment) && __.isUndefined(options.enabledForTemplateDeployment) && __.isUndefined(options.enabledForDiskEncryption)) {
         log.error($('Please inform at least one of the following:'));
         log.error($('    --perms-to-keys <perms-to-keys>'));
         log.error($('    --perms-to-secrets <perms-to-secrets>'));
+        log.error($('    --perms-to-certificates <perms-to-certificates>'));
         log.error($('    --enabled-for-deployment <boolean>'));
         log.error($('    --enabled-for-template-deployment <boolean>'));
         log.error($('    --enabled-for-disk-encryption <boolean>'));
         throw new Error($('Inconsistent arguments'));
       }
 
-      if (options.permsToKeys || options.permsToSecrets) {
+      if (options.permsToKeys || options.permsToSecrets || options.permsToCertificates) {
 
         var v = [];
         if (options.objectId) v.push('--object-id');
@@ -556,7 +562,7 @@ exports.init = function(cli) {
         if (options.upn) extraneous = '--upn';
 
         if (extraneous) {
-          throw new Error(util.format($('Inconsistent arguments: %s was informed while none of [--perms-to-keys, --perms-to-secrets] was informed'), extraneous));
+          throw new Error(util.format($('Inconsistent arguments: %s was informed while none of [--perms-to-keys, --perms-to-secrets, --perms-to-certificates] was informed'), extraneous));
         }
 
       }
@@ -590,7 +596,7 @@ exports.init = function(cli) {
 
       var properties = vaultResource.properties;
 
-      if (options.permsToKeys || options.permsToSecrets) {
+      if (options.permsToKeys || options.permsToSecrets || options.permsToCertificates) {
 
         /////////////////////////////////////////////////////////////
         // Finds the policy to change, or add if not found.        //
@@ -608,7 +614,8 @@ exports.init = function(cli) {
             objectId: options.objectId,
             permissions: {
               keys: [],
-              secrets: []
+              secrets: [],
+              certificates: []
             }
           };
           policies.push(policy);
@@ -626,8 +633,12 @@ exports.init = function(cli) {
           policy.permissions.secrets = options.permsToSecrets;
         }
 
-        // If both are empty, the policy entry is not required.
-        if (!policy.permissions.keys.length && !policy.permissions.secrets.length) {
+        if (options.permsToCertificates) {
+          policy.permissions.certificates = options.permsToCertificates;
+        }
+
+        // If all are empty, the policy entry is not required.
+        if (!policy.permissions.keys.length && !policy.permissions.secrets.length && !policy.permissions.certificates.length) {
           var index = policies.indexOf(policy);
           policies.splice(index, 1);
         }

--- a/lib/commands/arm/keyvault/keyvault.certificate._js
+++ b/lib/commands/arm/keyvault/keyvault.certificate._js
@@ -1,0 +1,1753 @@
+/**
+ * Copyright (c) Microsoft.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// Camel case checks disabled because the identifier certificate_ops is part of spec and can't be changed.
+/*jshint camelcase:false */
+
+var util = require('util');
+var fs = require('fs');
+
+var profile = require('../../../util/profile');
+var utils = require('../../../util/utils');
+var kvUtils = require('./kv-utils');
+var jsonlint = require('jsonlint');
+
+var $ = utils.getLocaleString;
+
+var ENCODINGS = ['base64'];
+var KEY_TYPES = ['RSA', 'RSA-HSM'];
+var SECRET_CONTENT_TYPES = ['application/x-pkcs12', 'application/x-pem-file'];
+
+exports.init = function(cli) {
+  var log = cli.output;
+
+  var certificate = cli.category('keyvault').category('certificate')
+    .description($('Commands to manage certificates in the Azure Key Vault service'));
+
+  certificate.command('list [vault-name]')
+    .description($('Lists certificates of a vault'))
+    .usage('[options] <vault-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .execute(function(vaultName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      ////////////////////////////////////////////
+      // Create the client and list certificates. //
+      ////////////////////////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+      var certificates = [];
+      var progress = cli.interaction.progress(util.format($('Loading certificates of vault %s'), options.vaultUri));
+      try {
+        var result = client.getCertificates(options.vaultUri, _);
+        if (result) {
+          certificates = result;
+
+          while (result && result.nextLink) {
+            log.verbose(util.format($('Found %d certificates, loading more'), certificates.length));
+            result = client.getCertificatesNext(result.nextLink, _);
+            if (result) {
+              certificates = certificates.concat(result);
+            }
+          }
+        }
+      } finally {
+        progress.end();
+      }
+
+      log.table(certificates, showCertificateRow);
+
+      log.info(util.format($('Found %d certificates'), certificates.length));
+    });
+
+  certificate.command('list-versions [vault-name] [certificate-name]')
+    .description($('Lists certificate versions'))
+    .usage('[options] <vault-name> [certificate-name]')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('lists only versions of this certificate'))
+    .execute(function(vaultName, certificateName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      ////////////////////////////////////////////
+      // Create the client and list certificates.       //
+      ////////////////////////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificates, certificateIdentifier, certificateVersions;
+      var progress;
+      if (!options.certificateName) {
+        certificates = [];
+        progress = cli.interaction.progress(util.format($('Loading certificates of vault %s'), options.vaultUri));
+        try {
+          var result = client.getCertificates(options.vaultUri, _);
+          if (result && result.length) {
+            for (var i = 0; i < result.length; ++i) {
+              certificateIdentifier = kvUtils.parseCertificateIdentifier(result[i].id);
+              certificateVersions = getCertificateVersions(client, certificateIdentifier.vaultUri, certificateIdentifier.name, _);
+              certificates = certificates.concat(certificateVersions);
+            }
+
+            while (result && result.nextLink) {
+              log.verbose(util.format($('Found %d certificates, loading more'), certificates.length));
+              result = client.getCertificatesNext(result.nextLink, _);
+              if (result && result.length) {
+                for (var j = 0; j < result.length; ++j) {
+                  certificateIdentifier = kvUtils.parseCertificateIdentifier(result[j].id);
+                  certificateVersions = getCertificateVersions(client, certificateIdentifier.vaultUri, certificateIdentifier.name, _);
+                  certificates = certificates.concat(certificateVersions);
+                }
+              }
+            }
+          }
+        } finally {
+          progress.end();
+        }
+      } else {
+        progress = cli.interaction.progress(util.format($('Loading certificates of vault %s'), options.vaultUri));
+        try {
+          certificates = getCertificateVersions(client, options.vaultUri, options.certificateName, _);
+        } finally {
+          progress.end();
+        }
+      }
+
+      log.table(certificates, showCertificateRow);
+
+      log.info(util.format($('Found %d certificates'), certificates.length));
+    });
+
+  certificate.command('show [vault-name] [certificate-name] [certificate-version]')
+    .description($('Shows a vault certificate'))
+    .usage('[options] <vault-name> <certificate-name> [certificate-version]')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('-r, --certificate-version <certificate-version>', $('the certificate version; if omited, uses the most recent'))
+    .execute(function(vaultName, certificateName, certificateVersion, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        certificateVersion: certificateVersion,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+      options.certificateVersion = options.certificateVersion || certificateVersion;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificateIdentifier = getCertificateIdentifier(options);
+      var progress = cli.interaction.progress(util.format($('Getting certificate %s'), certificateIdentifier));
+      try {
+        certificate = client.getCertificate(certificateIdentifier, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificate(options, certificate);
+    });
+
+  certificate.command('get [vault-name] [certificate-name] [certificate-version] [file]')
+    .description($('Downloads a certificate from the vault'))
+    .usage('[options] <vault-name> <certificate-name> [certificate-version] <file>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('-r, --certificate-version <certificate-version>', $('the certificate version; if omited, uses the most recent'))
+    .option('--file <file>', $('the file to receive certificate contents; the file must not exist otherwise the command fails'))
+    .option('--encode <encoding>', util.format($('tells to write a file by encoding certificate contents with the informed encoding; valid values: [%s]'), ENCODINGS.join(', ')))
+    .execute(function(vaultName, certificateName, certificateVersion, file, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        certificateVersion: certificateVersion,
+        file: file,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+      options.certificateVersion = options.certificateVersion || certificateVersion;
+      options.file = options.file || file;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      if (!options.file) {
+        return cli.missingArgument('file');
+      }
+
+      if (options.encode) {
+        options.encodeFile = kvUtils.parseEnumArgument('encode', options.encodeFile, ENCODINGS);
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificateIdentifier = getCertificateIdentifier(options);
+      var progress = cli.interaction.progress(util.format($('Getting certificate %s'), certificateIdentifier));
+      try {
+        certificate = client.getCertificate(certificateIdentifier, _);
+      } finally {
+        progress.end();
+      }
+      
+      log.info(util.format($('Writing certificate to %s'), options.file));
+      var data = certificate.cer;
+      if (options.encode === 'base64') {
+        data = kvUtils.bufferToBase64(certificate.cer);
+      }
+      
+      fs.writeFileSync(options.file, data, { flag: 'wx' });
+
+    });
+
+  certificate.command('create [vault-name] [certificate-name]')
+    .description($('Creates a certificate in the vault'))
+    .usage('[options] <vault-name> <certificate-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('-p --certificate-policy <certificate-policy>', $('a JSON-formatted string containing the certificate policy.'))
+    .fileRelatedOption('-e --certificate-policy-file <certificate-policy-file>', $('a file containing the certificate policy. Mutually exlcusive with --certificate-policy.'))
+    .option('-t, --tags <tags>', $('Tags to set on the certificate. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
+    .execute(function(vaultName, certificateName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      /////////////////////////////////////////////////
+      // Read the certificate policy.                //
+      /////////////////////////////////////////////////
+
+      var certificatePolicyOptions = [options.certificatePolicy, options.certificatePolicyFile];
+      var certificatePolicyOptionsProvided = certificatePolicyOptions.filter(function (value) { return value !== undefined; }).length;
+      if (certificatePolicyOptionsProvided > 1) {
+        throw new Error($('Specify exactly one of the --certificate-policy, or --certificate-policy-file options.'));
+      }
+
+      var certificatePolicy;
+      if (options.certificatePolicyFile) {
+        var jsonFile = fs.readFileSync(options.certificatePolicyFile);
+        certificatePolicy = jsonlint.parse(utils.stripBOM(jsonFile));
+      } else if (options.certificatePolicy) {
+        certificatePolicy = jsonlint.parse(options.certificatePolicy);
+      }
+
+      options.tags = kvUtils.parseTagsArgument('tags', options.tags);
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificateOperation;
+      var progress = cli.interaction.progress(util.format($('Creating certificate %s in vault %s'), options.certificateName, options.vaultName));
+      try {
+        certificateOperation = client.createCertificate(options.vaultUri, options.certificateName, { certificatePolicy: certificatePolicy, tags: options.tags }, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificateOperation(options, certificateOperation);
+    });
+
+  certificate.command('import [vault-name] [certificate-name]')
+    .description($('Imports a certificate into the vault'))
+    .usage('[options] <vault-name> <certificate-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('-b --content <content>', $('a base64 encoded string containing the certificate and private key (optional) to be imported'))
+    .fileRelatedOption('-e --content-file <content-file>', $('a file containing the certificate and private key (optional) to be imported'))
+    .option('--content-file-binary <boolean>', $('indicates if the content file is binary. valid values: [false, true]. default is false.'))
+    .option('-d, --password <password>', $('password of the file if it contains a encrypted private key'))
+    .option('-p --certificate-policy <certificate-policy>', $('a JSON-formatted string containing the certificate policy.'))
+    .fileRelatedOption('-e --certificate-policy-file <certificate-policy-file>', $('a file containing the certificate policy. Mutually exlusive with --certificate-policy.'))
+    .option('-t, --tags <tags>', $('Tags to set on the certificate. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
+    .execute(function(vaultName, certificateName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      options.tags = kvUtils.parseTagsArgument('tags', options.tags);
+
+      /////////////////////////////////////////////////
+      // Read the certificate content.               //
+      /////////////////////////////////////////////////
+
+      var contentOptions = [options.content, options.contentFile];
+      var contentOptionsProvided = contentOptions.filter(function (value) { return value !== undefined; }).length;
+      if (contentOptionsProvided > 1) {
+        throw new Error($('Specify exactly one of the --content, or --content-file options.'));
+      }
+
+      var certificateContent, contentFile;
+      if (options.contentFile) {
+        options.contentFileBinary = kvUtils.parseBooleanArgument('content-file-binary', options.contentFileBinary, false);
+        if (options.contentFileBinary) {
+          contentFile = fs.readFileSync(options.contentFile);
+          certificateContent = kvUtils.bufferToBase64(contentFile);
+        }
+        else {
+          contentFile = fs.readFileSync(options.contentFile, 'UTF-8');
+          certificateContent = contentFile;
+        }
+      } else if (options.content) {
+        certificateContent = options.content;
+      }
+
+      /////////////////////////////////////////////////
+      // Read the certificate policy.                //
+      /////////////////////////////////////////////////
+
+      var certificatePolicyOptions = [options.certificatePolicy, options.certificatePolicyFile];
+      var certificatePolicyOptionsProvided = certificatePolicyOptions.filter(function (value) { return value !== undefined; }).length;
+      if (certificatePolicyOptionsProvided > 1) {
+        throw new Error($('Specify exactly one of the --certificate-policy, or --certificate-policy-file options.'));
+      }
+
+      var certificatePolicy;
+      if (options.certificatePolicyFile) {
+        var jsonFile = fs.readFileSync(options.certificatePolicyFile);
+        certificatePolicy = jsonlint.parse(utils.stripBOM(jsonFile));
+      } else if (options.certificatePolicy) {
+        certificatePolicy = jsonlint.parse(options.certificatePolicy);
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificate;
+      var progress = cli.interaction.progress(util.format($('Importing certificate %s in vault %s'), options.certificateName, options.vaultName));
+      try {
+        certificate = client.importCertificate(options.vaultUri, options.certificateName, certificateContent, { password: options.password, certificatePolicy: certificatePolicy, tags: options.tags }, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificate(options, certificate);
+    });
+
+  certificate.command('merge [vault-name] [certificate-name] [content]')
+    .description($('Merges certificate(s)into the vault'))
+    .usage('[options] <vault-name> <certificate-name> <content>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('-b --content <content>', $('certificate chain to merge; must be JSON-encoded array of base64 encoded certificate'))
+    .option('-t, --tags <tags>', $('Tags to set on the certificate. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
+    .execute(function(vaultName, certificateName, content, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        content: content,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+      options.content = options.content || content;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      if (!options.content) {
+        return cli.missingArgument('content');
+      }
+
+      options.tags = kvUtils.parseTagsArgument('tags', options.tags);
+      options.content = kvUtils.validateArrayArgument('content', options.content);
+      for (var i = 0; i < options.content.length; ++i) {
+        options.content[i] = new Buffer(options.content[i], 'base64');
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificate;
+      var progress = cli.interaction.progress(util.format($('Merging certificate %s in vault %s'), options.certificateName, options.vaultName));
+      try {
+        certificate = client.mergeCertificate(options.vaultUri, options.certificateName, options.content, { tags: options.tags }, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificate(options, certificate);
+    });
+
+  certificate.command('set-attributes [vault-name] [certificate-name] [certificate-version]')
+    .description($('Changes attributes of an existing certificate'))
+    .usage('[options] <vault-name> <certificate-name> [certificate-version]')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('name of the certificate to be modified'))
+    .option('-r, --certificate-version <certificate-version>', $('the version to be modified; if omited, modifies only the most recent'))
+    .option('--enabled <boolean>', $('if informed, command will change the enabled state; valid values: [false, true]'))
+    .option('-t, --tags <tags>', $('Tags to set on the certificate. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
+    .option('--reset-tags', $('remove previously existing tags; can combined with --tags'))
+    .execute(function(vaultName, certificateName, certificateVersion, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        certificateVersion: certificateVersion,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+      options.certificateVersion = options.certificateVersion || certificateName;
+
+      var informed = {
+        enabled: options.enabled || false,
+        tags: options.tags || false,
+        resetTags: options.resetTags || false
+      };
+
+      options.enabled = kvUtils.parseBooleanArgument('enabled', options.enabled, true);
+      options.tags = kvUtils.parseTagsArgument('tags', options.tags);
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+      var certificateIdentifier = getCertificateIdentifier(options);
+
+      if (informed.tags) {
+
+        // Some tags were informed.
+        if (!informed.resetTags) {
+
+          // We must read existing tags and add the new ones.
+          log.info(util.format($('Getting certificate %s'), certificateIdentifier));
+          certificate = client.getCertificate(certificateIdentifier, _);
+          var currentTags = certificate.tags;
+          if (!currentTags) {
+            // Defend against undefined.
+            currentTags = {};
+          }
+          options.tags = kvUtils.mergeTags(currentTags, options.tags);
+        }
+      } else {
+
+        // No tags informed.
+        if (informed.resetTags) {
+
+          // Clear all tags ignoring existing one.
+          informed.tags = true;
+          options.tags = {};
+        }
+      }
+
+      var request = {
+        certificateAttributes: {}
+      };
+
+      if (informed.enabled) request.certificateAttributes.enabled = options.enabled;
+      if (informed.tags) request.tags = options.tags;
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+      var progress = cli.interaction.progress(util.format($('Setting attributes on certificate %s'), certificateIdentifier));
+      try {
+        certificate = client.updateCertificate(certificateIdentifier, request, _);
+      } finally {
+        progress.end();
+      }
+    });
+
+  certificate.command('delete [vault-name] [certificate-name]')
+    .description($('Deletes a certificate from the vault'))
+    .usage('[options] <vault-name> <certificate-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('-q, --quiet', $('quiet mode (do not ask for delete confirmation)'))
+    .execute(function(vaultName, certificateName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      if (!options.quiet && !cli.interaction.confirm(util.format($('Delete certificate %s from vault %s? [y/n] '), options.certificateName, options.vaultName), _)) {
+        throw new Error($('Aborted by user'));
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificate;
+      var progress = cli.interaction.progress(util.format($('Deleting certificate %s in vault %s'), options.certificateName, options.vaultName));
+      try {
+        certificate = client.deleteCertificate(options.vaultUri, options.certificateName, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificate(options, certificate);
+    });
+
+  var certificatePolicy = cli.category('keyvault').category('certificate').category('policy')
+    .description($('Commands to manage a certificate policy in the Azure Key Vault service'));
+
+  certificatePolicy.command('show [vault-name] [certificate-name]')
+    .description($('Shows a vault certificate policy'))
+    .usage('[options] <vault-name> <certificate-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .execute(function(vaultName, certificateName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificatePolicy;
+      var progress = cli.interaction.progress(util.format($('Getting policy for certificate %s'), options.certificateName));
+      try {
+        certificatePolicy = client.getCertificatePolicy(options.vaultUri, options.certificateName, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificatePolicy(options, certificatePolicy);
+    });
+
+  certificatePolicy.command('get [vault-name] [certificate-name] [file]')
+    .description($('Gets a vault certificate policy'))
+    .usage('[options] <vault-name> <certificate-name> <file>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('--file <file>', $('the file to receive certificate policy contents; the file must not exist otherwise the command fails'))
+    .execute(function(vaultName, certificateName, file, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        file: file,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+      options.file = options.file || file;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificatePolicy;
+      var progress = cli.interaction.progress(util.format($('Getting policy for certificate %s'), options.certificateName));
+      try {
+        certificatePolicy = client.getCertificatePolicy(options.vaultUri, options.certificateName, _);
+      } finally {
+        progress.end();
+      }
+
+      fs.writeFileSync(options.file, JSON.stringify(certificatePolicy), { flag: 'wx' });
+    });
+
+  /* jshint unused: false */
+  certificatePolicy.command('create [issuer-name] [subject-name] [file]')
+    .description($('Creates a new certificate policy JSON object. This policy object can be used as input to other certificate commands such as certificate create.'))
+    .usage('options <issuer-name> [subject-name] [file]')
+    .option('-i, --issuer-name <issuer-name>', $('issuer name'))
+    .option('-n, --subject-name <subject-name>', $('subject name'))
+    .option('--file <file>', $('the file to receive certificate policy object; the file must not exist otherwise the command fails'))
+    .option('-k, --key-type <key-type>', util.format($('tells if the key backing the certificate is software-protected or HSM-protected; valid values: [%s]'), KEY_TYPES.join(', ')))
+    .option('--reuse-key-on-renewal', $('indicates if the key should be reused on renewal; defaults to key is not reused'))
+    .option('--key-not-exportable', $('indicates if the key should not be exportable; defaults to key is exportable'))
+    .option('-t, --secret-content-type <secret-content-type>', util.format($('secret content type; valid values: [%s]'), SECRET_CONTENT_TYPES.join(', ')))
+    .option('-d, --dns-names <dns-name>', $('subject alternative dns names; must be JSON-encoded array of strings'))
+    .option('-e, --ekus <ekus>', $('extended key usages; must be JSON-encoded array of strings'))
+    .option('-m, --validity-in-months <validity-in-months>', $('validity of the certificate in months'))
+    .option('--renew-days-before-expiry <renew-days-before-expiry>', $('number of days before expiry to automatically renew the certificate'))
+    .option('--renew-at-percentage-lifetime <renew-at-percentage-lifetime>', $('lifetime percentage at which automatically renew the certificate'))
+    .option('--email-days-before-expiry <email-days-before-expiry>', $('number of days before expiry to send notification'))
+    .option('--email-at-percentage-lifetime <email-at-percentage-lifetime>', $('lifetime percentage at which send notification'))
+    .execute(function(issuerName, subjectName, file, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        issuerName: issuerName,
+        subjectName: subjectName,
+        file: file,
+        options: options
+      }));
+
+      options.issuerName = options.issuerName || issuerName;
+      options.subjectName = options.subjectName || subjectName;
+      options.file = options.file || file;
+
+      if (!options.issuerName) {
+        throw new Error(util.format($('Issuer name must be provided')));
+      }
+
+      //options.keyNotExportable = kvUtils.parseBooleanArgument('key-not-exportable', options.keyNotExportable, false);
+      //options.reuseKeyOnRenewal = kvUtils.parseBooleanArgument('reuse-key-on-renewal', options.reuseKeyOnRenewal, false);
+
+      var policy = {
+        keyProperties: {
+          exportable: !options.keyNotExportable,
+          reuseKey: options.reuseKeyOnRenewal,
+        },
+        x509CertificateProperties: {
+        },
+        issuerReference: {
+          name: options.issuerName
+        }
+      };
+
+      if (options.keyType) {
+        if (!KEY_TYPES.some(function(e) { return e.toUpperCase() === options.keyType.toUpperCase(); })) {
+          throw new Error(util.format($('Invalid value for key type argument. Accepted values are: %s'), KEY_TYPES.join(', ')));
+        }
+
+        policy.keyProperties.keyType = options.keyType.toUpperCase();
+      }
+
+      if (options.secretContentType) {
+        if (!SECRET_CONTENT_TYPES.some(function(e) { return e === options.secretContentType; })) {
+          throw new Error(util.format($('Invalid value for secret content type argument. Accepted values are: %s'), SECRET_CONTENT_TYPES.join(', ')));
+        }
+
+        policy.secretProperties = {
+          contentType: options.secretContentType
+        };
+      }
+
+      if (!options.subjectName && !options.dnsNames) {
+        throw new Error(util.format($('Either subject name or dns names must be provided')));
+      }
+
+      if (options.subjectName) {
+        policy.x509CertificateProperties.subject = options.subjectName;
+      }
+
+      if (options.dnsNames) {
+        options.dnsNames = kvUtils.validateArrayArgument('dns-names', options.dnsNames);
+        policy.x509CertificateProperties.subjectAlternativeNames = {
+          dnsNames: options.dnsNames
+        };
+      }
+
+      if (options.ekus) {
+        options.ekus = kvUtils.validateArrayArgument('ekus', options.ekus);
+        policy.x509CertificateProperties.ekus = options.ekus;
+      }
+
+      if (options.validityInMonths) {
+        options.validityInMonths = kvUtils.parseIntegerArgument('validity-in-months', options.validityInMonths);
+        policy.x509CertificateProperties.validityInMonths = options.validityInMonths;
+      }
+
+      var lifetimeActionOptions = [options.renewDaysBeforeExpiry, options.renewAtPercentageLifetime, options.emailDaysBeforeExpiry, options.emailAtPercentageLifetime];
+      var lifetimeActionOptionsProvided = lifetimeActionOptions.filter(function (value) { return value !== undefined; }).length;
+      if (lifetimeActionOptionsProvided > 1) {
+        throw new Error($('Specify exactly one of the --renew-days-before-expiry, --renew-at-percentage-lifetime, --email-days-before-expiry, or --email-at-percentage-lifetime options.'));
+      }
+
+      if (options.renewDaysBeforeExpiry) {
+        policy.lifetimeActions = [{
+          trigger: {
+            daysBeforeExpiry: options.renewDaysBeforeExpiry
+          },
+          action: {
+            actionType: 'AutoRenew'
+            }
+        }];
+      }
+
+      if (options.renewAtPercentageLifetime) {
+        policy.lifetimeActions = [{
+          trigger: {
+            lifetimePercentage: options.renewAtPercentageLifetime
+          },
+          action: {
+            actionType: 'AutoRenew'
+            }
+        }];
+      }
+
+      if (options.emailDaysBeforeExpiry) {
+        policy.lifetimeActions = [{
+          trigger: {
+            daysBeforeExpiry: options.emailDaysBeforeExpiry
+          },
+          action: {
+            actionType: 'EmailContacts'
+            }
+        }];
+      }
+
+      if (options.emailAtPercentageLifetime) {
+        policy.lifetimeActions = [{
+          trigger: {
+            lifetimePercentage: options.emailAtPercentageLifetime
+          },
+          action: {
+            actionType: 'EmailContacts'
+            }
+        }];
+      }
+
+      if (options.file) {
+        fs.writeFileSync(options.file, JSON.stringify(policy), { flag: 'wx' });
+      }
+      else {
+        showCertificatePolicy(options, policy);
+      }
+    });
+  /* jshint unused: true */
+
+  certificatePolicy.command('set [vault-name] [certificate-name]')
+    .description($('Sets a vault certificate policy'))
+    .usage('[options] <vault-name> <certificate-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('-p --certificate-policy <certificate-policy>', $('a JSON-formatted string containing the certificate policy'))
+    .fileRelatedOption('-e --certificate-policy-file <certificate-policy-file>', $('a file containing the certificate policy.Mutually exlcusive with --certificate-policy.'))
+    .execute(function(vaultName, certificateName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      /////////////////////////////////////////////////
+      // Read the certificate policy.                //
+      /////////////////////////////////////////////////
+
+      var certificatePolicyOptions = [options.certificatePolicy, options.certificatePolicyFile];
+      var certificatePolicyOptionsProvided = certificatePolicyOptions.filter(function (value) { return value !== undefined; }).length;
+      if (certificatePolicyOptionsProvided > 1) {
+        throw new Error($('Specify exactly one of the --certificate-policy, or --certificate-policy-file options.'));
+      } else if (certificatePolicyOptionsProvided === 0) {
+        throw new Error($('One of the --certificate-policy, or --certificate-policy-file options is required.'));
+      }
+
+      var certificatePolicy;
+      if (options.certificatePolicyFile) {
+        var jsonFile = fs.readFileSync(options.certificatePolicyFile);
+        certificatePolicy = jsonlint.parse(utils.stripBOM(jsonFile));
+      } else {
+        certificatePolicy = jsonlint.parse(options.certificatePolicy);
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var progress = cli.interaction.progress(util.format($('Updating policy for certificate %s'), options.certificateName));
+      try {
+        certificatePolicy = client.updateCertificatePolicy(options.vaultUri, options.certificateName, certificatePolicy, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificatePolicy(options, certificatePolicy);
+    });
+
+  var certificateOperation = cli.category('keyvault').category('certificate').category('operation')
+    .description($('Commands to manage certificate operations in the Azure Key Vault service'));
+
+  certificateOperation.command('show [vault-name] [certificate-name]')
+    .description($('Shows a vault certificate operation'))
+    .usage('[options] <vault-name> <certificate-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .execute(function(vaultName, certificateName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificateOperation;
+      var progress = cli.interaction.progress(util.format($('Getting operation for certificate %s'), options.certificateName));
+      try {
+        certificateOperation = client.getCertificateOperation(options.vaultUri, options.certificateName, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificateOperation(options, certificateOperation);
+    });
+
+  certificateOperation.command('cancel [vault-name] [certificate-name]')
+    .description($('Cancels a vault certificate operation'))
+    .usage('[options] <vault-name> <certificate-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('-q, --quiet', $('quiet mode (do not ask for cancel confirmation)'))
+    .execute(function(vaultName, certificateName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      if (!options.quiet && !cli.interaction.confirm(util.format($('Cancel certificate operation for certificate %s from vault %s? [y/n] '), options.certificateName, options.vaultName), _)) {
+        throw new Error($('Aborted by user'));
+      }
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+      var certificateOperation;
+      var progress = cli.interaction.progress(util.format($('Cancelling operation for certificate %s'), options.certificateName));
+      try {
+        certificateOperation = client.updateCertificateOperation(options.vaultUri, options.certificateName, { cancellationRequested : true }, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificateOperation(options, certificateOperation);
+    });
+
+  certificateOperation.command('delete [vault-name] [certificate-name]')
+    .description($('Deletes a vault certificate operation'))
+    .usage('[options] <vault-name> <certificate-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-name <certificate-name>', $('the certificate name'))
+    .option('-q, --quiet', $('quiet mode (do not ask for delete confirmation)'))
+    .execute(function(vaultName, certificateName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateName: certificateName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateName = options.certificateName || certificateName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateName) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      if (!options.quiet && !cli.interaction.confirm(util.format($('Delete certificate operation for certificate %s from vault %s? [y/n] '), options.certificateName, options.vaultName), _)) {
+        throw new Error($('Aborted by user'));
+      }
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+      var certificateOperation;
+      var progress = cli.interaction.progress(util.format($('Deleting operation for certificate %s'), options.certificateName));
+      try {
+        certificateOperation = client.deleteCertificateOperation(options.vaultUri, options.certificateName, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificateOperation(options, certificateOperation);
+    });
+
+  var certificateAdministrator = cli.category('keyvault').category('certificate').category('administrator')
+    .description($('Commands to manage certificate administrators in the Azure Key Vault service'));
+
+  /* jshint unused: false */
+  certificateAdministrator.command('create [first-name] [last-name] [email-address] [phone-number] [file]')
+    .description($('Creates a new certificate administator JSON object. This administratory object can be used as input to other certificate commands such as organization create.'))
+    .usage('[options] [first-name] [last-name] [email-address] [phone-number] [file]')
+    .option('-f, --first-name <first-name>', $('first name'))
+    .option('-l, --last-name <last-name>', $('last name'))
+    .option('-e, --email-address <email-address>', $('email-address'))
+    .option('-p, --phone-number <phone-number>', $('phone-number'))
+    .option('--file <file>', $('the file to receive certificate administator object; the file must not exist otherwise the command fails'))
+    .execute(function(firstName, lastName, emailAddress, phoneNumber, file, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        firstName: firstName,
+        lastName: lastName,
+        emailAddress: emailAddress,
+        phoneNumber: phoneNumber,
+        options: options
+      }));
+
+      options.firstName = options.firstName || firstName;
+      options.lastName = options.lastName || lastName;
+      options.emailAddress = options.emailAddress || emailAddress;
+      options.phoneNumber = options.phoneNumber || phoneNumber;
+      options.file = options.file || file;
+
+      ////////////////////////////////////////////
+      // Create certificate administrator       //
+      ////////////////////////////////////////////
+      var certificateAdministrator = {
+        firstName : options.firstName,
+        lastName : options.lastName,
+        emailAddress : options.emailAddress,
+        phone : options.phoneNumber
+      };
+
+      if (options.file) {
+        fs.writeFileSync(options.file, JSON.stringify(certificateAdministrator), { flag: 'wx' });
+      }
+      else {
+        showCertificateAdministrator(options, certificateAdministrator);
+      }
+    });
+  /* jshint unused: true */
+
+  var certificateOrganization = cli.category('keyvault').category('certificate').category('organization')
+    .description($('Commands to manage certificate organization in the Azure Key Vault service'));
+
+  /* jshint unused: false */
+  certificateOrganization.command('create [id] [file]')
+    .description($('Creates a new certificate organization JSON object. This organization object can be used as input to other certificate commands such as issuer create.'))
+    .usage('[options] [id] [file]')
+    .option('-i, --id <id>', $('organization identifier'))
+    .option('-a --certificate-administrator <certificate-administrator>', $('a JSON-formatted string containing a certificate administrator or an array of certificate administrators'))
+    .fileRelatedOption('-e --certificate-administrator-file <certificate-administrator-file>', $('a file containing a certificate administrator or an array of certificate administrator. Mutually exclusive with --certificate-administrator.'))
+    .option('--file <file>', $('the file to receive certificate organization object; the file must not exist otherwise the command fails'))
+    .execute(function(id, file, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        id: id,
+        file: file,
+        options: options
+      }));
+
+      options.id = options.id || id;
+      options.file = options.file || file;
+
+      ////////////////////////////////////////////
+      // Read certificate administrator         //
+      ////////////////////////////////////////////
+      var certificateAdministratorOptions = [options.certificateAdministrator, options.certificateAdministratorFile];
+      var certificateAdministratorOptionsProvided = certificateAdministratorOptions.filter(function (value) { return value !== undefined; }).length;
+      if (certificateAdministratorOptionsProvided > 1) {
+        throw new Error($('Specify exactly one of the --certificate-administrator, or --certificate-administrator-file options.'));
+      }
+
+      var certificateAdministrator;
+      if (options.certificateAdministratorFile) {
+        var jsonFile = fs.readFileSync(options.certificateAdministratorFile);
+        certificateAdministrator = jsonlint.parse(utils.stripBOM(jsonFile));
+      } else if (options.certificateAdministrator) {
+        certificateAdministrator = jsonlint.parse(options.certificateAdministrator);
+      }
+
+      // If certificateAdministrator is a single object,
+      // we need to wrap it as an array
+      if (!Array.isArray(certificateAdministrator)) {
+        certificateAdministrator = [ certificateAdministrator ];
+      }
+      ////////////////////////////////////////////
+      // Create certificate organization        //
+      ////////////////////////////////////////////
+      var certificateOrganization = {
+        id : options.id,
+        administratorDetails : certificateAdministrator
+      };
+
+      if (options.file) {
+        fs.writeFileSync(options.file, JSON.stringify(certificateOrganization), { flag: 'wx' });
+      }
+      else {
+        showCertificateOrganization(options, certificateOrganization);
+      }
+    });
+  /* jshint unused: true */
+
+  var certificateIssuer = cli.category('keyvault').category('certificate').category('issuer')
+    .description($('Commands to manage certificate issuers in the Azure Key Vault service'));
+
+  certificateIssuer.command('list [vault-name]')
+    .description($('Lists certificate issuers of a vault'))
+    .usage('[options] <vault-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .execute(function(vaultName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      ////////////////////////////////////////////
+      // Create the client and list certificate issuers. //
+      ////////////////////////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+      var certificateIssuers = [];
+      var progress = cli.interaction.progress(util.format($('Loading certificate issuers of vault %s'), options.vaultUri));
+      try {
+        var result = client.getCertificateIssuers(options.vaultUri, _);
+        if (result) {
+          certificateIssuers = result;
+
+          while (result && result.nextLink) {
+            log.verbose(util.format($('Found %d certificate issuers, loading more'), certificateIssuers.length));
+            result = client.getCertificatesNext(result.nextLink, _);
+            if (result) {
+              certificateIssuers = certificateIssuers.concat(result);
+            }
+          }
+        }
+      } finally {
+        progress.end();
+      }
+
+      log.table(certificateIssuers, showCertificateIssuerRow);
+      log.info(util.format($('Found %d certificate issuers'), certificateIssuers.length));
+    });
+
+  certificateIssuer.command('show [vault-name] [certificate-issuer-name]')
+    .description($('Shows a vault certificate issuer'))
+    .usage('[options] <vault-name> <certificate-issuer-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-issuer-name <certificate-issuer-name>', $('the certificate issuer name'))
+    .execute(function(vaultName, certificateIssuerName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateIssuerName: certificateIssuerName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateIssuerName = options.certificateIssuerName || certificateIssuerName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateIssuerName) {
+        return cli.missingArgument('certificate-issuer-name');
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificateIssuer;
+      var progress = cli.interaction.progress(util.format($('Getting certificate issuer %s'), options.certificateIssuerName));
+      try {
+        certificateIssuer = client.getCertificateIssuer(options.vaultUri, options.certificateIssuerName, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificateIssuer(options, certificateIssuer);
+    });
+
+  certificateIssuer.command('create [vault-name] [certificate-issuer-name] [provider-name]')
+    .description($('Creates a vault certificate issuer'))
+    .usage('[options] <vault-name> <certificate-issuer-name> <provider-name> ')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-issuer-name <certificate-issuer-name>', $('the certificate issuer name'))
+    .option('-p, --provider-name <provider-name>', $('the provider-name'))
+    .option('-a, --account-id <account-id>', $('account identifier'))
+    .option('-k, --api-key <api-key>', $('api key for the account'))
+    .option('-o, --certificate-organization <certificate-organization>', $('the certificate organization'))
+    .fileRelatedOption('-e --certificate-organization-file <certificate-organization-file>', $('a file containing the certificate organization. Mutually exclusive with --certificate-organization.'))
+    .execute(function(vaultName, certificateIssuerName, providerName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateIssuerName: certificateIssuerName,
+        providerName: providerName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateIssuerName = options.certificateIssuerName || certificateIssuerName;
+      options.providerName = options.providerName || providerName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateIssuerName) {
+        return cli.missingArgument('certificate-issuer-name');
+      }
+
+      if (!options.providerName) {
+          return cli.missingArgument('provider-name');
+      }
+
+      /////////////////////////////////////////////////
+      // Read the certificate organization           //
+      /////////////////////////////////////////////////
+
+      var certificateOrganizationOptions = [options.certificateOrganization, options.certificateOrganizationFile];
+      var certificateOrganizationOptionsProvided = certificateOrganizationOptions.filter(function (value) { return value !== undefined; }).length;
+      if (certificateOrganizationOptionsProvided > 1) {
+        throw new Error($('Specify exactly one of the --certificate-organization, or --certificate-organization-file options.'));
+      }
+
+      var certificateOrganization;
+      if (options.certificateOrganizationFile) {
+        var jsonFile = fs.readFileSync(options.certificateOrganizationFile);
+        certificateOrganization = jsonlint.parse(utils.stripBOM(jsonFile));
+      } else if (options.certificateOrganization) {
+        certificateOrganization = jsonlint.parse(options.certificateOrganization);
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+      var issuerBundle = {
+        credentials : {
+          accountId : options.accountId,
+          password : options.apiKey
+        },
+        organizationDetails : certificateOrganization
+      };
+
+      var certificateIssuer;
+      var progress = cli.interaction.progress(util.format($('Creating certificate issuer %s'), options.certificateIssuerName));
+      try {
+        certificateIssuer = client.setCertificateIssuer(options.vaultUri, options.certificateIssuerName, options.providerName, issuerBundle, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificateIssuer(options, certificateIssuer);
+    });
+
+  certificateIssuer.command('delete [vault-name] [certificate-issuer-name]')
+    .description($('Deletes a certificate issuer from the vault'))
+    .usage('[options] <vault-name> <certificate-issuer-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-c, --certificate-issuer-name <certificate-issuer-name>', $('the certificate issuer name'))
+    .option('-q, --quiet', $('quiet mode (do not ask for delete confirmation)'))
+    .execute(function(vaultName, certificateIssuerName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        certificateIssuerName: certificateIssuerName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.certificateIssuerName = options.certificateIssuerName || certificateIssuerName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.certificateIssuerName) {
+        return cli.missingArgument('certificate-issuer-name');
+      }
+
+      if (!options.quiet && !cli.interaction.confirm(util.format($('Delete certificate issuer %s from vault %s? [y/n] '), options.certificateIssuerName, options.vaultName), _)) {
+        throw new Error($('Aborted by user'));
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var certificateIssuer;
+      var progress = cli.interaction.progress(util.format($('Deleting certificate issuer %s in vault %s'), options.certificateIssuerName, options.vaultName));
+      try {
+        certificateIssuer = client.deleteCertificateIssuer(options.vaultUri, options.certificateIssuerName, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificateIssuer(options, certificateIssuer);
+    });
+
+  var certificateContact = cli.category('keyvault').category('certificate').category('contact')
+    .description($('Commands to manage certificate contacts in the Azure Key Vault service'));
+
+  certificateContact.command('list [vault-name]')
+    .description($('List vault certificate contacts'))
+    .usage('[options] <vault-name>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .execute(function(vaultName, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+      
+      var certificateContacts;
+      var progress = cli.interaction.progress(util.format($('Getting certificate contacts for vault %s'), options.vaultUri));
+      try {
+        certificateContacts = client.getCertificateContacts(options.vaultUri, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificateContacts(options, certificateContacts);
+    });
+
+  certificateContact.command('add [vault-name] [email-address]')
+    .description($('Adds a certificate contact to the vault'))
+    .usage('[options] <vault-name> <email-address>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-e, --email-address <email-address>', $('the contact email address'))
+    .execute(function(vaultName, emailAddress, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        emailAddress: emailAddress,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.emailAddress = options.emailAddress || emailAddress;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.emailAddress) {
+        return cli.missingArgument('email-address');
+      }
+      
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var currentCertificateContacts, certificateContacts;
+      var progress = cli.interaction.progress(util.format($('Adding certificate contact with email address %s in vault %s'), options.emailAddress, options.vaultName));
+      try {
+        currentCertificateContacts = client.getCertificateContacts(options.vaultUri, _);
+      }
+      catch (ex) {
+        if (ex.statusCode === null || ex.statusCode != 404) {
+          throw (ex);
+        }
+        
+        currentCertificateContacts = { };
+      }
+
+      try {
+        if (currentCertificateContacts.contactList === undefined || currentCertificateContacts.contactList === null) {
+          currentCertificateContacts.contactList = [{ emailAddress: options.emailAddress}];
+        }
+        else {
+          if (currentCertificateContacts.contactList.some(function(e) { return e.emailAddress.toUpperCase() == options.emailAddress.toUpperCase(); })) {
+            throw new Error(util.format($('Certificate contact with email address %s already present'), options.emailAddress));
+          }
+
+          currentCertificateContacts.contactList.push({ emailAddress: options.emailAddress});
+        }
+
+        certificateContacts = client.setCertificateContacts(options.vaultUri, currentCertificateContacts, _);
+      } finally {
+        progress.end();
+      }
+
+      showCertificateContacts(options, certificateContacts);
+    });
+
+  certificateContact.command('delete [vault-name] [email-address]')
+    .description($('Deletes a certificate contact from the vault'))
+    .usage('[options <vault-name> <email-address>')
+    .option('-u, --vault-name <vault-name>', $('the vault name'))
+    .option('-e, --email-address <email-address>', $('the email address'))
+    .option('-q, --quiet', $('quiet mode (do not ask for delete confirmation)'))
+    .execute(function(vaultName, emailAddress, options, _) {
+
+      ///////////////////////
+      // Parse arguments.  //
+      ///////////////////////
+
+      log.verbose('arguments: ' + JSON.stringify({
+        vaultName: vaultName,
+        emailAddress: emailAddress,
+        options: options
+      }));
+
+      options.vaultName = options.vaultName || vaultName;
+      options.emailAddress = options.emailAddress || emailAddress;
+
+      if (!options.vaultName) {
+        return cli.missingArgument('vault-name');
+      }
+
+      if (!options.emailAddress) {
+        return cli.missingArgument('certificate-name');
+      }
+
+      if (!options.quiet && !cli.interaction.confirm(util.format($('Delete certificate contact %s from vault %s? [y/n] '), options.emailAddress, options.vaultName), _)) {
+        throw new Error($('Aborted by user'));
+      }
+
+      /////////////////////////
+      // Send the request.   //
+      /////////////////////////
+
+      options.vaultUri = createVaultUri(options);
+      var client = createClient(options);
+
+      var currentCertificateContacts;
+      var progress = cli.interaction.progress(util.format($('Deleting certificate contact with email address %s in vault %s'), options.emailAddress, options.vaultName));
+      try {
+        currentCertificateContacts = client.getCertificateContacts(options.vaultUri, _);
+        if (currentCertificateContacts.contactList === null) {
+          throw new Error(util.format($('Certificate contact with email address %s not found'), options.emailAddress));
+        }
+
+        var index = currentCertificateContacts.contactList.findIndex(
+          function(e) { return e.emailAddress.toUpperCase() == options.emailAddress.toUpperCase(); });
+
+        if (index == -1) {
+            throw new Error(util.format($('Certificate contact with email address %s not found'), options.emailAddress));
+        }
+
+        currentCertificateContacts.contactList.splice(index, 1);
+        if (currentCertificateContacts.contactList.length > 0) {
+          client.setCertificateContacts(options.vaultUri, currentCertificateContacts, _);
+        }
+        else {
+          client.deleteCertificateContacts(options.vaultUri, _);
+        }
+      } finally {
+        progress.end();
+      }
+    });
+
+  function createVaultUri(options) {
+    var subscription = profile.current.getSubscription(options.subscription);
+    return 'https://' + options.vaultName + subscription.keyVaultDnsSuffix;
+  }
+
+  function createClient(options) {
+    var subscription = profile.current.getSubscription(options.subscription);
+    log.verbose(util.format($('Using subscription %s (%s)'), subscription.name, subscription.id));
+    return utils.createKeyVaultClient(subscription);
+  }
+
+  function getCertificateIdentifier(options) {
+    var id = options.vaultUri + '/certificates/' + options.certificateName;
+    if (options.certificateVersion) {
+      id += '/' + options.certificateVersion;
+    }
+    return id;
+  }
+
+  function getCertificateVersions(client, vaultUri, certificateName, _) {
+
+    log.verbose(util.format($('Loading versions of certificate %s'), certificateName));
+
+    var certificates = [];
+    var result = client.getCertificateVersions(vaultUri, certificateName, _);
+    if (result) {
+      certificates = result;
+
+      while (result && result.nextLink) {
+        log.verbose(util.format($('Found %d versions, loading more'), certificates.length));
+        result = client.getCertificateVersionsNext(result.nextLink, _);
+        if (result) {
+          certificates = certificates.concat(result);
+        }
+      }
+    }
+
+    return certificates;
+  }
+
+  function showCertificate(options, certificate) {
+    if (certificate.cer) {
+      certificate.cer = kvUtils.bufferToBase64(certificate.cer);
+    }
+
+    if (certificate.x509Thumbprint) {
+      certificate.x509Thumbprint = kvUtils.bufferToHex(certificate.x509Thumbprint);
+    }
+
+    cli.interaction.formatOutput(certificate, function(certificate) {
+      certificate.attributes = kvUtils.getAttributesWithPrettyDates(certificate.attributes);
+      utils.logLineFormat(certificate, log.data);
+    });
+  }
+
+  function showCertificateRow(row, item) {
+    var identifier = kvUtils.parseCertificateIdentifier(item.id);
+    // The vault is the same, so we don't show.
+    // row.cell($('Vault'), identifier.vaultUri);
+    row.cell($('Name'), identifier.name);
+    if (identifier.version) {
+      row.cell($('Version'), identifier.version);
+    }
+    row.cell($('Enabled'), item.attributes.enabled);
+    var attributes = kvUtils.getAttributesWithPrettyDates(item.attributes);
+    row.cell($('Not Before'), attributes.notBefore || '');
+    row.cell($('Expires'), attributes.expires || '');
+    row.cell($('Created'), attributes.created);
+    row.cell($('Updated'), attributes.updated);
+    row.cell($('Tags'), kvUtils.getTagsInfo(item.tags));
+  }
+
+  function showCertificatePolicy(options, certificatePolicy) {
+    cli.interaction.formatOutput(certificatePolicy, function(certificatePolicy) {
+      utils.logLineFormat(certificatePolicy, log.data);
+    });
+  }
+
+  function showCertificateOperation(options, certificateOperation) {
+    certificateOperation.csr = kvUtils.bufferToBase64(certificateOperation.csr);
+    cli.interaction.formatOutput(certificateOperation, function(certificateOperation) {
+      certificateOperation.attributes = kvUtils.getAttributesWithPrettyDates(certificateOperation.attributes);
+      utils.logLineFormat(certificateOperation, log.data);
+    });
+  }
+
+  function showCertificateAdministrator(options, certificateAdministrator) {
+    cli.interaction.formatOutput(certificateAdministrator, function(certificateAdministrator) {
+      utils.logLineFormat(certificateAdministrator, log.data);
+    });
+  }
+
+  function showCertificateOrganization(options, certificateOrganization) {
+    cli.interaction.formatOutput(certificateOrganization, function(certificateOrganization) {
+      utils.logLineFormat(certificateOrganization, log.data);
+    });
+  }
+
+  function showCertificateIssuer(options, certificateIssuer) {
+    cli.interaction.formatOutput(certificateIssuer, function(certificateIssuer) {
+      certificateIssuer.attributes = kvUtils.getAttributesWithPrettyDates(certificateIssuer.attributes);
+      utils.logLineFormat(certificateIssuer, log.data);
+    });
+  }
+
+  function showCertificateIssuerRow(row, item) {
+    var identifier = kvUtils.parseCertificateIssuerIdentifier(item.id);
+    row.cell($('Name'), identifier.name);
+    row.cell($('Provider'), item.provider);
+  }
+
+  function showCertificateContacts(options, certificateContacts) {
+    var contactList = certificateContacts.contactList;
+    cli.interaction.formatOutput(contactList, function(contactList) {
+      utils.logLineFormat(contactList, log.data);
+    });
+  }
+};

--- a/lib/commands/arm/keyvault/keyvault.key._js
+++ b/lib/commands/arm/keyvault/keyvault.key._js
@@ -26,7 +26,6 @@ var forge = require('node-forge');
 var profile = require('../../../util/profile');
 var utils = require('../../../util/utils');
 var kvUtils = require('./kv-utils');
-var kvLegacy = require('./kv-legacy');
 
 var $ = utils.getLocaleString;
 
@@ -46,7 +45,7 @@ exports.init = function(cli) {
 
   key.command('list [vault-name]')
     .description($('Lists keys of a vault'))
-    .usage('[--vault-name] <vault-name> [options]')
+    .usage('[options] <vault-name>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .execute(function(vaultName, options, _) {
 
@@ -69,21 +68,23 @@ exports.init = function(cli) {
       // Create the client and list keys.       //
       ////////////////////////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
       var keys = [];
       var progress = cli.interaction.progress(util.format($('Loading keys of vault %s'), options.vaultUri));
       try {
-        var result = client.keys.list(options.vaultUri, null, _);
-        for (;;) {
-          if (result.value && result.value.length) {
-            keys = keys.concat(result.value);
+        var result = client.getKeys(options.vaultUri, null, _);
+        if (result) {
+          keys = result;
+
+          while (result && result.nextLink) {
+            log.verbose(util.format($('Found %d keys, loading more'), keys.length));
+            result = client.getKeysNext(result.nextLink, _);
+            if (result) {
+              keys = keys.concat(result);
+            }
           }
-          if (!result.nextLink) {
-            break;
-          }
-          log.verbose(util.format($('Found %d keys, loading more'), keys.length));
-          result = client.keys.listNext(result.nextLink, _);
         }
       } finally {
         progress.end();
@@ -95,7 +96,7 @@ exports.init = function(cli) {
 
   key.command('list-versions [vault-name] [key-name]')
     .description($('Lists key versions'))
-    .usage('[--vault-name] <vault-name> [[--key-name] <key-name>] [options]')
+    .usage('[options] <vault-name> [key-name>]')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-k, --key-name <key-name>', $('lists only versions of this key'))
     .execute(function(vaultName, keyName, options, _) {
@@ -121,29 +122,34 @@ exports.init = function(cli) {
       // Create the client and list keys.       //
       ////////////////////////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
-      var keys;
+      var keys, keyIdentifier, keyVersions;
       var progress;
       if (!options.keyName) {
         keys = [];
         progress = cli.interaction.progress(util.format($('Loading keys of vault %s'), options.vaultUri));
         try {
-          var result = client.keys.list(options.vaultUri, null, _);
-          for (;;) {
-            var items = result.value;
-            if (items && items.length) {
-              for (var i = 0; i < items.length; ++i) {
-                var keyIdentifier = kvUtils.parseKeyIdentifier(items[i].kid);
-                var keyVersions = getKeyVersions(client, keyIdentifier.vaultUri, keyIdentifier.name, _);
-                keys = keys.concat(keyVersions);
+          var result = client.getKeys(options.vaultUri, null, _);
+          if (result && result.length) {
+            for (var i = 0; i < result.length; ++i) {
+              keyIdentifier = kvUtils.parseKeyIdentifier(result[i].kid);
+              keyVersions = getKeyVersions(client, keyIdentifier.vaultUri, keyIdentifier.name, _);
+              keys = keys.concat(keyVersions);
+            }
+
+            while (result && result.nextLink) {
+              log.verbose(util.format($('Found %d keys, loading more'), keys.length));
+              result = client.getKeysNext(result.nextLink, _);
+              if (result && result.length) {
+                for (var j = 0; j < result.length; ++j) {
+                  keyIdentifier = kvUtils.parseKeyIdentifier(result[j].kid);
+                  keyVersions = getKeyVersions(client, keyIdentifier.vaultUri, keyIdentifier.name, _);
+                  keys = keys.concat(keyVersions);
+                }
               }
             }
-            if (!result.nextLink) {
-              break;
-            }
-            log.verbose(util.format($('Found %d keys, loading more'), keys.length));
-            result = client.keys.listNext(result.nextLink, _);
           }
         } finally {
           progress.end();
@@ -163,13 +169,13 @@ exports.init = function(cli) {
 
   key.command('create [vault-name] [key-name]')
     .description($('Creates a key in the vault'))
-    .usage('[--vault-name] <vault-name> [--key-name] <key-name> --destination <destination> [options]')
+    .usage('[options] <vault-name> <key-name>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-k, --key-name <key-name>', $('name of the key to be created; if already exists, a new key version is generated'))
     .option('-d, --destination <destination>', util.format($('tells if the key is software-protected or HSM-protected; valid values: [%s]'), KEY_DESTS.join(', ')))
     .option('--enabled <boolean>', $('tells if the key should be enabled; valid values: [false, true]; default is true'))
-    .option('-e, --expires <datetime>', $('key expiration time, expressed as Unix Time integer, or ISO 8601 date format'))
-    .option('-n, --not-before <datetime>', $('time before which key cannot be used, expressed as Unix Time integer, or ISO 8601 date format'))
+    .option('-e, --expires <datetime>', $('key expiration time, expressed in RFC-1123/ISO8601 date format'))
+    .option('-n, --not-before <datetime>', $('time before which key cannot be used, expressed in RFC-1123/ISO8601 date format'))
     .option('-o, --key-ops <key-ops>', util.format($('JSON-encoded array of strings representing key operations; each string can be one of [%s]'), KEY_OPS.join(', ')))
     .option('-t, --tags <tags>', $('Tags to set on the key. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
     .execute(function(vaultName, keyName, options, _) {
@@ -186,26 +192,26 @@ exports.init = function(cli) {
       // Perform the request.                        //
       /////////////////////////////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
-      var request = {
-        kty: options.kty,
-        key_ops: options.keyOps,
-        attributes: {
+      var requestOptions = {
+        keyOps: options.keyOps,
+        keyAttributes: {
           enabled: options.enabled,
-          nbf: options.notBefore,
-          exp: options.expires
+          notBefore: options.notBefore,
+          expires: options.expires
         },
         tags: options.tags
       };
 
-      log.verbose('request: ' + JSON.stringify(request));
+      log.verbose('request options: ' + JSON.stringify(requestOptions));
 
       var key;
       var keyIdentifier = getKeyIdentifier(options);
       var progress = cli.interaction.progress(util.format($('Creating key %s'), keyIdentifier));
       try {
-        key = client.keys.create(options.vaultUri, options.keyName, request, _);
+        key = client.createKey(options.vaultUri, options.keyName, options.kty, requestOptions, _);
       } finally {
         progress.end();
       }
@@ -215,7 +221,7 @@ exports.init = function(cli) {
 
   key.command('import [vault-name] [key-name]')
     .description($('Imports an existing key into a vault'))
-    .usage('[--vault-name] <vault-name> [--key-name] <key-name> ( --pem-file | --byok-file ) <file-name> [--destination <destination>] [options]')
+    .usage('[options] <vault-name> <key-name>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-k, --key-name <key-name>', $('name of the key to be imported; if already exists, a new key version is generated'))
     .option('--pem-file <file-name>', $('name of a PEM file containing the key to be imported; the file must not be password protected'))
@@ -223,8 +229,8 @@ exports.init = function(cli) {
     .option('-p, --password <password>', $('password of key file; if not informed and the file is encrypted, will prompt'))
     .option('-d, --destination <destination>', util.format($('tells if the key is software-protected or HSM-protected; valid values: [%s]'), KEY_DESTS.join(', ')))
     .option('--enabled <boolean>', $('tells if the key should be enabled; valid values: [false, true]; default is true'))
-    .option('-e, --expires <datetime>', $('key expiration time, expressed as Unix Time integer, or ISO 8601 date format'))
-    .option('-n, --not-before <datetime>', $('time before which key cannot be used, expressed as Unix Time integer, or ISO 8601 date format'))
+    .option('-e, --expires <datetime>', $('key expiration time, expressed in RFC-1123/ISO8601 date format'))
+    .option('-n, --not-before <datetime>', $('time before which key cannot be used, expressed in RFC-1123/ISO8601 date format'))
     .option('-o, --key-ops <key-ops>', util.format($('JSON-encoded array of strings representing key operations; each string can be one of [%s]'), KEY_OPS.join(', ')))
     .option('-t, --tags <tags>', $('Tags to set on the key. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
     .execute(function(vaultName, keyName, options, _) {
@@ -249,22 +255,23 @@ exports.init = function(cli) {
       }
 
       if (options.byokFile && options.destination && !options.hsm) {
-        log.error(util.format($('Value of parameter --destination (%s) is incompatible with input key type (BYOK).'), options.destination));
+        throw new Error(util.format($('Value of parameter --destination (%s) is incompatible with input key type (BYOK).'), options.destination));
       }
 
       /////////////////////////////////////////////////
       // Read the file and build the request.        //
       /////////////////////////////////////////////////
 
-      var request = {
-        key: {
-          key_ops: options.keyOps,
-        },
+      var requestKey = {
+        keyOps: options.keyOps,
+      };
+
+      var requestOptions = {
         hsm: options.hsm,
-        attributes: {
+        keyAttributes: {
           enabled: options.enabled,
-          nbf: options.notBefore,
-          exp: options.expires
+          notBefore: options.notBefore,
+          expires: options.expires
         },
         tags: options.tags
       };
@@ -273,7 +280,7 @@ exports.init = function(cli) {
       var keyFile;
       if (options.pemFile) {
 
-        request.key.kty = 'RSA';
+        requestKey.kty = 'RSA';
         log.verbose('reading ' + options.pemFile);
         data = fs.readFileSync(options.pemFile);
         var keyInfo;
@@ -290,16 +297,15 @@ exports.init = function(cli) {
         }
 
         log.verbose('setting RSA parameters from PEM data');
-        setRsaParameters(request.key, keyInfo);
+        setRsaParameters(requestKey, keyInfo);
         keyFile = options.pemFile;
 
       } else {
 
-        request.key.kty = 'RSA-HSM';
+        requestKey.kty = 'RSA-HSM';
         log.verbose('reading ' + options.byokFile);
-        data = fs.readFileSync(options.byokFile);
         log.verbose('setting BYOK parameters from file');
-        setHsmParameters(request.key, data);
+        requestKey.t = fs.readFileSync(options.byokFile);
         keyFile = options.byokFile;
 
         if (options.password) {
@@ -312,15 +318,15 @@ exports.init = function(cli) {
       // Send the request.                           //
       /////////////////////////////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
-      log.verbose('request: ' + JSON.stringify(request, null, ' '));
+      log.verbose('request options: ' + JSON.stringify(requestOptions, null, ' '));
 
       var key;
-      var keyIdentifier = getKeyIdentifier(options);
-      var progress = cli.interaction.progress(util.format($('Importing file %s into %s'), keyFile, keyIdentifier));
+      var progress = cli.interaction.progress(util.format($('Importing file %s into key %s'), keyFile, options.keyName));
       try {
-        key = client.keys.importMethod(keyIdentifier, request, _);
+        key = client.importKey(options.vaultUri, options.keyName, requestKey, requestOptions, _);
       } finally {
         progress.end();
       }
@@ -330,13 +336,13 @@ exports.init = function(cli) {
 
   key.command('set-attributes [vault-name] [key-name] [key-version]')
     .description($('Changes attributes of an existing key'))
-    .usage('[--vault-name] <vault-name> [--key-name] <key-name> [[--key-version] <key-version>] [options]')
+    .usage('[options] <vault-name> <key-name> [key-version]')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-k, --key-name <key-name>', $('name of the key to be modified'))
-    .option('-r, --key-version <key-version>', $('the version to be modified; if ommited, modifies only the most recent'))
+    .option('-r, --key-version <key-version>', $('the version to be modified; if omited, modifies only the most recent'))
     .option('--enabled <boolean>', $('if informed, command will change the enabled state; valid values: [false, true]'))
-    .option('-e, --expires <datetime>', $('if informed, command will change secret expiration time; expressed as Unix Time integer, or ISO 8601 date format, or null to clear the value'))
-    .option('-n, --not-before <datetime>', $('if informed, command will change time before which secret cannot be used; expressed as Unix Time integer, or ISO 8601 date format, or null to clear the value'))
+    .option('-e, --expires <datetime>', $('if informed, command will change secret expiration time; expressed in RFC-1123/ISO8601 date format, or null to clear the value'))
+    .option('-n, --not-before <datetime>', $('if informed, command will change time before which secret cannot be used; expressed in RFC-1123/ISO8601 date format, or null to clear the value'))
     .option('-o, --key-ops <key-ops>', util.format($('if informed, command will change valid operations; must be JSON-encoded array of strings representing key operations; each string can be one of [%s]'), KEY_OPS.join(', ')))
     .option('-t, --tags <tags>', $('Tags to set on the key. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
     .option('--reset-tags', $('remove previously existing tags; can combined with --tags'))
@@ -362,6 +368,7 @@ exports.init = function(cli) {
       // Deal with tags. Load existing vault, if needed.  //
       //////////////////////////////////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
       var key;
@@ -375,7 +382,7 @@ exports.init = function(cli) {
 
           // We must read existing tags and add the new ones.
           log.info(util.format($('Getting key %s'), keyIdentifier));
-          key = client.keys.get(keyIdentifier, _);
+          key = client.getKey(keyIdentifier, _);
           var currentTags = key.tags;
           if (!currentTags) {
             // Defend against undefined.
@@ -404,13 +411,13 @@ exports.init = function(cli) {
       ////////////////////////////////////////////////////////////
 
       var request = {
-        attributes: {}
+        keyAttributes: {}
       };
 
-      if (informed.keyOps) request.key_ops = options.keyOps;
-      if (informed.enabled) request.attributes.enabled = options.enabled;
-      if (informed.notBefore) request.attributes.nbf = options.notBefore;
-      if (informed.expires) request.attributes.exp = options.expires;
+      if (informed.keyOps) request.keyOps = options.keyOps;
+      if (informed.enabled) request.keyAttributes.enabled = options.enabled;
+      if (informed.notBefore) request.keyAttributes.notBefore = options.notBefore;
+      if (informed.expires) request.keyAttributes.expires = options.expires;
       if (informed.tags) request.tags = options.tags;
 
       /////////////////////////////////////////////////
@@ -421,7 +428,7 @@ exports.init = function(cli) {
 
       var progress = cli.interaction.progress(util.format($('Updating key %s'), keyIdentifier));
       try {
-        key = client.keys.update(keyIdentifier, request, _);
+        key = client.updateKey(keyIdentifier, request, _);
       } finally {
         progress.end();
       }
@@ -431,10 +438,10 @@ exports.init = function(cli) {
 
   key.command('show [vault-name] [key-name] [key-version]')
     .description($('Shows properties of a vault key'))
-    .usage('[--vault-name] <vault-name> [--key-name] <key-name> [[--key-version] <key-version>] [options]')
+    .usage('[options] <vault-name> <key-name> [key-version]')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-k, --key-name <key-name>', $('the key name'))
-    .option('-r, --key-version <key-version>', $('the key version; if ommited, uses the most recent'))
+    .option('-r, --key-version <key-version>', $('the key version; if omited, uses the most recent'))
     .execute(function(vaultName, keyName, keyVersion, options, _) {
 
       ///////////////////////
@@ -464,12 +471,13 @@ exports.init = function(cli) {
       // Send the request.   //
       /////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
       var keyIdentifier = getKeyIdentifier(options);
       var progress = cli.interaction.progress(util.format($('Getting key %s'), keyIdentifier));
       try {
-        key = client.keys.get(keyIdentifier, _);
+        key = client.getKey(keyIdentifier, _);
       } finally {
         progress.end();
       }
@@ -479,11 +487,10 @@ exports.init = function(cli) {
 
   key.command('delete [vault-name] [key-name]')
     .description($('Deletes a key from the vault'))
-    .usage('[--vault-name] <vault-name> [--key-name] <key-name> [options]')
+    .usage('[options] <vault-name> <key-name>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-k, --key-name <key-name>', $('the key name'))
     .option('-q, --quiet', $('quiet mode (do not ask for delete confirmation)'))
-    .option('-p, --pass-thru', $('outputs the deleted key'))
     .execute(function(vaultName, keyName, options, _) {
 
       ///////////////////////
@@ -515,25 +522,24 @@ exports.init = function(cli) {
       // Send the request.   //
       /////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
       var key;
       var keyIdentifier = getKeyIdentifier(options);
       var progress = cli.interaction.progress(util.format($('Deleting key %s'), keyIdentifier));
       try {
-        key = client.keys.deleteKey(options.vaultUri, options.keyName, _);
+        key = client.deleteKey(options.vaultUri, options.keyName, _);
       } finally {
         progress.end();
       }
 
-      if (options.passThru) {
-        showKey(key);
-      }
+      showKey(key);
     });
 
   key.command('backup [vault-name] [key-name] [output-file]')
     .description($('Generates a protected backup of a vault key'))
-    .usage('[--vault-name] <vault-name> [--key-name] <key-name> [--output-file] <output-file> [options]')
+    .usage('[options] <vault-name> <key-name> <output-file>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-k, --key-name <key-name>', $('the key name'))
     .option('-f, --output-file <output-file>', $('name of the binary file that will contain backup data'))
@@ -570,26 +576,26 @@ exports.init = function(cli) {
       // Send the request.   //
       /////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
       var blob;
       var keyIdentifier = getKeyIdentifier(options);
       var progress = cli.interaction.progress(util.format($('Requesting a backup blob for key %s'), keyIdentifier));
       try {
-        blob = client.keys.backup(keyIdentifier, _);
+        blob = client.backupKey(options.vaultUri, options.keyName, _);
+        //console.log(JSON.stringify(blob));
       } finally {
         progress.end();
       }
 
-      var data = kvUtils.base64UrlToBuffer(blob.value);
-
       log.info(util.format($('Writing file %s'), options.outputFile));
-      fs.writeFileSync(options.outputFile, data);
+      fs.writeFileSync(options.outputFile, blob.value);
     });
 
   key.command('restore [vault-name] [input-file]')
     .description($('Restores a backed up key to a vault'))
-    .usage('[--vault-name] <vault-name> [--input-file] <input-file> [options]')
+    .usage('[options] <vault-name> <input-file>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-f, --input-file <input-file>', $('name of the binary file that contains backup data'))
     .execute(function(vaultName, inputFile, options, _) {
@@ -622,18 +628,13 @@ exports.init = function(cli) {
       log.info(util.format($('Reading file %s'), options.inputFile));
       var buffer = fs.readFileSync(options.inputFile);
 
-      var request = {
-        value: kvUtils.bufferToBase64Url(buffer)
-      };
-
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
-
-      log.verbose('request: ' + JSON.stringify(request, null, ' '));
 
       var key;
       var progress = cli.interaction.progress(util.format($('Restoring key into vault %s'), options.vaultUri));
       try {
-        key = client.keys.restore(options.vaultUri, request, _);
+        key = client.restoreKey(options.vaultUri, buffer, _);
       } finally {
         progress.end();
       }
@@ -642,13 +643,15 @@ exports.init = function(cli) {
 
     });
 
+  function createVaultUri(options) {
+    var subscription = profile.current.getSubscription(options.subscription);
+    return 'https://' + options.vaultName + subscription.keyVaultDnsSuffix;
+  }
+
   function createClient(options) {
     var subscription = profile.current.getSubscription(options.subscription);
     log.verbose(util.format($('Using subscription %s (%s)'), subscription.name, subscription.id));
-    options.vaultUri = 'https://' + options.vaultName + subscription.keyVaultDnsSuffix;
-    var newClient = utils.createKeyVaultClient(subscription, options.vaultUri);
-    // The new client returns high-level objects, we need low-level JSON objects for CLI.
-    return new kvLegacy.KeyVaultClient(newClient._internalClient);
+    return utils.createKeyVaultClient(subscription);
   }
   
   function isPemEncrypted(pem) {
@@ -709,8 +712,6 @@ exports.init = function(cli) {
       options.hsm = false;
     }
 
-    options.expires = kvUtils.parseDateArgument('expires', options.expires, null);
-    options.notBefore = kvUtils.parseDateArgument('not-before', options.notBefore, null);
     options.keyOps = kvUtils.parseArrayArgument('key-ops', options.keyOps, KEY_OPS, []);
     options.enabled = kvUtils.parseBooleanArgument('enabled', options.enabled, true);
     options.tags = kvUtils.parseTagsArgument('tags', options.tags);
@@ -722,26 +723,28 @@ exports.init = function(cli) {
     log.verbose(util.format($('Loading versions of key %s'), keyName));
 
     var keys = [];
-    var result = client.keys.listVersions(vaultUri, keyName, null, _);
-    for (;;) {
-      var items = result.value;
-      if (items && items.length) {
-        keys = keys.concat(items);
-      }
-      if (!result.nextLink) {
-        break;
-      }
-      log.verbose(util.format($('Found %d versions, loading more'), keys.length));
-      result = client.keys.listVersionsNext(result.nextLink, _);
-    }
+    var result = client.getKeyVersions(vaultUri, keyName, null, _);
+    if (result) {
+      keys = result;
 
+      while (result && result.nextLink) {
+        log.verbose(util.format($('Found %d versions, loading more'), keys.length));
+        result = client.getKeyVersionsNext(result.nextLink, _);
+        if (result) {
+          keys = keys.concat(result);
+        }
+      }
+    }
     return keys;
   }
 
   function showKey(key) {
+    key.key.n = kvUtils.bufferToBase64Url(key.key.n);
+    key.key.e = kvUtils.bufferToBase64Url(key.key.e);
+
     cli.interaction.formatOutput(key, function(key) {
       key.attributes = kvUtils.getAttributesWithPrettyDates(key.attributes);
-      utils.logLineFormat(key, log.data);      
+      utils.logLineFormat(key, log.data);
     });
   }
 
@@ -755,25 +758,24 @@ exports.init = function(cli) {
     }
     row.cell($('Enabled'), item.attributes.enabled);
     var attributes = kvUtils.getAttributesWithPrettyDates(item.attributes);
-    row.cell($('Not Before'), attributes.nbf || '');
-    row.cell($('Expires'), attributes.exp || '');
+    row.cell($('Not Before'), attributes.notBefore || '');
+    row.cell($('Expires'), attributes.expires || '');
     row.cell($('Created'), attributes.created);
     row.cell($('Updated'), attributes.updated);
   }
 
   function setRsaParameters(dest, key) {
-    dest.n = bigIntegerToBase64Url(key.n);
-    dest.e = bigIntegerToBase64Url(key.e);
-    dest.d = bigIntegerToBase64Url(key.d);
-    dest.p = bigIntegerToBase64Url(key.p);
-    dest.q = bigIntegerToBase64Url(key.q);
-    dest.dp = bigIntegerToBase64Url(key.dP);
-    dest.dq = bigIntegerToBase64Url(key.dQ);
-    dest.qi = bigIntegerToBase64Url(key.qInv);
+    dest.n = bigIntegerToBuffer(key.n);
+    dest.e = bigIntegerToBuffer(key.e);
+    dest.d = bigIntegerToBuffer(key.d);
+    dest.p = bigIntegerToBuffer(key.p);
+    dest.q = bigIntegerToBuffer(key.q);
+    dest.dp = bigIntegerToBuffer(key.dP);
+    dest.dq = bigIntegerToBuffer(key.dQ);
+    dest.qi = bigIntegerToBuffer(key.qInv);
   }
 
-  function bigIntegerToBase64Url(n) {
-
+  function bigIntegerToBuffer(n) {
     // Convert to binary and remove leading zeroes.
     var data = n.toByteArray();
     var leadingZeroes = 0;
@@ -784,12 +786,6 @@ exports.init = function(cli) {
       data = data.slice(leadingZeroes);
     }
 
-    var buffer = new Buffer(data);
-    return kvUtils.bufferToBase64Url(buffer);
+    return new Buffer(data);
   }
-
-  function setHsmParameters(dest, byokBlob) {
-    dest.key_hsm = kvUtils.bufferToBase64Url(byokBlob);
-  }
-
 };

--- a/lib/commands/arm/keyvault/keyvault.secret._js
+++ b/lib/commands/arm/keyvault/keyvault.secret._js
@@ -24,7 +24,6 @@ var fs = require('fs');
 var profile = require('../../../util/profile');
 var utils = require('../../../util/utils');
 var kvUtils = require('./kv-utils');
-var kvLegacy = require('./kv-legacy');
 
 var $ = utils.getLocaleString;
 
@@ -40,7 +39,7 @@ exports.init = function(cli) {
 
   secret.command('list [vault-name]')
     .description($('Lists secrets of a vault'))
-    .usage('[--vault-name] <vault-name> [options]')
+    .usage('[options] <vault-name>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .execute(function(vaultName, options, _) {
 
@@ -63,21 +62,22 @@ exports.init = function(cli) {
       // Create the client and list secrets.       //
       ////////////////////////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
-
       var secrets = [];
       var progress = cli.interaction.progress(util.format($('Loading secrets of vault %s'), options.vaultUri));
       try {
-        var result = client.secrets.list(options.vaultUri, null, _);
-        for (;;) {
-          if (result.value && result.value.length) {
-            secrets = secrets.concat(result.value);
+        var result = client.getSecrets(options.vaultUri, null, _);
+        if (result) {
+          secrets = result;
+
+          while (result && result.nextLink) {
+            log.verbose(util.format($('Found %d secrets, loading more'), secrets.length));
+            result = client.getSecretsNext(result.nextLink, _);
+            if (result) {
+              secrets = secrets.concat(result);
+            }
           }
-          if (!result.nextLink) {
-            break;
-          }
-          log.verbose(util.format($('Found %d secrets, loading more'), secrets.length));
-          result = client.secrets.listNext(result.nextLink, _);
         }
       } finally {
         progress.end();
@@ -90,7 +90,7 @@ exports.init = function(cli) {
 
   secret.command('list-versions [vault-name] [secret-name]')
     .description($('Lists secret versions'))
-    .usage('[--vault-name] <vault-name> [[--secret-name] <secret-name>] [options]')
+    .usage('[options] <vault-name> [secret-name]')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-s, --secret-name <secret-name>', $('lists only versions of this secret'))
     .execute(function(vaultName, secretName, options, _) {
@@ -116,29 +116,34 @@ exports.init = function(cli) {
       // Create the client and list secrets.       //
       ////////////////////////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
-      var secrets;
+      var secrets, secretIdentifier, secretVersions; 
       var progress;
       if (!options.secretName) {
         secrets = [];
         progress = cli.interaction.progress(util.format($('Loading secrets of vault %s'), options.vaultUri));
         try {
-          var result = client.secrets.list(options.vaultUri, null, _);
-          for (;;) {
-            var items = result.value;
-            if (items && items.length) {
-              for (var i = 0; i < items.length; ++i) {
-                var secretIdentifier = kvUtils.parseSecretIdentifier(items[i].id);
-                var secretVersions = getSecretVersions(client, secretIdentifier.vaultUri, secretIdentifier.name, _);
-                secrets = secrets.concat(secretVersions);
+          var result = client.getSecrets(options.vaultUri, null, _);
+          if (result && result.length) {
+            for (var i = 0; i < result.length; ++i) {
+              secretIdentifier = kvUtils.parseSecretIdentifier(result[i].id);
+              secretVersions = getSecretVersions(client, secretIdentifier.vaultUri, secretIdentifier.name, _);
+              secrets = secrets.concat(secretVersions);
+            }
+
+            while (result && result.nextLink) {
+              log.verbose(util.format($('Found %d secrets, loading more'), secrets.length));
+              result = client.getSecretsNext(result.nextLink, _);
+              if (result && result.length) {
+                for (var j = 0; j < result.length; ++j) {
+                  secretIdentifier = kvUtils.parseSecretIdentifier(result[j].id);
+                  secretVersions = getSecretVersions(client, secretIdentifier.vaultUri, secretIdentifier.name, _);
+                  secrets = secrets.concat(secretVersions);
+                }
               }
             }
-            if (!result.nextLink) {
-              break;
-            }
-            log.verbose(util.format($('Found %d secrets, loading more'), secrets.length));
-            result = client.secrets.listNext(result.nextLink, _);
           }
         } finally {
           progress.end();
@@ -159,7 +164,7 @@ exports.init = function(cli) {
 
   secret.command('set [vault-name] [secret-name] [secret-value]')
     .description($('Stores a secret on the vault'))
-    .usage('[--vault-name] <vault-name> [--secret-name] <secret-name> [options]')
+    .usage('options <vault-name> <secret-name>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-s, --secret-name <secret-name>', $('name of the secret to be created; if already exists, a new secret version is created'))
     .option('-w, --value <secret-value>', $('the secret value to be uploaded, expressed as an arbitrary sequence of characters; cannot be used along with --json-value or --file flags'))
@@ -167,11 +172,11 @@ exports.init = function(cli) {
     .option('--file <file-name>', $('the file that contains the secret value to be uploaded; cannot be used along with the --value or --json-value flag'))
     .option('--file-encoding <encoding>', util.format($('for text files, specifies encoding used on the file; valid values: [%s]; default is %s'), TEXT_FILE_ENCODINGS.join(', '), TEXT_FILE_ENCODINGS[0]))
     .option('--encode-binary <encoding>', util.format($('tells the file is binary and encodes it before uploading; valid values: [%s]'), BINARY_FILE_ENCODINGS.join(', ')))
+    .option('-c, --content-type <content-type>', $('the content type'))
     .option('--enabled <boolean>', $('tells if the secret should be enabled; valid values: [false, true]; default is true'))
-    .option('-e, --expires <datetime>', $('expiration time of secret, expressed as Unix Time integer, or ISO 8601 date format'))
-    .option('-n, --not-before <datetime>', $('time before which secret cannot be used, expressed as Unix Time integer, or ISO 8601 date format'))
+    .option('-e, --expires <datetime>', $('expiration time of secret, expressed in RFC-1123/ISO8601 date format'))
+    .option('-n, --not-before <datetime>', $('time before which secret cannot be used, expressed in RFC-1123/ISO8601 date format'))
     .option('-t, --tags <tags>', $('Tags to set on the secret. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
-    .option('-p, --pass-thru', $('outputs the stored secret; note it always outputs when --json or verbose is informed'))
     .execute(function(vaultName, secretName, secretValue, options, _) {
 
       ///////////////////////
@@ -186,25 +191,26 @@ exports.init = function(cli) {
       // Perform the request.                        //
       /////////////////////////////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
-      var request = {
-        value: options.value,
-        attributes: {
+      var requestOptions = {
+        tags: options.tags,
+        contentType: options.contentType,
+        secretAttributes: {
           enabled: options.enabled,
-          nbf: options.notBefore,
-          exp: options.expires
+          notBefore: options.notBefore,
+          expires: options.expires
         },
-        tags: options.tags
       };
 
-      log.verbose('request: ' + JSON.stringify(request));
+      log.verbose('request options: ' + JSON.stringify(requestOptions));
 
       var secret;
       var secretIdentifier = getSecretIdentifier(options);
       var progress = cli.interaction.progress(util.format($('Creating secret %s'), secretIdentifier));
       try {
-        secret = client.secrets.set(secretIdentifier, request, _);
+        secret = client.setSecret(options.vaultUri, options.secretName, options.value, requestOptions, _);
       } finally {
         progress.end();
       }
@@ -215,16 +221,16 @@ exports.init = function(cli) {
 
   secret.command('set-attributes [vault-name] [secret-name] [secret-version]')
     .description($('Changes attributes of an existing secret'))
-    .usage('[--vault-name] <vault-name> [--secret-name] <secret-name> [[--secret-version] <secret-version>] [options]')
+    .usage('[options] <vault-name> <secret-name> [secret-version]')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-s, --secret-name <secret-name>', $('name of the secret to be modified'))
-    .option('-r, --secret-version <secret-version>', $('the version to be modified; if ommited, modifies only the most recent'))
+    .option('-r, --secret-version <secret-version>', $('the version to be modified; if omited, modifies only the most recent'))
+    .option('-c, --content-type <content-type>', $('the content type'))
     .option('--enabled <boolean>', $('if informed, command will change the enabled state; valid values: [false, true]'))
-    .option('-e, --expires <datetime>', $('if informed, command will change secret expiration time; expressed as Unix Time integer, or ISO 8601 date format, or null to clear the value'))
-    .option('-n, --not-before <datetime>', $('if informed, command will change time before which secret cannot be used; expressed as Unix Time integer, or ISO 8601 date format, or null to clear the value'))
+    .option('-e, --expires <datetime>', $('if informed, command will change secret expiration time; expressed in RFC-1123/ISO8601 date format, or null to clear the value'))
+    .option('-n, --not-before <datetime>', $('if informed, command will change time before which secret cannot be used; expressed in RFC-1123/ISO8601 date format, or null to clear the value'))
     .option('-t, --tags <tags>', $('Tags to set on the secret. Can be multiple in the format \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
     .option('--reset-tags', $('remove previously existing tags; can combined with --tags'))
-    .option('-p, --pass-thru', $('outputs attributes of the modified secret; note it always outputs when --json or verbose is informed'))
     .execute(function(vaultName, secretName, secretVersion, options, _) {
 
       ///////////////////////
@@ -247,6 +253,7 @@ exports.init = function(cli) {
       // Deal with tags. Load existing vault, if needed.  //
       //////////////////////////////////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
       var secret;
@@ -260,7 +267,7 @@ exports.init = function(cli) {
 
           // We must read existing tags and add the new ones.
           log.info(util.format($('Getting secret %s'), secretIdentifier));
-          secret = client.secrets.get(secretIdentifier, _);
+          secret = client.getSecret(secretIdentifier, _);
           var currentTags = secret.tags;
           if (!currentTags) {
             // Defend against undefined.
@@ -288,25 +295,26 @@ exports.init = function(cli) {
       // Build the request based on informed parameters.        //
       ////////////////////////////////////////////////////////////
 
-      var request = {
-        attributes: {}
+      var requestOptions = {
+        secretAttributes: {
+        },
       };
 
-      if (informed.secretOps) request.secret_ops = options.secretOps;
-      if (informed.enabled) request.attributes.enabled = options.enabled;
-      if (informed.notBefore) request.attributes.nbf = options.notBefore;
-      if (informed.expires) request.attributes.exp = options.expires;
-      if (informed.tags) request.tags = options.tags;
+      if (informed.secretOps) requestOptions.secretOps = options.secretOps;
+      if (informed.enabled) requestOptions.secretAttributes.enabled = options.enabled;
+      if (informed.notBefore) requestOptions.secretAttributes.notBefore = options.notBefore;
+      if (informed.expires) requestOptions.secretAttributes.expires = options.expires;
+      if (informed.tags) requestOptions.tags = options.tags;
 
       /////////////////////////////////////////////////
       // Send the request.                           //
       /////////////////////////////////////////////////
 
-      log.verbose('request: ' + JSON.stringify(request, null, ' '));
+      log.verbose('request options: ' + JSON.stringify(requestOptions, null, ' '));
 
       var progress = cli.interaction.progress(util.format($('Updating secret %s'), secretIdentifier));
       try {
-        secret = client.secrets.update(secretIdentifier, request, _);
+        secret = client.updateSecret(secretIdentifier, requestOptions, _);
       } finally {
         progress.end();
       }
@@ -317,10 +325,10 @@ exports.init = function(cli) {
 
   secret.command('show [vault-name] [secret-name] [secret-version]')
     .description($('Shows a vault secret'))
-    .usage('[--vault-name] <vault-name> [--secret-name] <secret-name> [[--secret-version] <secret-version>] [options]')
+    .usage('[options] <vault-name> <secret-name> [secret-version]')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-s, --secret-name <secret-name>', $('the secret name'))
-    .option('-r, --secret-version <secret-version>', $('the secret version; if ommited, uses the most recent'))
+    .option('-r, --secret-version <secret-version>', $('the secret version; if omited, uses the most recent'))
     .execute(function(vaultName, secretName, secretVersion, options, _) {
 
       ///////////////////////
@@ -343,26 +351,26 @@ exports.init = function(cli) {
       // Send the request.   //
       /////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
       var secretIdentifier = getSecretIdentifier(options);
       var progress = cli.interaction.progress(util.format($('Getting secret %s'), secretIdentifier));
       try {
-        secret = client.secrets.get(secretIdentifier, _);
+        secret = client.getSecret(secretIdentifier, _);
       } finally {
         progress.end();
       }
 
-      options.passThru = true;
       showSecret(options, secret);
     });
 
   secret.command('get [vault-name] [secret-name] [secret-version] [file]')
     .description($('Downloads a secret from the vault'))
-    .usage('[--vault-name] <vault-name> [--secret-name] <secret-name> [[--secret-version] <secret-version>] [--file] <file-name> [options]')
+    .usage('[options] <vault-name> <secret-name> [secret-version] <file>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-s, --secret-name <secret-name>', $('the secret name'))
-    .option('-r, --secret-version <secret-version>', $('the secret version; if ommited, uses the most recent'))
+    .option('-r, --secret-version <secret-version>', $('the secret version; if omited, uses the most recent'))
     .option('--file <file-name>', $('the file to receive secret contents; the file must not exist otherwise the command fails'))
     .option('--file-encoding <encoding>', util.format($('specifies how to encode the secret contents in the file; valid values: [%s]; default is %s'), TEXT_FILE_ENCODINGS.join(', '), TEXT_FILE_ENCODINGS[0]))
     .option('--decode-binary <encoding>', util.format($('tells to write a binary file by decoding secret contents with the informed encoding; valid values: [%s]'), BINARY_FILE_ENCODINGS.join(', ')))
@@ -406,12 +414,13 @@ exports.init = function(cli) {
       // Send the request.   //
       /////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
       var secretIdentifier = getSecretIdentifier(options);
       var progress = cli.interaction.progress(util.format($('Getting secret %s'), secretIdentifier));
       try {
-        secret = client.secrets.get(secretIdentifier, _);
+        secret = client.getSecret(secretIdentifier, _);
       } finally {
         progress.end();
       }
@@ -441,7 +450,7 @@ exports.init = function(cli) {
         }
 
         fs.writeFileSync(options.file, data, { flag: 'wx' });
-        
+
       } else {
         
         // Writes a zero-length file.
@@ -453,11 +462,10 @@ exports.init = function(cli) {
 
   secret.command('delete [vault-name] [secret-name]')
     .description($('Deletes a secret from the vault'))
-    .usage('[--vault-name] <vault-name> [--secret-name] <secret-name> [options]')
+    .usage('[options] <vault-name> <secret-name>')
     .option('-u, --vault-name <vault-name>', $('the vault name'))
     .option('-s, --secret-name <secret-name>', $('the secret name'))
     .option('-q, --quiet', $('quiet mode (do not ask for delete confirmation)'))
-    .option('-p, --pass-thru', $('outputs the deleted secret; note it always outputs when --json or verbose is informed'))
     .execute(function(vaultName, secretName, options, _) {
 
       ///////////////////////
@@ -489,13 +497,13 @@ exports.init = function(cli) {
       // Send the request.   //
       /////////////////////////
 
+      options.vaultUri = createVaultUri(options);
       var client = createClient(options);
 
       var secret;
-      var secretIdentifier = getSecretIdentifier(options);
-      var progress = cli.interaction.progress(util.format($('Deleting secret %s'), secretIdentifier));
+      var progress = cli.interaction.progress(util.format($('Deleting secret %s from vault %s'), options.secretName, options.vaultName));
       try {
-        secret = client.secrets.deleteMethod(secretIdentifier, _);
+        secret = client.deleteSecret(options.vaultUri, options.secretName, _);
       } finally {
         progress.end();
       }
@@ -503,13 +511,15 @@ exports.init = function(cli) {
       showSecret(options, secret);
     });
 
+  function createVaultUri(options) {
+    var subscription = profile.current.getSubscription(options.subscription);
+    return 'https://' + options.vaultName + subscription.keyVaultDnsSuffix;
+  }
+
   function createClient(options) {
     var subscription = profile.current.getSubscription(options.subscription);
     log.verbose(util.format($('Using subscription %s (%s)'), subscription.name, subscription.id));
-    options.vaultUri = 'https://' + options.vaultName + subscription.keyVaultDnsSuffix;
-    var newClient = utils.createKeyVaultClient(subscription, options.vaultUri);
-    // The new client returns high-level objects, we need low-level JSON objects for CLI.
-    return new kvLegacy.KeyVaultClient(newClient._internalClient);
+    return utils.createKeyVaultClient(subscription);
   }
 
   function getSecretIdentifier(options) {
@@ -614,8 +624,6 @@ exports.init = function(cli) {
       return cli.missingArgument('secret-name');
     }
 
-    options.expires = kvUtils.parseDateArgument('expires', options.expires, null);
-    options.notBefore = kvUtils.parseDateArgument('not-before', options.notBefore, null);
     options.enabled = kvUtils.parseBooleanArgument('enabled', options.enabled, true);
     options.tags = kvUtils.parseTagsArgument('tags', options.tags);
 
@@ -626,25 +634,23 @@ exports.init = function(cli) {
     log.verbose(util.format($('Loading versions of secret %s'), secretName));
 
     var secrets = [];
-    var result = client.secrets.listVersions(vaultUri, secretName, null, _);
-    for (;;) {
-      var items = result.value;
-      if (items && items.length) {
-        secrets = secrets.concat(items);
+    var result = client.getSecretVersions(vaultUri, secretName, null, _);
+    if (result) {
+      secrets = result;
+
+      while (result && result.nextLink) {
+        log.verbose(util.format($('Found %d versions, loading more'), secrets.length));
+        result = client.getSecretVersionsNext(result.nextLink, _);
+        if (result) {
+          secrets = secrets.concat(result);
+        }
       }
-      if (!result.nextLink) {
-        break;
-      }
-      log.verbose(util.format($('Found %d versions, loading more'), secrets.length));
-      result = client.secrets.listVersionsNext(result.nextLink, _);
     }
 
     return secrets;
   }
 
   function showSecret(options, secret) {
-    if (!options.passThru && !options.json)
-      return;    
     cli.interaction.formatOutput(secret, function(secret) {
       secret.attributes = kvUtils.getAttributesWithPrettyDates(secret.attributes);
       utils.logLineFormat(secret, log.data);      
@@ -661,8 +667,8 @@ exports.init = function(cli) {
     }
     row.cell($('Enabled'), item.attributes.enabled);
     var attributes = kvUtils.getAttributesWithPrettyDates(item.attributes);
-    row.cell($('Not Before'), attributes.nbf || '');
-    row.cell($('Expires'), attributes.exp || '');
+    row.cell($('Not Before'), attributes.notBefore || '');
+    row.cell($('Expires'), attributes.expires || '');
     row.cell($('Created'), attributes.created);
     row.cell($('Updated'), attributes.updated);
     row.cell($('Tags'), kvUtils.getTagsInfo(item.tags));

--- a/lib/commands/arm/keyvault/kv-utils.js
+++ b/lib/commands/arm/keyvault/kv-utils.js
@@ -59,6 +59,20 @@ exports.parseDateArgument = function(argName, argValue, _default) {
   throw new Error(util.format($('Invalid date specified on %s: %s.'), argName, argValue));
 };
 
+exports.parseIntegerArgument = function(argName, argValue, _default) {
+  if (__.isUndefined(argValue)) {
+    return _default;
+  }
+  if (utils.ignoreCaseEquals(argValue, 'null')) {
+    return null;
+  }
+  var n = parseInt(argValue);
+  if (__.isNumber(n) && !__.isNaN(n)) {
+    return n;
+  }
+  throw new Error(util.format($('Invalid interger specified on %s: %s.'), argName, argValue));
+};
+
 exports.parseBooleanArgument = function(argName, argValue, _default) {
   if (__.isUndefined(argValue)) {
     return _default;
@@ -97,6 +111,22 @@ exports.parseJsonStringArgument = function(argName, argValue, _default) {
     throw new Error(util.format($('Invalid JSON string on argument %s: %s'), argName, argValue));
   }
   return a;
+};
+
+exports.validateArrayArgument = function(argName, argValue, _default) {
+  if (__.isUndefined(argValue)) {
+    return _default;
+  }
+  var a;
+  try {
+    a = JSON.parse(argValue);
+  } catch (err) {
+    throw new Error(util.format($('Not a JSON value informed on %s: %s.'), argName, argValue));
+  }
+  if (__.isArray(a)) {
+    return a;
+  }
+  throw new Error(util.format($('Invalid value specified on %s: %s.'), argName, argValue));
 };
 
 exports.parseArrayArgument = function(argName, argValue, validValues, _default) {
@@ -167,6 +197,36 @@ exports.parseSecretIdentifier = function(identifier) {
   return parseIdentifier(identifier, 'secrets');
 };
 
+exports.parseCertificateIdentifier = function(identifier) {
+  return parseIdentifier(identifier, 'certificates');
+};
+
+exports.parseCertificateIssuerIdentifier = function(identifier) {
+  var parsed = url.parse(identifier);
+
+  var vaultUri = '';
+  vaultUri += parsed.protocol || '';
+  if (parsed.slashes) {
+    vaultUri += '//';
+  }
+  vaultUri += parsed.host || '';
+
+  if (!parsed.pathname) {
+    throw unsupported();
+  }
+
+  var path = parsed.pathname.split('/');
+  var name = path[3];
+  return {
+    vaultUri: vaultUri,
+    name: name
+  };
+
+  function unsupported() {
+    throw new Error(util.format($('Unsupported identifier: %s'), identifier));
+  }
+};
+
 function parseIdentifier(identifier, folder) {
   var parsed = url.parse(identifier);
 
@@ -208,6 +268,16 @@ exports.bufferToBase64Url = function(buffer) {
   var str = buffer.toString('base64');
   // Base64 to Base64Url.
   return trimEnd(str, '=').replace(/\+/g, '-').replace(/\//g, '_');
+};
+
+exports.bufferToBase64 = function(buffer) {
+  // Buffer to Base64.
+  return buffer.toString('base64');
+};
+
+exports.bufferToHex = function(buffer) {
+  // Buffer to Hex.
+  return buffer.toString('hex');
 };
 
 function trimEnd(str, ch) {

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -33067,7 +33067,7 @@
                   "bool": true,
                   "short": "-U",
                   "long": "--auto-upgrade-minor-version",
-                  "description": "Enable auto-upgrade across minor version"
+                  "description": "Pick the highest minor version of the extension"
                 },
                 {
                   "flags": "-s, --subscription <id>",
@@ -46668,6 +46668,14 @@
               "description": "JSON-encoded array of strings representing secret operations; each string can be one of [all, set, get, list, delete]"
             },
             {
+              "flags": "--perms-to-certificates <perms-to-certificates>",
+              "required": -25,
+              "optional": 0,
+              "bool": true,
+              "long": "--perms-to-certificates",
+              "description": "JSON-encoded array of strings representing certificate operations; each string can be one of [all, get, list, delete, create, import, update, managecontacts, getissuers, listissuers, setissuers, deleteissuers]"
+            },
+            {
               "flags": "--enabled-for-deployment <boolean>",
               "required": -26,
               "optional": 0,
@@ -46813,6 +46821,1791 @@
         }
       ],
       "categories": {
+        "certificate": {
+          "name": "certificate",
+          "description": "Commands to manage certificates in the Azure Key Vault service",
+          "fullName": "keyvault certificate",
+          "usage": "[options] [command]",
+          "options": [],
+          "commands": [
+            {
+              "name": "list",
+              "description": "Lists certificates of a vault",
+              "fullName": "keyvault certificate list",
+              "usage": "[options] <vault-name>",
+              "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-u, --vault-name <vault-name>",
+                  "required": -18,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-u",
+                  "long": "--vault-name",
+                  "description": "the vault name"
+                }
+              ]
+            },
+            {
+              "name": "list-versions",
+              "description": "Lists certificate versions",
+              "fullName": "keyvault certificate list-versions",
+              "usage": "[options] <vault-name> [certificate-name]",
+              "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-u, --vault-name <vault-name>",
+                  "required": -18,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-u",
+                  "long": "--vault-name",
+                  "description": "the vault name"
+                },
+                {
+                  "flags": "-c, --certificate-name <certificate-name>",
+                  "required": -24,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--certificate-name",
+                  "description": "lists only versions of this certificate"
+                }
+              ]
+            },
+            {
+              "name": "show",
+              "description": "Shows a vault certificate",
+              "fullName": "keyvault certificate show",
+              "usage": "[options] <vault-name> <certificate-name> [certificate-version]",
+              "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-u, --vault-name <vault-name>",
+                  "required": -18,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-u",
+                  "long": "--vault-name",
+                  "description": "the vault name"
+                },
+                {
+                  "flags": "-c, --certificate-name <certificate-name>",
+                  "required": -24,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--certificate-name",
+                  "description": "the certificate name"
+                },
+                {
+                  "flags": "-r, --certificate-version <certificate-version>",
+                  "required": -27,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-r",
+                  "long": "--certificate-version",
+                  "description": "the certificate version; if omited, uses the most recent"
+                }
+              ]
+            },
+            {
+              "name": "get",
+              "description": "Downloads a certificate from the vault",
+              "fullName": "keyvault certificate get",
+              "usage": "[options] <vault-name> <certificate-name> [certificate-version] <file>",
+              "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-u, --vault-name <vault-name>",
+                  "required": -18,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-u",
+                  "long": "--vault-name",
+                  "description": "the vault name"
+                },
+                {
+                  "flags": "-c, --certificate-name <certificate-name>",
+                  "required": -24,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--certificate-name",
+                  "description": "the certificate name"
+                },
+                {
+                  "flags": "-r, --certificate-version <certificate-version>",
+                  "required": -27,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-r",
+                  "long": "--certificate-version",
+                  "description": "the certificate version; if omited, uses the most recent"
+                },
+                {
+                  "flags": "--file <file>",
+                  "required": -8,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--file",
+                  "description": "the file to receive certificate contents; the file must not exist otherwise the command fails"
+                },
+                {
+                  "flags": "--encode <encoding>",
+                  "required": -10,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--encode",
+                  "description": "tells to write a file by encoding certificate contents with the informed encoding; valid values: [base64]"
+                }
+              ]
+            },
+            {
+              "name": "create",
+              "description": "Creates a certificate in the vault",
+              "fullName": "keyvault certificate create",
+              "usage": "[options] <vault-name> <certificate-name>",
+              "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-u, --vault-name <vault-name>",
+                  "required": -18,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-u",
+                  "long": "--vault-name",
+                  "description": "the vault name"
+                },
+                {
+                  "flags": "-c, --certificate-name <certificate-name>",
+                  "required": -24,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--certificate-name",
+                  "description": "the certificate name"
+                },
+                {
+                  "flags": "-p --certificate-policy <certificate-policy>",
+                  "required": -25,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-p",
+                  "long": "--certificate-policy",
+                  "description": "a JSON-formatted string containing the certificate policy."
+                },
+                {
+                  "flags": "-e --certificate-policy-file <certificate-policy-file>",
+                  "required": -30,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-e",
+                  "long": "--certificate-policy-file",
+                  "description": "a file containing the certificate policy. Mutually exlcusive with --certificate-policy.",
+                  "fileRelatedOption": true
+                },
+                {
+                  "flags": "-t, --tags <tags>",
+                  "required": -12,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-t",
+                  "long": "--tags",
+                  "description": "Tags to set on the certificate. Can be multiple in the format 'name=value'. Name is required and value is optional. For example, -t tag1=value1;tag2"
+                }
+              ]
+            },
+            {
+              "name": "import",
+              "description": "Imports a certificate into the vault",
+              "fullName": "keyvault certificate import",
+              "usage": "[options] <vault-name> <certificate-name>",
+              "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-u, --vault-name <vault-name>",
+                  "required": -18,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-u",
+                  "long": "--vault-name",
+                  "description": "the vault name"
+                },
+                {
+                  "flags": "-c, --certificate-name <certificate-name>",
+                  "required": -24,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--certificate-name",
+                  "description": "the certificate name"
+                },
+                {
+                  "flags": "-b --content <content>",
+                  "required": -14,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-b",
+                  "long": "--content",
+                  "description": "a base64 encoded string containing the certificate and private key (optional) to be imported"
+                },
+                {
+                  "flags": "-e --content-file <content-file>",
+                  "required": -19,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-e",
+                  "long": "--content-file",
+                  "description": "a file containing the certificate and private key (optional) to be imported",
+                  "fileRelatedOption": true
+                },
+                {
+                  "flags": "--content-file-binary <boolean>",
+                  "required": -23,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--content-file-binary",
+                  "description": "indicates if the content file is binary. valid values: [false, true]. default is false."
+                },
+                {
+                  "flags": "-d, --password <password>",
+                  "required": -16,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-d",
+                  "long": "--password",
+                  "description": "password of the file if it contains a encrypted private key"
+                },
+                {
+                  "flags": "-p --certificate-policy <certificate-policy>",
+                  "required": -25,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-p",
+                  "long": "--certificate-policy",
+                  "description": "a JSON-formatted string containing the certificate policy."
+                },
+                {
+                  "flags": "-e --certificate-policy-file <certificate-policy-file>",
+                  "required": -30,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-e",
+                  "long": "--certificate-policy-file",
+                  "description": "a file containing the certificate policy. Mutually exlusive with --certificate-policy.",
+                  "fileRelatedOption": true
+                },
+                {
+                  "flags": "-t, --tags <tags>",
+                  "required": -12,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-t",
+                  "long": "--tags",
+                  "description": "Tags to set on the certificate. Can be multiple in the format 'name=value'. Name is required and value is optional. For example, -t tag1=value1;tag2"
+                }
+              ]
+            },
+            {
+              "name": "merge",
+              "description": "Merges certificate(s)into the vault",
+              "fullName": "keyvault certificate merge",
+              "usage": "[options] <vault-name> <certificate-name> <content>",
+              "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-u, --vault-name <vault-name>",
+                  "required": -18,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-u",
+                  "long": "--vault-name",
+                  "description": "the vault name"
+                },
+                {
+                  "flags": "-c, --certificate-name <certificate-name>",
+                  "required": -24,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--certificate-name",
+                  "description": "the certificate name"
+                },
+                {
+                  "flags": "-b --content <content>",
+                  "required": -14,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-b",
+                  "long": "--content",
+                  "description": "certificate chain to merge; must be JSON-encoded array of base64 encoded certificate"
+                },
+                {
+                  "flags": "-t, --tags <tags>",
+                  "required": -12,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-t",
+                  "long": "--tags",
+                  "description": "Tags to set on the certificate. Can be multiple in the format 'name=value'. Name is required and value is optional. For example, -t tag1=value1;tag2"
+                }
+              ]
+            },
+            {
+              "name": "set-attributes",
+              "description": "Changes attributes of an existing certificate",
+              "fullName": "keyvault certificate set-attributes",
+              "usage": "[options] <vault-name> <certificate-name> [certificate-version]",
+              "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-u, --vault-name <vault-name>",
+                  "required": -18,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-u",
+                  "long": "--vault-name",
+                  "description": "the vault name"
+                },
+                {
+                  "flags": "-c, --certificate-name <certificate-name>",
+                  "required": -24,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--certificate-name",
+                  "description": "name of the certificate to be modified"
+                },
+                {
+                  "flags": "-r, --certificate-version <certificate-version>",
+                  "required": -27,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-r",
+                  "long": "--certificate-version",
+                  "description": "the version to be modified; if omited, modifies only the most recent"
+                },
+                {
+                  "flags": "--enabled <boolean>",
+                  "required": -11,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--enabled",
+                  "description": "if informed, command will change the enabled state; valid values: [false, true]"
+                },
+                {
+                  "flags": "-t, --tags <tags>",
+                  "required": -12,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-t",
+                  "long": "--tags",
+                  "description": "Tags to set on the certificate. Can be multiple in the format 'name=value'. Name is required and value is optional. For example, -t tag1=value1;tag2"
+                },
+                {
+                  "flags": "--reset-tags",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--reset-tags",
+                  "description": "remove previously existing tags; can combined with --tags"
+                }
+              ]
+            },
+            {
+              "name": "delete",
+              "description": "Deletes a certificate from the vault",
+              "fullName": "keyvault certificate delete",
+              "usage": "[options] <vault-name> <certificate-name>",
+              "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-u, --vault-name <vault-name>",
+                  "required": -18,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-u",
+                  "long": "--vault-name",
+                  "description": "the vault name"
+                },
+                {
+                  "flags": "-c, --certificate-name <certificate-name>",
+                  "required": -24,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--certificate-name",
+                  "description": "the certificate name"
+                },
+                {
+                  "flags": "-q, --quiet",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-q",
+                  "long": "--quiet",
+                  "description": "quiet mode (do not ask for delete confirmation)"
+                }
+              ]
+            }
+          ],
+          "categories": {
+            "policy": {
+              "name": "policy",
+              "description": "Commands to manage a certificate policy in the Azure Key Vault service",
+              "fullName": "keyvault certificate policy",
+              "usage": "[options] [command]",
+              "options": [],
+              "commands": [
+                {
+                  "name": "show",
+                  "description": "Shows a vault certificate policy",
+                  "fullName": "keyvault certificate policy show",
+                  "usage": "[options] <vault-name> <certificate-name>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-c, --certificate-name <certificate-name>",
+                      "required": -24,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-c",
+                      "long": "--certificate-name",
+                      "description": "the certificate name"
+                    }
+                  ]
+                },
+                {
+                  "name": "get",
+                  "description": "Gets a vault certificate policy",
+                  "fullName": "keyvault certificate policy get",
+                  "usage": "[options] <vault-name> <certificate-name> <file>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-c, --certificate-name <certificate-name>",
+                      "required": -24,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-c",
+                      "long": "--certificate-name",
+                      "description": "the certificate name"
+                    },
+                    {
+                      "flags": "--file <file>",
+                      "required": -8,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--file",
+                      "description": "the file to receive certificate policy contents; the file must not exist otherwise the command fails"
+                    }
+                  ]
+                },
+                {
+                  "name": "create",
+                  "description": "Creates a new certificate policy JSON object. This policy object can be used as input to other certificate commands such as certificate create.",
+                  "fullName": "keyvault certificate policy create",
+                  "usage": "options <issuer-name> [subject-name] [file]",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-i, --issuer-name <issuer-name>",
+                      "required": -19,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-i",
+                      "long": "--issuer-name",
+                      "description": "issuer name"
+                    },
+                    {
+                      "flags": "-n, --subject-name <subject-name>",
+                      "required": -20,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-n",
+                      "long": "--subject-name",
+                      "description": "subject name"
+                    },
+                    {
+                      "flags": "--file <file>",
+                      "required": -8,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--file",
+                      "description": "the file to receive certificate policy object; the file must not exist otherwise the command fails"
+                    },
+                    {
+                      "flags": "-k, --key-type <key-type>",
+                      "required": -16,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-k",
+                      "long": "--key-type",
+                      "description": "tells if the key backing the certificate is software-protected or HSM-protected; valid values: [RSA, RSA-HSM]"
+                    },
+                    {
+                      "flags": "--reuse-key-on-renewal",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--reuse-key-on-renewal",
+                      "description": "indicates if the key should be reused on renewal; defaults to key is not reused"
+                    },
+                    {
+                      "flags": "--key-not-exportable",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--key-not-exportable",
+                      "description": "indicates if the key should not be exportable; defaults to key is exportable"
+                    },
+                    {
+                      "flags": "-t, --secret-content-type <secret-content-type>",
+                      "required": -27,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-t",
+                      "long": "--secret-content-type",
+                      "description": "secret content type; valid values: [application/x-pkcs12, application/x-pem-file]"
+                    },
+                    {
+                      "flags": "-d, --dns-names <dns-name>",
+                      "required": -17,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-d",
+                      "long": "--dns-names",
+                      "description": "subject alternative dns names; must be JSON-encoded array of strings"
+                    },
+                    {
+                      "flags": "-e, --ekus <ekus>",
+                      "required": -12,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-e",
+                      "long": "--ekus",
+                      "description": "extended key usages; must be JSON-encoded array of strings"
+                    },
+                    {
+                      "flags": "-m, --validity-in-months <validity-in-months>",
+                      "required": -26,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-m",
+                      "long": "--validity-in-months",
+                      "description": "validity of the certificate in months"
+                    },
+                    {
+                      "flags": "--renew-days-before-expiry <renew-days-before-expiry>",
+                      "required": -28,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--renew-days-before-expiry",
+                      "description": "number of days before expiry to automatically renew the certificate"
+                    },
+                    {
+                      "flags": "--renew-at-percentage-lifetime <renew-at-percentage-lifetime>",
+                      "required": -32,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--renew-at-percentage-lifetime",
+                      "description": "lifetime percentage at which automatically renew the certificate"
+                    },
+                    {
+                      "flags": "--email-days-before-expiry <email-days-before-expiry>",
+                      "required": -28,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--email-days-before-expiry",
+                      "description": "number of days before expiry to send notification"
+                    },
+                    {
+                      "flags": "--email-at-percentage-lifetime <email-at-percentage-lifetime>",
+                      "required": -32,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--email-at-percentage-lifetime",
+                      "description": "lifetime percentage at which send notification"
+                    }
+                  ]
+                },
+                {
+                  "name": "set",
+                  "description": "Sets a vault certificate policy",
+                  "fullName": "keyvault certificate policy set",
+                  "usage": "[options] <vault-name> <certificate-name>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-c, --certificate-name <certificate-name>",
+                      "required": -24,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-c",
+                      "long": "--certificate-name",
+                      "description": "the certificate name"
+                    },
+                    {
+                      "flags": "-p --certificate-policy <certificate-policy>",
+                      "required": -25,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-p",
+                      "long": "--certificate-policy",
+                      "description": "a JSON-formatted string containing the certificate policy"
+                    },
+                    {
+                      "flags": "-e --certificate-policy-file <certificate-policy-file>",
+                      "required": -30,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-e",
+                      "long": "--certificate-policy-file",
+                      "description": "a file containing the certificate policy.Mutually exlcusive with --certificate-policy.",
+                      "fileRelatedOption": true
+                    }
+                  ]
+                }
+              ],
+              "categories": {}
+            },
+            "operation": {
+              "name": "operation",
+              "description": "Commands to manage certificate operations in the Azure Key Vault service",
+              "fullName": "keyvault certificate operation",
+              "usage": "[options] [command]",
+              "options": [],
+              "commands": [
+                {
+                  "name": "show",
+                  "description": "Shows a vault certificate operation",
+                  "fullName": "keyvault certificate operation show",
+                  "usage": "[options] <vault-name> <certificate-name>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-c, --certificate-name <certificate-name>",
+                      "required": -24,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-c",
+                      "long": "--certificate-name",
+                      "description": "the certificate name"
+                    }
+                  ]
+                },
+                {
+                  "name": "cancel",
+                  "description": "Cancels a vault certificate operation",
+                  "fullName": "keyvault certificate operation cancel",
+                  "usage": "[options] <vault-name> <certificate-name>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-c, --certificate-name <certificate-name>",
+                      "required": -24,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-c",
+                      "long": "--certificate-name",
+                      "description": "the certificate name"
+                    },
+                    {
+                      "flags": "-q, --quiet",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-q",
+                      "long": "--quiet",
+                      "description": "quiet mode (do not ask for cancel confirmation)"
+                    }
+                  ]
+                },
+                {
+                  "name": "delete",
+                  "description": "Deletes a vault certificate operation",
+                  "fullName": "keyvault certificate operation delete",
+                  "usage": "[options] <vault-name> <certificate-name>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-c, --certificate-name <certificate-name>",
+                      "required": -24,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-c",
+                      "long": "--certificate-name",
+                      "description": "the certificate name"
+                    },
+                    {
+                      "flags": "-q, --quiet",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-q",
+                      "long": "--quiet",
+                      "description": "quiet mode (do not ask for delete confirmation)"
+                    }
+                  ]
+                }
+              ],
+              "categories": {}
+            },
+            "administrator": {
+              "name": "administrator",
+              "description": "Commands to manage certificate administrators in the Azure Key Vault service",
+              "fullName": "keyvault certificate administrator",
+              "usage": "[options] [command]",
+              "options": [],
+              "commands": [
+                {
+                  "name": "create",
+                  "description": "Creates a new certificate administator JSON object. This administratory object can be used as input to other certificate commands such as organization create.",
+                  "fullName": "keyvault certificate administrator create",
+                  "usage": "[options] [first-name] [last-name] [email-address] [phone-number] [file]",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-f, --first-name <first-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-f",
+                      "long": "--first-name",
+                      "description": "first name"
+                    },
+                    {
+                      "flags": "-l, --last-name <last-name>",
+                      "required": -17,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-l",
+                      "long": "--last-name",
+                      "description": "last name"
+                    },
+                    {
+                      "flags": "-e, --email-address <email-address>",
+                      "required": -21,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-e",
+                      "long": "--email-address",
+                      "description": "email-address"
+                    },
+                    {
+                      "flags": "-p, --phone-number <phone-number>",
+                      "required": -20,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-p",
+                      "long": "--phone-number",
+                      "description": "phone-number"
+                    },
+                    {
+                      "flags": "--file <file>",
+                      "required": -8,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--file",
+                      "description": "the file to receive certificate administator object; the file must not exist otherwise the command fails"
+                    }
+                  ]
+                }
+              ],
+              "categories": {}
+            },
+            "organization": {
+              "name": "organization",
+              "description": "Commands to manage certificate organization in the Azure Key Vault service",
+              "fullName": "keyvault certificate organization",
+              "usage": "[options] [command]",
+              "options": [],
+              "commands": [
+                {
+                  "name": "create",
+                  "description": "Creates a new certificate organization JSON object. This organization object can be used as input to other certificate commands such as issuer create.",
+                  "fullName": "keyvault certificate organization create",
+                  "usage": "[options] [id] [file]",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-i, --id <id>",
+                      "required": -10,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-i",
+                      "long": "--id",
+                      "description": "organization identifier"
+                    },
+                    {
+                      "flags": "-a --certificate-administrator <certificate-administrator>",
+                      "required": -32,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-a",
+                      "long": "--certificate-administrator",
+                      "description": "a JSON-formatted string containing a certificate administrator or an array of certificate administrators"
+                    },
+                    {
+                      "flags": "-e --certificate-administrator-file <certificate-administrator-file>",
+                      "required": -37,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-e",
+                      "long": "--certificate-administrator-file",
+                      "description": "a file containing a certificate administrator or an array of certificate administrator. Mutually exclusive with --certificate-administrator.",
+                      "fileRelatedOption": true
+                    },
+                    {
+                      "flags": "--file <file>",
+                      "required": -8,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--file",
+                      "description": "the file to receive certificate organization object; the file must not exist otherwise the command fails"
+                    }
+                  ]
+                }
+              ],
+              "categories": {}
+            },
+            "issuer": {
+              "name": "issuer",
+              "description": "Commands to manage certificate issuers in the Azure Key Vault service",
+              "fullName": "keyvault certificate issuer",
+              "usage": "[options] [command]",
+              "options": [],
+              "commands": [
+                {
+                  "name": "list",
+                  "description": "Lists certificate issuers of a vault",
+                  "fullName": "keyvault certificate issuer list",
+                  "usage": "[options] <vault-name>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    }
+                  ]
+                },
+                {
+                  "name": "show",
+                  "description": "Shows a vault certificate issuer",
+                  "fullName": "keyvault certificate issuer show",
+                  "usage": "[options] <vault-name> <certificate-issuer-name>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-c, --certificate-issuer-name <certificate-issuer-name>",
+                      "required": -31,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-c",
+                      "long": "--certificate-issuer-name",
+                      "description": "the certificate issuer name"
+                    }
+                  ]
+                },
+                {
+                  "name": "create",
+                  "description": "Creates a vault certificate issuer",
+                  "fullName": "keyvault certificate issuer create",
+                  "usage": "[options] <vault-name> <certificate-issuer-name> <provider-name> ",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-c, --certificate-issuer-name <certificate-issuer-name>",
+                      "required": -31,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-c",
+                      "long": "--certificate-issuer-name",
+                      "description": "the certificate issuer name"
+                    },
+                    {
+                      "flags": "-p, --provider-name <provider-name>",
+                      "required": -21,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-p",
+                      "long": "--provider-name",
+                      "description": "the provider-name"
+                    },
+                    {
+                      "flags": "-a, --account-id <account-id>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-a",
+                      "long": "--account-id",
+                      "description": "account identifier"
+                    },
+                    {
+                      "flags": "-k, --api-key <api-key>",
+                      "required": -15,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-k",
+                      "long": "--api-key",
+                      "description": "api key for the account"
+                    },
+                    {
+                      "flags": "-o, --certificate-organization <certificate-organization>",
+                      "required": -32,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-o",
+                      "long": "--certificate-organization",
+                      "description": "the certificate organization"
+                    },
+                    {
+                      "flags": "-e --certificate-organization-file <certificate-organization-file>",
+                      "required": -36,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-e",
+                      "long": "--certificate-organization-file",
+                      "description": "a file containing the certificate organization. Mutually exclusive with --certificate-organization.",
+                      "fileRelatedOption": true
+                    }
+                  ]
+                },
+                {
+                  "name": "delete",
+                  "description": "Deletes a certificate issuer from the vault",
+                  "fullName": "keyvault certificate issuer delete",
+                  "usage": "[options] <vault-name> <certificate-issuer-name>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-c, --certificate-issuer-name <certificate-issuer-name>",
+                      "required": -31,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-c",
+                      "long": "--certificate-issuer-name",
+                      "description": "the certificate issuer name"
+                    },
+                    {
+                      "flags": "-q, --quiet",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-q",
+                      "long": "--quiet",
+                      "description": "quiet mode (do not ask for delete confirmation)"
+                    }
+                  ]
+                }
+              ],
+              "categories": {}
+            },
+            "contact": {
+              "name": "contact",
+              "description": "Commands to manage certificate contacts in the Azure Key Vault service",
+              "fullName": "keyvault certificate contact",
+              "usage": "[options] [command]",
+              "options": [],
+              "commands": [
+                {
+                  "name": "list",
+                  "description": "List vault certificate contacts",
+                  "fullName": "keyvault certificate contact list",
+                  "usage": "[options] <vault-name>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    }
+                  ]
+                },
+                {
+                  "name": "add",
+                  "description": "Adds a certificate contact to the vault",
+                  "fullName": "keyvault certificate contact add",
+                  "usage": "[options] <vault-name> <email-address>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-e, --email-address <email-address>",
+                      "required": -21,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-e",
+                      "long": "--email-address",
+                      "description": "the contact email address"
+                    }
+                  ]
+                },
+                {
+                  "name": "delete",
+                  "description": "Deletes a certificate contact from the vault",
+                  "fullName": "keyvault certificate contact delete",
+                  "usage": "[options <vault-name> <email-address>",
+                  "filePath": "commands/arm/keyvault/keyvault.certificate._js",
+                  "options": [
+                    {
+                      "flags": "-v, --verbose",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-v",
+                      "long": "--verbose",
+                      "description": "use verbose output"
+                    },
+                    {
+                      "flags": "-vv",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "-vv",
+                      "description": "more verbose with debug output"
+                    },
+                    {
+                      "flags": "--json",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--json",
+                      "description": "use json output"
+                    },
+                    {
+                      "flags": "-u, --vault-name <vault-name>",
+                      "required": -18,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-u",
+                      "long": "--vault-name",
+                      "description": "the vault name"
+                    },
+                    {
+                      "flags": "-e, --email-address <email-address>",
+                      "required": -21,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-e",
+                      "long": "--email-address",
+                      "description": "the email address"
+                    },
+                    {
+                      "flags": "-q, --quiet",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "short": "-q",
+                      "long": "--quiet",
+                      "description": "quiet mode (do not ask for delete confirmation)"
+                    }
+                  ]
+                }
+              ],
+              "categories": {}
+            }
+          }
+        },
         "key": {
           "name": "key",
           "description": "Commands to manage keys in the Azure Key Vault service",
@@ -46824,7 +48617,7 @@
               "name": "list",
               "description": "Lists keys of a vault",
               "fullName": "keyvault key list",
-              "usage": "[--vault-name] <vault-name> [options]",
+              "usage": "[options] <vault-name>",
               "filePath": "commands/arm/keyvault/keyvault.key._js",
               "options": [
                 {
@@ -46867,7 +48660,7 @@
               "name": "list-versions",
               "description": "Lists key versions",
               "fullName": "keyvault key list-versions",
-              "usage": "[--vault-name] <vault-name> [[--key-name] <key-name>] [options]",
+              "usage": "[options] <vault-name> [key-name>]",
               "filePath": "commands/arm/keyvault/keyvault.key._js",
               "options": [
                 {
@@ -46919,7 +48712,7 @@
               "name": "create",
               "description": "Creates a key in the vault",
               "fullName": "keyvault key create",
-              "usage": "[--vault-name] <vault-name> [--key-name] <key-name> --destination <destination> [options]",
+              "usage": "[options] <vault-name> <key-name>",
               "filePath": "commands/arm/keyvault/keyvault.key._js",
               "options": [
                 {
@@ -46989,7 +48782,7 @@
                   "bool": true,
                   "short": "-e",
                   "long": "--expires",
-                  "description": "key expiration time, expressed as Unix Time integer, or ISO 8601 date format"
+                  "description": "key expiration time, expressed in RFC-1123/ISO8601 date format"
                 },
                 {
                   "flags": "-n, --not-before <datetime>",
@@ -46998,7 +48791,7 @@
                   "bool": true,
                   "short": "-n",
                   "long": "--not-before",
-                  "description": "time before which key cannot be used, expressed as Unix Time integer, or ISO 8601 date format"
+                  "description": "time before which key cannot be used, expressed in RFC-1123/ISO8601 date format"
                 },
                 {
                   "flags": "-o, --key-ops <key-ops>",
@@ -47024,7 +48817,7 @@
               "name": "import",
               "description": "Imports an existing key into a vault",
               "fullName": "keyvault key import",
-              "usage": "[--vault-name] <vault-name> [--key-name] <key-name> ( --pem-file | --byok-file ) <file-name> [--destination <destination>] [options]",
+              "usage": "[options] <vault-name> <key-name>",
               "filePath": "commands/arm/keyvault/keyvault.key._js",
               "options": [
                 {
@@ -47119,7 +48912,7 @@
                   "bool": true,
                   "short": "-e",
                   "long": "--expires",
-                  "description": "key expiration time, expressed as Unix Time integer, or ISO 8601 date format"
+                  "description": "key expiration time, expressed in RFC-1123/ISO8601 date format"
                 },
                 {
                   "flags": "-n, --not-before <datetime>",
@@ -47128,7 +48921,7 @@
                   "bool": true,
                   "short": "-n",
                   "long": "--not-before",
-                  "description": "time before which key cannot be used, expressed as Unix Time integer, or ISO 8601 date format"
+                  "description": "time before which key cannot be used, expressed in RFC-1123/ISO8601 date format"
                 },
                 {
                   "flags": "-o, --key-ops <key-ops>",
@@ -47154,7 +48947,7 @@
               "name": "set-attributes",
               "description": "Changes attributes of an existing key",
               "fullName": "keyvault key set-attributes",
-              "usage": "[--vault-name] <vault-name> [--key-name] <key-name> [[--key-version] <key-version>] [options]",
+              "usage": "[options] <vault-name> <key-name> [key-version]",
               "filePath": "commands/arm/keyvault/keyvault.key._js",
               "options": [
                 {
@@ -47207,7 +49000,7 @@
                   "bool": true,
                   "short": "-r",
                   "long": "--key-version",
-                  "description": "the version to be modified; if ommited, modifies only the most recent"
+                  "description": "the version to be modified; if omited, modifies only the most recent"
                 },
                 {
                   "flags": "--enabled <boolean>",
@@ -47224,7 +49017,7 @@
                   "bool": true,
                   "short": "-e",
                   "long": "--expires",
-                  "description": "if informed, command will change secret expiration time; expressed as Unix Time integer, or ISO 8601 date format, or null to clear the value"
+                  "description": "if informed, command will change secret expiration time; expressed in RFC-1123/ISO8601 date format, or null to clear the value"
                 },
                 {
                   "flags": "-n, --not-before <datetime>",
@@ -47233,7 +49026,7 @@
                   "bool": true,
                   "short": "-n",
                   "long": "--not-before",
-                  "description": "if informed, command will change time before which secret cannot be used; expressed as Unix Time integer, or ISO 8601 date format, or null to clear the value"
+                  "description": "if informed, command will change time before which secret cannot be used; expressed in RFC-1123/ISO8601 date format, or null to clear the value"
                 },
                 {
                   "flags": "-o, --key-ops <key-ops>",
@@ -47267,7 +49060,7 @@
               "name": "show",
               "description": "Shows properties of a vault key",
               "fullName": "keyvault key show",
-              "usage": "[--vault-name] <vault-name> [--key-name] <key-name> [[--key-version] <key-version>] [options]",
+              "usage": "[options] <vault-name> <key-name> [key-version]",
               "filePath": "commands/arm/keyvault/keyvault.key._js",
               "options": [
                 {
@@ -47320,7 +49113,7 @@
                   "bool": true,
                   "short": "-r",
                   "long": "--key-version",
-                  "description": "the key version; if ommited, uses the most recent"
+                  "description": "the key version; if omited, uses the most recent"
                 }
               ]
             },
@@ -47328,7 +49121,7 @@
               "name": "delete",
               "description": "Deletes a key from the vault",
               "fullName": "keyvault key delete",
-              "usage": "[--vault-name] <vault-name> [--key-name] <key-name> [options]",
+              "usage": "[options] <vault-name> <key-name>",
               "filePath": "commands/arm/keyvault/keyvault.key._js",
               "options": [
                 {
@@ -47382,15 +49175,6 @@
                   "short": "-q",
                   "long": "--quiet",
                   "description": "quiet mode (do not ask for delete confirmation)"
-                },
-                {
-                  "flags": "-p, --pass-thru",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": true,
-                  "short": "-p",
-                  "long": "--pass-thru",
-                  "description": "outputs the deleted key"
                 }
               ]
             },
@@ -47398,7 +49182,7 @@
               "name": "backup",
               "description": "Generates a protected backup of a vault key",
               "fullName": "keyvault key backup",
-              "usage": "[--vault-name] <vault-name> [--key-name] <key-name> [--output-file] <output-file> [options]",
+              "usage": "[options] <vault-name> <key-name> <output-file>",
               "filePath": "commands/arm/keyvault/keyvault.key._js",
               "options": [
                 {
@@ -47459,7 +49243,7 @@
               "name": "restore",
               "description": "Restores a backed up key to a vault",
               "fullName": "keyvault key restore",
-              "usage": "[--vault-name] <vault-name> [--input-file] <input-file> [options]",
+              "usage": "[options] <vault-name> <input-file>",
               "filePath": "commands/arm/keyvault/keyvault.key._js",
               "options": [
                 {
@@ -47521,7 +49305,7 @@
               "name": "list",
               "description": "Lists secrets of a vault",
               "fullName": "keyvault secret list",
-              "usage": "[--vault-name] <vault-name> [options]",
+              "usage": "[options] <vault-name>",
               "filePath": "commands/arm/keyvault/keyvault.secret._js",
               "options": [
                 {
@@ -47564,7 +49348,7 @@
               "name": "list-versions",
               "description": "Lists secret versions",
               "fullName": "keyvault secret list-versions",
-              "usage": "[--vault-name] <vault-name> [[--secret-name] <secret-name>] [options]",
+              "usage": "[options] <vault-name> [secret-name]",
               "filePath": "commands/arm/keyvault/keyvault.secret._js",
               "options": [
                 {
@@ -47616,7 +49400,7 @@
               "name": "set",
               "description": "Stores a secret on the vault",
               "fullName": "keyvault secret set",
-              "usage": "[--vault-name] <vault-name> [--secret-name] <secret-name> [options]",
+              "usage": "options <vault-name> <secret-name>",
               "filePath": "commands/arm/keyvault/keyvault.secret._js",
               "options": [
                 {
@@ -47704,6 +49488,15 @@
                   "description": "tells the file is binary and encodes it before uploading; valid values: [base64, hex]"
                 },
                 {
+                  "flags": "-c, --content-type <content-type>",
+                  "required": -20,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--content-type",
+                  "description": "the content type"
+                },
+                {
                   "flags": "--enabled <boolean>",
                   "required": -11,
                   "optional": 0,
@@ -47718,7 +49511,7 @@
                   "bool": true,
                   "short": "-e",
                   "long": "--expires",
-                  "description": "expiration time of secret, expressed as Unix Time integer, or ISO 8601 date format"
+                  "description": "expiration time of secret, expressed in RFC-1123/ISO8601 date format"
                 },
                 {
                   "flags": "-n, --not-before <datetime>",
@@ -47727,7 +49520,7 @@
                   "bool": true,
                   "short": "-n",
                   "long": "--not-before",
-                  "description": "time before which secret cannot be used, expressed as Unix Time integer, or ISO 8601 date format"
+                  "description": "time before which secret cannot be used, expressed in RFC-1123/ISO8601 date format"
                 },
                 {
                   "flags": "-t, --tags <tags>",
@@ -47737,15 +49530,6 @@
                   "short": "-t",
                   "long": "--tags",
                   "description": "Tags to set on the secret. Can be multiple in the format 'name=value'. Name is required and value is optional. For example, -t tag1=value1;tag2"
-                },
-                {
-                  "flags": "-p, --pass-thru",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": true,
-                  "short": "-p",
-                  "long": "--pass-thru",
-                  "description": "outputs the stored secret; note it always outputs when --json or verbose is informed"
                 }
               ]
             },
@@ -47753,7 +49537,7 @@
               "name": "set-attributes",
               "description": "Changes attributes of an existing secret",
               "fullName": "keyvault secret set-attributes",
-              "usage": "[--vault-name] <vault-name> [--secret-name] <secret-name> [[--secret-version] <secret-version>] [options]",
+              "usage": "[options] <vault-name> <secret-name> [secret-version]",
               "filePath": "commands/arm/keyvault/keyvault.secret._js",
               "options": [
                 {
@@ -47806,7 +49590,16 @@
                   "bool": true,
                   "short": "-r",
                   "long": "--secret-version",
-                  "description": "the version to be modified; if ommited, modifies only the most recent"
+                  "description": "the version to be modified; if omited, modifies only the most recent"
+                },
+                {
+                  "flags": "-c, --content-type <content-type>",
+                  "required": -20,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-c",
+                  "long": "--content-type",
+                  "description": "the content type"
                 },
                 {
                   "flags": "--enabled <boolean>",
@@ -47823,7 +49616,7 @@
                   "bool": true,
                   "short": "-e",
                   "long": "--expires",
-                  "description": "if informed, command will change secret expiration time; expressed as Unix Time integer, or ISO 8601 date format, or null to clear the value"
+                  "description": "if informed, command will change secret expiration time; expressed in RFC-1123/ISO8601 date format, or null to clear the value"
                 },
                 {
                   "flags": "-n, --not-before <datetime>",
@@ -47832,7 +49625,7 @@
                   "bool": true,
                   "short": "-n",
                   "long": "--not-before",
-                  "description": "if informed, command will change time before which secret cannot be used; expressed as Unix Time integer, or ISO 8601 date format, or null to clear the value"
+                  "description": "if informed, command will change time before which secret cannot be used; expressed in RFC-1123/ISO8601 date format, or null to clear the value"
                 },
                 {
                   "flags": "-t, --tags <tags>",
@@ -47850,15 +49643,6 @@
                   "bool": true,
                   "long": "--reset-tags",
                   "description": "remove previously existing tags; can combined with --tags"
-                },
-                {
-                  "flags": "-p, --pass-thru",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": true,
-                  "short": "-p",
-                  "long": "--pass-thru",
-                  "description": "outputs attributes of the modified secret; note it always outputs when --json or verbose is informed"
                 }
               ]
             },
@@ -47866,7 +49650,7 @@
               "name": "show",
               "description": "Shows a vault secret",
               "fullName": "keyvault secret show",
-              "usage": "[--vault-name] <vault-name> [--secret-name] <secret-name> [[--secret-version] <secret-version>] [options]",
+              "usage": "[options] <vault-name> <secret-name> [secret-version]",
               "filePath": "commands/arm/keyvault/keyvault.secret._js",
               "options": [
                 {
@@ -47919,7 +49703,7 @@
                   "bool": true,
                   "short": "-r",
                   "long": "--secret-version",
-                  "description": "the secret version; if ommited, uses the most recent"
+                  "description": "the secret version; if omited, uses the most recent"
                 }
               ]
             },
@@ -47927,7 +49711,7 @@
               "name": "get",
               "description": "Downloads a secret from the vault",
               "fullName": "keyvault secret get",
-              "usage": "[--vault-name] <vault-name> [--secret-name] <secret-name> [[--secret-version] <secret-version>] [--file] <file-name> [options]",
+              "usage": "[options] <vault-name> <secret-name> [secret-version] <file>",
               "filePath": "commands/arm/keyvault/keyvault.secret._js",
               "options": [
                 {
@@ -47980,7 +49764,7 @@
                   "bool": true,
                   "short": "-r",
                   "long": "--secret-version",
-                  "description": "the secret version; if ommited, uses the most recent"
+                  "description": "the secret version; if omited, uses the most recent"
                 },
                 {
                   "flags": "--file <file-name>",
@@ -48012,7 +49796,7 @@
               "name": "delete",
               "description": "Deletes a secret from the vault",
               "fullName": "keyvault secret delete",
-              "usage": "[--vault-name] <vault-name> [--secret-name] <secret-name> [options]",
+              "usage": "[options] <vault-name> <secret-name>",
               "filePath": "commands/arm/keyvault/keyvault.secret._js",
               "options": [
                 {
@@ -48066,15 +49850,6 @@
                   "short": "-q",
                   "long": "--quiet",
                   "description": "quiet mode (do not ask for delete confirmation)"
-                },
-                {
-                  "flags": "-p, --pass-thru",
-                  "required": 0,
-                  "optional": 0,
-                  "bool": true,
-                  "short": "-p",
-                  "long": "--pass-thru",
-                  "description": "outputs the deleted secret; note it always outputs when --json or verbose is informed"
                 }
               ]
             }
@@ -64595,14 +66370,6 @@
               "description": "more verbose with debug output"
             },
             {
-              "flags": "--details",
-              "required": 0,
-              "optional": 0,
-              "bool": true,
-              "long": "--details",
-              "description": "shows full list of resource type and locations."
-            },
-            {
               "flags": "--json",
               "required": 0,
               "optional": 0,
@@ -64618,6 +66385,14 @@
               "short": "-s",
               "long": "--subscription",
               "description": "Subscription to list providers for"
+            },
+            {
+              "flags": "--details",
+              "required": 0,
+              "optional": 0,
+              "bool": true,
+              "long": "--details",
+              "description": "shows full list of resource type and locations."
             }
           ]
         },

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -378,9 +378,8 @@ exports.createEventsClient = function (subscription) {
   return _createArmClient(factoryMethod, subscription);
 };
 
-exports.createKeyVaultClient = function (subscription, vaultUri) {
+exports.createKeyVaultClient = function (subscription) {
   var keyvault = require('azure-keyvault');
-  var factoryMethod = keyvault.createKeyVaultClient;
   
   var authenticator = function (challenge, callback) {
     // challenge.resource contains keyvault resourceId
@@ -399,9 +398,17 @@ exports.createKeyVaultClient = function (subscription, vaultUri) {
   } else {
     throw new Error('Unsupported subscription object.');
   }
-  return exports.createClient(factoryMethod,
-                              credentials,
-                              vaultUri);
+
+  var options = {
+    filters: [
+      exports.certAuthFilter(credentials),
+      azureCommon.UserAgentFilter.create(exports.getUserAgent()),
+      exports.createPostBodyFilter(),
+      polishErrorCausedByArmProviderNotRegistered()
+    ]
+  };
+
+  return keyvault.createKeyVaultClient(credentials, options);
 };
 
 exports.createGalleryClient = function (subscription) {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "azure-arm-devtestlabs": "0.1.0",
     "azure-graph": "1.0.1",
     "azure-gallery": "2.0.0-pre.18",
-    "azure-keyvault": "0.10.1",
+    "azure-keyvault": "0.10.2",
     "azure-asm-compute": "0.17.0",
     "azure-asm-hdinsight": "0.10.2",
     "azure-asm-trafficmanager": "0.10.3",

--- a/test/commands/arm/keyvault/arm.keyvault-certificate-tests.js
+++ b/test/commands/arm/keyvault/arm.keyvault-certificate-tests.js
@@ -1,0 +1,700 @@
+/**
+ * Copyright (c) Microsoft.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var should = require('should');
+
+var path = require('path');
+var util = require('util');
+var fs = require('fs')
+
+var CLITest = require('../../../framework/arm-cli-test');
+var log = require('../../../framework/test-logger');
+var testUtil = require('../../../util/util');
+var utils = require('../../../../lib/util/utils');
+var profile = require('../../../../lib/util/profile');
+
+var testPrefix = 'arm-cli-keyvault-tests';
+var rgPrefix = 'xplatTestRg';
+var vaultPrefix = 'xplatTestVault';
+var certificatePrefix = 'xplatTestCertificate';
+var certificateIssuerPrefix = 'xplatTestCertificateIssuer';
+var knownNames = [];
+
+var requiredEnvironment = [
+  { requiresToken: true }, 
+  { name: 'AZURE_ARM_TEST_LOCATION', defaultValue: 'West US' } 
+];
+
+var galleryTemplateName;
+var galleryTemplateUrl;
+
+describe('arm', function() {
+
+  describe('keyvault-certificate', function() {
+    
+    var suite;
+    var dnsUpdateWait;
+    var testLocation;
+    var testResourceGroup;
+    var testVault;
+
+    before(function(done) {
+      suite = new CLITest(this, testPrefix, requiredEnvironment);
+      suite.setupSuite(function() { 
+        dnsUpdateWait = suite.isPlayback() ? 0 : 5000;
+        testLocation = process.env.AZURE_ARM_TEST_LOCATION;
+        testLocation = testLocation.toLowerCase().replace(/ /g, '');
+        testResourceGroup = suite.generateId(rgPrefix, knownNames);
+        testVault = suite.generateId(vaultPrefix, knownNames);
+        suite.execute('group create %s --location %s', testResourceGroup, testLocation, function(result) {          
+          result.exitStatus.should.be.equal(0);
+          suite.execute('keyvault create %s --resource-group %s --location %s --json', testVault, testResourceGroup, testLocation, function(result) {
+            result.exitStatus.should.be.equal(0);
+            setTimeout(done, dnsUpdateWait);
+          });
+        });      
+      });
+    });
+
+    after(function(done) {
+      suite.execute('group delete %s --quiet', testResourceGroup, function() {
+        suite.teardownSuite(done);
+      });
+    });
+
+    beforeEach(function(done) {
+      suite.setupTest(function() {
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      suite.teardownTest(done);
+    });
+
+    describe('basic', function() {
+
+      it('certificate import (pfx) and management commands should work', function(done) {
+
+        var certificateName = suite.generateId(certificatePrefix, knownNames);
+        var importCertificateContent = 'MIIKKAIBAzCCCeQGCSqGSIb3DQEHAaCCCdUEggnRMIIJzTCCBhYGCSqGSIb3DQEHAaCCBgcEggYDMIIF/zCCBfsGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAiKTp+7CoR5MwICB9AEggTY/IKeiENcZyCYPTY5sUKSMAmtZg7hT2YNqirIDX0EYjIf9lIzfF+uf2n5qfear6aVVD9L8LaTKdTSUkmoV9pbCW+rr1YDbEF5v/bp289+V5hg8tf+OIEEshzTxot7VKk/laVKM6uMumBPCQvdiZa69rt2m515Z9smOYU79CXW7YKtrGgnOnk9fuFc8uGvvtm1fWQZHi7Dtm3vdDt2tvpdFebV0DqAPtAZOWhF8KIUBEFL0rq0j/U3VtB0D9RElbhzi9zFHbBvQkSvri9oa+agUYexd87DlEeksgQXZaFMCkaxcAPvlzCSDB6KspfaprksoayxhmbfchRK9WOVkx4iQE84M7PP3c5wJ9z+BebtTpqc6rolUJAkKKqKe78yD+y0Bz9nme1i1YP4puqMNxdDZV+Vs0KzFfKeIr9BuIYlPMkggQ0dJJBTIpakc2NW+pU2vlzU2fSNzscVP9utIwYVlijGRROXF5yRNT5Ntharw/xiUg35LByuKpgdf0QIH7hrk4HUQpyBSiV1gE4aEjTq9EBbUf+oSxPa6ftdGOOUR1USIqoMBKw3g2PG5lSi1EL6yyFzy42E+E2Xi+T36senP3pEYzJjM8MfLKcaSTYwDEvVH7phQTY7OT7i5Ox8YG7MgKSMaQ4SQ8UVyfrc6EWYmY0rY/LdYoXxz6yrQyF9OlIEIGgZoOkW40jX2Jz9HW0dMFOPkRuqnL2zoEJnVQQLhgjdvYdTXmwv2+V8bxe7ePG3EKEUSuktZnsA5schBrTq4GkI62UJwZeeDFMDHjKIl+IE1gPpp4mR+APSslKBB2Z4Tenbu1AToMe4rDeyLJtDbuHuJ9VfyT/SwpeObihbr/VyRQMKVRvX2oIz/P0WU5l2Pm3pcen6E+jCij0K+SF4CDNT8uP2/ON6983RPjnGymPUQ73aIoWXTQsK9Bl5u+Jqdsn79nILAdMVwE94nv/N8waeS7g380129jnBvPT7BsWYybv9j1wDsiaW+Oy26GsLlbGzjtsa9KDTXPdYlDjnwEZdDxpKzijPrnvfq4qT0PsgMEZhcV0efT7BbuLzVokFUCr3eXKMP/OqBKlOIE/GE61+JlVRBtzB+dW5DYnWlJNjtfWBp+9PcZc/nhSqFrGrTehV6/0lpznQ/XNy6B7v6kNW5ngQe1pAl4E5z7oITsHG5crQcu/RM14mUWcs1xUgLjrIR+zdCcfkWMrXJeRoJvCilQLBiJ+cItri/tOL+gQnt6QVudkROrUmQLtKcI8WS3hxb+cWrTk5obaQAkOCTqh9ZNo2z3YO6Ek4FZTEs3gWiAVEgrxVzThJXNqbckfrvB7RY3MHCa8anbwJdWNAcdFImxH835TD42NtpcLxAJ/ucH8O2bmcBLUBvOhdK+aLMokiDvcaA1mVdJCuAewbRurt52TQRulYC1G67Q10Tt5NwRqrIn8GkfCtz1CUgMjhMmXCyFt2kefwWVlbOX0EjOZKUIosDuSlH4gV71vWDeq+JbkYSxJyG2E0Yhl6pGhgddmeeSU9UTuHji7fuCLFVtrlMgpd2sTLqzOWjcIFejbwHNNZkZjL5yWKUrpaqe5sd9WRy1U6PH/iK84ek6Pmo69Y/YvnTi8/DiYpmrap0cgcftHuNcd+h2OhgglTXuYnZsS07H4PyjGB6TATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IAGEANgAyAGIANgA5AGMAMwAtADkAZgBjADAALQA0AGEAZQBmAC0AYQBjAGEAMwAtAGMAZABjAGMAMgAxADQAZAA1ADgANQAxMHkGCSsGAQQBgjcRATFsHmoATQBpAGMAcgBvAHMAbwBmAHQAIABFAG4AaABhAG4AYwBlAGQAIABSAFMAQQAgAGEAbgBkACAAQQBFAFMAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMIIDrwYJKoZIhvcNAQcGoIIDoDCCA5wCAQAwggOVBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBBjAOBAjUGyZnibwFRAICB9CAggNoiczPdE4wuOyv6Ei5c5xij93/FKWdelietGpngONdsRKjC1+uzNokx/vgfe+O2OKj5fC5ZmmiYK84iot7bpHodjYWLXg35TcNWRzrDuilYw7LPFsS7WqhCrazldLjnJJEPEh2lYo96kllquYIzBaRXkuwCo9r0m29ofqV0SROJCs7va3wp5FUR8K8W9o18d3kZSK0DhEO6BsnKJet6GL/vU/N3Z/oLv5HGZNOAwSJni08CQfiq2qqgPLDfE5iZuVmUSFsNwIvxcTlIRG3FyYguX8jNzOG4NxW7OmgvUWuwFaoHrOdrIQN9zuWxSgdZOJgP6kH6DDg4KTzbeYb4Hy7Hi4G2UwusVYVdIOdg2y6gWXQBuD81t+CDzrmEp+EhAvYZSHfUOZla0I/MYU21aedZgTeoTklU3gD43CjxGWWdPUPdZJwXgSplxIIjnemjAJ+VluEX3V8JjNGDp+y68j0ts91y+72e5/KNc3pr6eXvZNTySOopMr/Pi1PkYfPymrCEqfelk572CcnmuyA99Vw4gr0jAMR0X0YYSZ5GnhaSCI1dCO+eCCjROosEJwNNcSPT17ycvEUFrX9mt8kXzRvOfW1xS+bn0GpicNWYMXkBw/rz8JR3LxgncsaPdcp724+vNgJuF4JiximjTd9TH4n9O6X9pCA68VdiPutNegOThqFGTs1b0WItayqfkTOzRg+JOZrk311ia2go+O7+T+EqB3JlVcq6F+yQ3Lkqp2Tr8d0UMMF7fR0bj8EwzEl0CuWGN5xyfJc3tQJznLJo9e2nYZtQ3tw5Dy3gwKfmO/FKQ2umxiX3ZvHk8/DIUYn++YH5EaGLlwppHPcKVy0X7Kii7LE1nekYkCRMC+sXpO0V8Eq91x2YxmSHyo1RJGra+kybZZ7cO3QBJwhS5PyosGZnR39z2ShHMk8PrbkQSFv3kJqxeIV4E2KnWnbxyjrXLS3XBhCyS4uCxiFZzXGcFXjlSAUnQ9DpHrxvoKbVipekVjOTjuoFk5SzkQgiOa+WREvHv3YU0iJGjnV78XB+ZKqG9q1ok/tEDssf0TaOL6cT0OV4BqRQyu6cuYk/630MpVbkJJG8OBg/5oL9muO2oFaxfVZGeQpWNTah9yaCj7piaXok43nnEne3CNvxCBCEBPz4GcDvlTOjy4wOzAfMAcGBSsOAwIaBBQFPX6XGMp7gA4008VqyInDcud/TQQUBqn/Em9qWdkmXyOdpr2zLZDjOFECAgfQ';
+        var importCertificatePassword = '123';
+        var importCertificatePolicy = '{ \"keyProperties\" : { \"exportable\" : true, \"keyType\" : \"RSA\", \"keySize\" : 2048, \"reuseKey\" : false }, \"secretProperties\" : { \"contentType\" : \"application/x-pkcs12\" }, \"issuerReference\" : { \"name\" : \"Self\" } }';
+        var certificateId;
+        importCertificateMustSucceed();
+
+        function importCertificateMustSucceed() {
+          suite.execute('keyvault certificate import %s %s --content %s --password %s --certificate-policy %s', testVault, certificateName, importCertificateContent, importCertificatePassword, importCertificatePolicy, function(result) {
+            result.exitStatus.should.be.equal(0);
+            showCertificateMustSucceed();
+          });
+        }
+
+        function showCertificateMustSucceed() {
+          suite.execute('keyvault certificate show %s %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificate = JSON.parse(result.text);
+            certificate.should.have.property('id');
+            certificateId = certificate.id;
+            var subscription = profile.current.getSubscription();
+            certificateId.should.include(util.format('https://%s%s/certificates/%s/', testVault.toLowerCase(), subscription.keyVaultDnsSuffix, certificateName));
+            certificate.should.have.property('cer');
+            listCertificatesMustSucceed();
+          });
+        }
+
+        function listCertificatesMustSucceed() {
+          suite.execute('keyvault certificate list %s --json', testVault, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificateId.indexOf(certificate.id + '/') === 0;
+            }).should.be.true;
+            listCertificateVersionsMustSucceed();
+          });
+        }
+
+        function listCertificateVersionsMustSucceed() {
+          suite.execute('keyvault certificate list-versions %s -c %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificate.id === certificateId;
+            }).should.be.true;
+            deleteCertificateMustSucceed();
+          });
+        }
+
+        function deleteCertificateMustSucceed() {
+          suite.execute('keyvault certificate delete %s %s --quiet', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            showCertificateMustFail();
+          });
+        }
+
+        function showCertificateMustFail() {
+          suite.execute('keyvault certificate show %s %s', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(1);
+            result.errorText.should.include(util.format('Certificate %s not found', certificateName));
+            done();
+          });
+        }
+
+      });
+
+      it('certificate import (pem) and management commands should work', function(done) {
+
+        var certificateName = suite.generateId(certificatePrefix, knownNames);
+        var importCertificateContent =  '-----BEGIN CERTIFICATE-----' + '\n' +
+          "MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNV" + '\n' +
+          "BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX" + '\n' +
+          "aWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUw" + '\n' +
+          "M1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUt" + '\n' +
+          "U3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UE" + '\n' +
+          "CwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNn" + '\n' +
+          "B7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZq" + '\n' +
+          "lSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+" + '\n' +
+          "lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGG" + '\n' +
+          "pgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8" + '\n' +
+          "NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxT" + '\n' +
+          "QHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern" + '\n' +
+          "0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTAD" + '\n' +
+          "AQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQ" + '\n' +
+          "Kq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1" + '\n' +
+          "Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r" + '\n' +
+          "8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1" + '\n' +
+          "rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jP" + '\n' +
+          "wNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT" + '\n' +
+          "-----END CERTIFICATE-----" + '\n' +
+          "-----BEGIN ENCRYPTED PRIVATE KEY-----" + '\n' +
+          "MIIE6jAcBgoqhkiG9w0BDAEDMA4ECJiLClPM6t5JAgIIAASCBMigL+KlEA9fagX0" + '\n' +
+          "PFhQBeFjDiebJbMuTfa9HcOVZEDyrqmGng2Lfz+TUa3ys/V86okbUp2N9MoGK7gx" + '\n' +
+          "cPqdq7rnu563LT9wGhtn8mUn8Wul0FfV2K56wsBGehJ+MPmlEjs6OZR0nVdXkwAh" + '\n' +
+          "dVIzH9eFdz8mhJZOZI61TQNKCKbCqsR7lslkL2VWrSFgnHCUj5bR/BLIA2oRpQZv" + '\n' +
+          "nw0SeYFQWMRyXgKH4VWMqOlObXm/ELnVOr9dJVzvTG42DRaK5N8BA9NTMsK1+8m+" + '\n' +
+          "enCg4iNI/s81MD8iIy/d7MmsJFh8WQoqzUZmOVxfqNHw0TPgDpbCpCWRNigkRoGS" + '\n' +
+          "Rosc7MIlCPPangjPMFZg5QeMuUBrE01fSvJtZ52jSMkyloSfQzQJJb9Aam6q6Dzo" + '\n' +
+          "uPCH32zz1GV/56yJoO8IefOMIujvXFZku/QNzKWiXnuSA+xjFZhGEGQToU5wLtHX" + '\n' +
+          "eEhz1cF519c8CkM4Ll/UUHPWtb90vqO2+O2DLug9qUUnoQl7P0O3W2NpAoBCLxUO" + '\n' +
+          "qrfSyLUosms7Eg1DIVo5pwxawPK8qk7gwLntATZc+aTSUR9Y1dn4vJ9j9GZWIu9J" + '\n' +
+          "VKO616gDO7q8R1C3mT72k2oUuUG25TtZOxsl+Y3iJgEyp9N7jo/Rdx5KkcvvB8zt" + '\n' +
+          "gPCh5diKDjbo3LxmYRt62heOLEPs2YDjKByn0Nikco3LqTnedJeXEH2mBc7x1VWE" + '\n' +
+          "0qTV4xqOXL9F7000Mv1cJcE2E88fN6tDge1IpuJbs03Ij0OgpaFRfS57NciBthgm" + '\n' +
+          "Bp3lREHYNVa4sqWHlUqakoNtc2H62t9nmpzFV7zXJkqKPPpanKV5Q9zOD0VKgcoF" + '\n' +
+          "yAuMkhuPV4IfOEbG8iiZozayk2nfRrm4+nz7b31/5Him2MEce3wbUtmWR6OPdswr" + '\n' +
+          "B6K58j8TGGzOAEDTdWc9yOf/auSIBVDw+23/TbrVD3xRWdesKa4sj7rMW+3VZ1mh" + '\n' +
+          "3/ghyhVPtvFcUKrAjjBjkdeMl84m+P+KcV9Ov57bojKVQdKc7kHrkpi4F66s4Z/J" + '\n' +
+          "ZvWHw4LyK4PRlRFzm8eKtXkYLFssxtTRYRydT4wh6VJaOQD2Ww1cPOc/D74Qr/ap" + '\n' +
+          "wQu/fx1Guqk1artbE+BalJakMNKd5Cu2/MfWt8kEjNctGrAHeDmznk/TbvX2rEpv" + '\n' +
+          "/P16WFcjB4bb1Nee96xfuGPUcHul3fG5TRmKJnaxWeg5FM4H4cP5jmeXyGNqdbDS" + '\n' +
+          "rgqpXChenTBwS5JvAVgv8ZvxJxp4h8fLFlUOKuKUR95gB09nBGnwAtEM4zgjKkcC" + '\n' +
+          "PcvDZ7YpzU40gx6QiCVb2UPtggiEp2WyIrpe8VfzK4C7pQGInLn3Rm4G7mEFacv5" + '\n' +
+          "HlbGJO+2XIk3ibFJYTQvMFYc/ESeRSOw6TDoy1sg3+Yl5BXYC+90lCGR9JK/sBYs" + '\n' +
+          "12eVEqxi8kmoNXJ4on0snfDuRDv/6bIIDpfPAKqZzbTq7h6wzIreoz3wx4Oa8A9V" + '\n' +
+          "rtG8TOkCYaoJRYD5uV1lc6Ok3CpZrI7kTGAfvQNi+H0Obz+sSXGksNtfdwNUzUd6" + '\n' +
+          "p4CXrZmc/r6o3j4biteWTURnRQqkh67QM5qHJhmXuWD82sjSKU16MM0KqPze/Tl+" + '\n' +
+          "+Figx8pgk29H6LM+N9Y=" + '\n' +
+          "-----END ENCRYPTED PRIVATE KEY-----";
+        var importCertificatePassword = '1234';
+        var importCertificatePolicy = '{ \"keyProperties\" : { \"exportable\" : true, \"keyType\" : \"RSA\", \"keySize\" : 2048, \"reuseKey\" : false }, \"secretProperties\" : { \"contentType\" : \"application/x-pem-file\" }, \"issuerReference\" : { \"name\" : \"Self\" } }';
+        var certificateFile = 'cert.pem';
+        fs.writeFileSync(certificateFile, importCertificateContent);
+
+        var certificateId;
+        importCertificateMustSucceed();
+
+        function importCertificateMustSucceed() {
+          suite.execute('keyvault certificate import %s %s --content-file %s --password %s --certificate-policy %s', testVault, certificateName, certificateFile, importCertificatePassword, importCertificatePolicy, function(result) {
+            result.exitStatus.should.be.equal(0);
+            fs.unlinkSync(certificateFile);
+            showCertificateMustSucceed();
+          });
+        }
+
+        function showCertificateMustSucceed() {
+          suite.execute('keyvault certificate show %s %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificate = JSON.parse(result.text);
+            certificate.should.have.property('id');
+            certificateId = certificate.id;
+            var subscription = profile.current.getSubscription();
+            certificateId.should.include(util.format('https://%s%s/certificates/%s/', testVault.toLowerCase(), subscription.keyVaultDnsSuffix, certificateName));
+            certificate.should.have.property('cer');
+            listCertificatesMustSucceed();
+          });
+        }
+
+        function listCertificatesMustSucceed() {
+          suite.execute('keyvault certificate list %s --json', testVault, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificateId.indexOf(certificate.id + '/') === 0;
+            }).should.be.true;
+            listCertificateVersionsMustSucceed();
+          });
+        }
+
+        function listCertificateVersionsMustSucceed() {
+          suite.execute('keyvault certificate list-versions %s -c %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificate.id === certificateId;
+            }).should.be.true;
+            deleteCertificateMustSucceed();
+          });
+        }
+
+        function deleteCertificateMustSucceed() {
+          suite.execute('keyvault certificate delete %s %s --quiet', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            showCertificateMustFail();
+          });
+        }
+
+        function showCertificateMustFail() {
+          suite.execute('keyvault certificate show %s %s', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(1);
+            result.errorText.should.include(util.format('Certificate %s not found', certificateName));
+            done();
+          });
+        }
+
+      });
+
+      it('certificate (self-signed) create and management commands should work', function(done) {
+
+        var certificateName = suite.generateId(certificatePrefix, knownNames);
+        var certificatePolicy, certificatePolicyFile;
+        var certificateOperation, certificateId;
+
+        createSelfSignedCertificateMustSucceed();
+
+        function createSelfSignedCertificateMustSucceed() {
+          suite.execute('keyvault certificate policy create --issuer-name Self --subject-name CN=AZURE --secret-content-type application/x-pem-file --validity-in-months 24 --json', function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificatePolicy = JSON.parse(result.text);
+            certificatePolicyFile = 'policy.js';
+            fs.writeFileSync(certificatePolicyFile, JSON.stringify(certificatePolicy));
+            createCertificateMustSucceed();
+          });
+        }
+
+        function createCertificateMustSucceed() {
+          suite.execute('keyvault certificate create %s %s --certificate-policy-file %s --json', testVault, certificateName, certificatePolicyFile, function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificateOperation = JSON.parse(result.text);
+            fs.unlinkSync(certificatePolicyFile);
+
+            // Wait 120 seconds for enrollment to complete.
+            var start = new Date().getTime();
+            while (new Date().getTime() < start + 120000);
+            enrollCertificateMustSucceed();
+          });
+        }
+
+        function enrollCertificateMustSucceed() {
+          suite.execute('keyvault certificate operation show %s %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificateOperation = JSON.parse(result.text);
+            certificateOperation.status.should.be.equal("completed");
+            showCertificateMustSucceed();
+          });
+        }
+
+        function showCertificateMustSucceed() {
+          suite.execute('keyvault certificate show %s %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificate = JSON.parse(result.text);
+            certificate.should.have.property('id');
+            certificateId = certificate.id;
+            var subscription = profile.current.getSubscription();
+            certificateId.should.include(util.format('https://%s%s/certificates/%s/', testVault.toLowerCase(), subscription.keyVaultDnsSuffix, certificateName));
+            certificate.should.have.property('cer');
+            listCertificatesMustSucceed();
+          });
+        }
+
+        function listCertificatesMustSucceed() {
+          suite.execute('keyvault certificate list %s --json', testVault, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificateId.indexOf(certificate.id + '/') === 0;
+            }).should.be.true;
+            listCertificateVersionsMustSucceed();
+          });
+        }
+
+        function listCertificateVersionsMustSucceed() {
+          suite.execute('keyvault certificate list-versions %s -c %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificate.id === certificateId;
+            }).should.be.true;
+            deleteCertificateMustSucceed();
+          });
+        }
+
+        function deleteCertificateMustSucceed() {
+          suite.execute('keyvault certificate delete %s %s --quiet', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            showCertificateMustFail();
+          });
+        }
+
+        function showCertificateMustFail() {
+          suite.execute('keyvault certificate show %s %s', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(1);
+            result.errorText.should.include(util.format('Certificate %s not found', certificateName));
+            done();
+          });
+        }
+
+      });
+
+      it('certificate (test provider based) create and management commands should work', function(done) {
+
+        var certificateName = suite.generateId(certificatePrefix, knownNames);
+        var certificateIssuerName = suite.generateId(certificateIssuerPrefix, knownNames);
+
+        var certificateAdministrator, certificateAdministratorFile;
+        var certificateOrganization, certificateOrganizationFile;
+        var certificateIssuer;
+        var certificatePolicy, certificatePolicyFile;
+        var certificateOperation, certificateId;
+
+        createIssuerBasedCertificateMustSucceed();
+
+        function createIssuerBasedCertificateMustSucceed() {
+          suite.execute('keyvault certificate administrator create --first-name John --last-name Doe --email-address john.doe@contoso.com --phone-number 5555555555 --json', function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificateAdministrator = JSON.parse(result.text);
+            certificateAdministratorFile = 'certificate-administrator.js';
+            fs.writeFileSync(certificateAdministratorFile, JSON.stringify(certificateAdministrator));
+            createCertificateOrganizationMustSucceed();
+          });
+        }
+
+        function createCertificateOrganizationMustSucceed() {
+          suite.execute('keyvault certificate organization create --id CONTOSO --certificate-administrator-file %s --json', certificateAdministratorFile, function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificateOrganization = JSON.parse(result.text);
+            certificateOrganizationFile = 'certificate-organization.js';
+            fs.writeFileSync(certificateOrganizationFile, JSON.stringify(certificateOrganization));
+            fs.unlinkSync(certificateAdministratorFile);
+            createCertificateIssuerMustSucceed();
+          });
+        }
+
+        function createCertificateIssuerMustSucceed() {
+          suite.execute('keyvault certificate issuer create %s --certificate-issuer-name %s --provider-name Test --account-id 1 --api-key 99 --certificate-organization-file %s --json', testVault, certificateIssuerName, certificateOrganizationFile, function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificateIssuer = JSON.parse(result.text);
+            fs.unlinkSync(certificateOrganizationFile);
+            createTestIssuerBasedCertificateMustSucceed();
+          });
+        }
+
+        function createTestIssuerBasedCertificateMustSucceed() {
+          suite.execute('keyvault certificate policy create --issuer-name %s --subject-name CN=AZURE --secret-content-type application/x-pem-file --validity-in-months 24 --json', certificateIssuerName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificatePolicy = JSON.parse(result.text);
+            certificatePolicyFile = 'policy.js';
+            fs.writeFileSync(certificatePolicyFile, JSON.stringify(certificatePolicy));
+            createCertificateMustSucceed();
+          });
+        }
+
+        function createCertificateMustSucceed() {
+          suite.execute('keyvault certificate create %s %s --certificate-policy-file %s --json', testVault, certificateName, certificatePolicyFile, function(result) {            
+            result.exitStatus.should.be.equal(0);
+            certificateOperation = JSON.parse(result.text);
+            fs.unlinkSync(certificatePolicyFile);
+
+            // Wait 120 seconds for enrollment to complete.
+            var start = new Date().getTime();
+            while (new Date().getTime() < start + 120000);
+            enrollCertificateMustSucceed();
+          });
+        }
+
+        function enrollCertificateMustSucceed() {
+          suite.execute('keyvault certificate operation show %s %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificateOperation = JSON.parse(result.text);
+            certificateOperation.status.should.be.equal("completed");
+            showCertificateMustSucceed();
+          });
+        }
+
+        function showCertificateMustSucceed() {
+          suite.execute('keyvault certificate show %s %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificate = JSON.parse(result.text);
+            certificate.should.have.property('id');
+            certificateId = certificate.id;
+            var subscription = profile.current.getSubscription();
+            certificateId.should.include(util.format('https://%s%s/certificates/%s/', testVault.toLowerCase(), subscription.keyVaultDnsSuffix, certificateName));
+            certificate.should.have.property('cer');
+            listCertificatesMustSucceed();
+          });
+        }
+
+        function listCertificatesMustSucceed() {
+          suite.execute('keyvault certificate list %s --json', testVault, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificateId.indexOf(certificate.id + '/') === 0;
+            }).should.be.true;
+            listCertificateVersionsMustSucceed();
+          });
+        }
+
+        function listCertificateVersionsMustSucceed() {
+          suite.execute('keyvault certificate list-versions %s -c %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificate.id === certificateId;
+            }).should.be.true;
+            deleteCertificateMustSucceed();
+          });
+        }
+
+        function deleteCertificateMustSucceed() {
+          suite.execute('keyvault certificate delete %s %s --quiet', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            showCertificateMustFail();
+          });
+        }
+
+        function showCertificateMustFail() {
+          suite.execute('keyvault certificate show %s %s', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(1);
+            result.errorText.should.include(util.format('Certificate %s not found', certificateName));
+            done();
+          });
+        }
+
+      });
+
+      it('certificate policy management commands should work', function(done) {
+
+        var certificateName = suite.generateId(certificatePrefix, knownNames);
+        var importCertificateContent = 'MIIKKAIBAzCCCeQGCSqGSIb3DQEHAaCCCdUEggnRMIIJzTCCBhYGCSqGSIb3DQEHAaCCBgcEggYDMIIF/zCCBfsGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAiKTp+7CoR5MwICB9AEggTY/IKeiENcZyCYPTY5sUKSMAmtZg7hT2YNqirIDX0EYjIf9lIzfF+uf2n5qfear6aVVD9L8LaTKdTSUkmoV9pbCW+rr1YDbEF5v/bp289+V5hg8tf+OIEEshzTxot7VKk/laVKM6uMumBPCQvdiZa69rt2m515Z9smOYU79CXW7YKtrGgnOnk9fuFc8uGvvtm1fWQZHi7Dtm3vdDt2tvpdFebV0DqAPtAZOWhF8KIUBEFL0rq0j/U3VtB0D9RElbhzi9zFHbBvQkSvri9oa+agUYexd87DlEeksgQXZaFMCkaxcAPvlzCSDB6KspfaprksoayxhmbfchRK9WOVkx4iQE84M7PP3c5wJ9z+BebtTpqc6rolUJAkKKqKe78yD+y0Bz9nme1i1YP4puqMNxdDZV+Vs0KzFfKeIr9BuIYlPMkggQ0dJJBTIpakc2NW+pU2vlzU2fSNzscVP9utIwYVlijGRROXF5yRNT5Ntharw/xiUg35LByuKpgdf0QIH7hrk4HUQpyBSiV1gE4aEjTq9EBbUf+oSxPa6ftdGOOUR1USIqoMBKw3g2PG5lSi1EL6yyFzy42E+E2Xi+T36senP3pEYzJjM8MfLKcaSTYwDEvVH7phQTY7OT7i5Ox8YG7MgKSMaQ4SQ8UVyfrc6EWYmY0rY/LdYoXxz6yrQyF9OlIEIGgZoOkW40jX2Jz9HW0dMFOPkRuqnL2zoEJnVQQLhgjdvYdTXmwv2+V8bxe7ePG3EKEUSuktZnsA5schBrTq4GkI62UJwZeeDFMDHjKIl+IE1gPpp4mR+APSslKBB2Z4Tenbu1AToMe4rDeyLJtDbuHuJ9VfyT/SwpeObihbr/VyRQMKVRvX2oIz/P0WU5l2Pm3pcen6E+jCij0K+SF4CDNT8uP2/ON6983RPjnGymPUQ73aIoWXTQsK9Bl5u+Jqdsn79nILAdMVwE94nv/N8waeS7g380129jnBvPT7BsWYybv9j1wDsiaW+Oy26GsLlbGzjtsa9KDTXPdYlDjnwEZdDxpKzijPrnvfq4qT0PsgMEZhcV0efT7BbuLzVokFUCr3eXKMP/OqBKlOIE/GE61+JlVRBtzB+dW5DYnWlJNjtfWBp+9PcZc/nhSqFrGrTehV6/0lpznQ/XNy6B7v6kNW5ngQe1pAl4E5z7oITsHG5crQcu/RM14mUWcs1xUgLjrIR+zdCcfkWMrXJeRoJvCilQLBiJ+cItri/tOL+gQnt6QVudkROrUmQLtKcI8WS3hxb+cWrTk5obaQAkOCTqh9ZNo2z3YO6Ek4FZTEs3gWiAVEgrxVzThJXNqbckfrvB7RY3MHCa8anbwJdWNAcdFImxH835TD42NtpcLxAJ/ucH8O2bmcBLUBvOhdK+aLMokiDvcaA1mVdJCuAewbRurt52TQRulYC1G67Q10Tt5NwRqrIn8GkfCtz1CUgMjhMmXCyFt2kefwWVlbOX0EjOZKUIosDuSlH4gV71vWDeq+JbkYSxJyG2E0Yhl6pGhgddmeeSU9UTuHji7fuCLFVtrlMgpd2sTLqzOWjcIFejbwHNNZkZjL5yWKUrpaqe5sd9WRy1U6PH/iK84ek6Pmo69Y/YvnTi8/DiYpmrap0cgcftHuNcd+h2OhgglTXuYnZsS07H4PyjGB6TATBgkqhkiG9w0BCRUxBgQEAQAAADBXBgkqhkiG9w0BCRQxSh5IAGEANgAyAGIANgA5AGMAMwAtADkAZgBjADAALQA0AGEAZQBmAC0AYQBjAGEAMwAtAGMAZABjAGMAMgAxADQAZAA1ADgANQAxMHkGCSsGAQQBgjcRATFsHmoATQBpAGMAcgBvAHMAbwBmAHQAIABFAG4AaABhAG4AYwBlAGQAIABSAFMAQQAgAGEAbgBkACAAQQBFAFMAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMIIDrwYJKoZIhvcNAQcGoIIDoDCCA5wCAQAwggOVBgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBBjAOBAjUGyZnibwFRAICB9CAggNoiczPdE4wuOyv6Ei5c5xij93/FKWdelietGpngONdsRKjC1+uzNokx/vgfe+O2OKj5fC5ZmmiYK84iot7bpHodjYWLXg35TcNWRzrDuilYw7LPFsS7WqhCrazldLjnJJEPEh2lYo96kllquYIzBaRXkuwCo9r0m29ofqV0SROJCs7va3wp5FUR8K8W9o18d3kZSK0DhEO6BsnKJet6GL/vU/N3Z/oLv5HGZNOAwSJni08CQfiq2qqgPLDfE5iZuVmUSFsNwIvxcTlIRG3FyYguX8jNzOG4NxW7OmgvUWuwFaoHrOdrIQN9zuWxSgdZOJgP6kH6DDg4KTzbeYb4Hy7Hi4G2UwusVYVdIOdg2y6gWXQBuD81t+CDzrmEp+EhAvYZSHfUOZla0I/MYU21aedZgTeoTklU3gD43CjxGWWdPUPdZJwXgSplxIIjnemjAJ+VluEX3V8JjNGDp+y68j0ts91y+72e5/KNc3pr6eXvZNTySOopMr/Pi1PkYfPymrCEqfelk572CcnmuyA99Vw4gr0jAMR0X0YYSZ5GnhaSCI1dCO+eCCjROosEJwNNcSPT17ycvEUFrX9mt8kXzRvOfW1xS+bn0GpicNWYMXkBw/rz8JR3LxgncsaPdcp724+vNgJuF4JiximjTd9TH4n9O6X9pCA68VdiPutNegOThqFGTs1b0WItayqfkTOzRg+JOZrk311ia2go+O7+T+EqB3JlVcq6F+yQ3Lkqp2Tr8d0UMMF7fR0bj8EwzEl0CuWGN5xyfJc3tQJznLJo9e2nYZtQ3tw5Dy3gwKfmO/FKQ2umxiX3ZvHk8/DIUYn++YH5EaGLlwppHPcKVy0X7Kii7LE1nekYkCRMC+sXpO0V8Eq91x2YxmSHyo1RJGra+kybZZ7cO3QBJwhS5PyosGZnR39z2ShHMk8PrbkQSFv3kJqxeIV4E2KnWnbxyjrXLS3XBhCyS4uCxiFZzXGcFXjlSAUnQ9DpHrxvoKbVipekVjOTjuoFk5SzkQgiOa+WREvHv3YU0iJGjnV78XB+ZKqG9q1ok/tEDssf0TaOL6cT0OV4BqRQyu6cuYk/630MpVbkJJG8OBg/5oL9muO2oFaxfVZGeQpWNTah9yaCj7piaXok43nnEne3CNvxCBCEBPz4GcDvlTOjy4wOzAfMAcGBSsOAwIaBBQFPX6XGMp7gA4008VqyInDcud/TQQUBqn/Em9qWdkmXyOdpr2zLZDjOFECAgfQ';
+        var importCertificatePassword = '123';
+        var importCertificatePolicy = '{ \"keyProperties\" : { \"exportable\" : true, \"keyType\" : \"RSA\", \"keySize\" : 2048, \"reuseKey\" : false }, \"secretProperties\" : { \"contentType\" : \"application/x-pkcs12\" }, \"issuerReference\" : { \"name\" : \"Self\" } }';
+
+        var certificatePolicy, certificatePolicyFile;
+        var certificateId;
+
+        importCertificateMustSucceed();
+
+        function importCertificateMustSucceed() {
+          suite.execute('keyvault certificate import %s %s --content %s --password %s --certificate-policy %s', testVault, certificateName, importCertificateContent, importCertificatePassword, importCertificatePolicy, function(result) {
+            result.exitStatus.should.be.equal(0);
+            showCertificateMustSucceed();
+          });
+        }
+
+        function showCertificateMustSucceed() {
+          suite.execute('keyvault certificate show %s %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificate = JSON.parse(result.text);
+            certificate.should.have.property('id');
+            certificateId = certificate.id;
+            var subscription = profile.current.getSubscription();
+            certificateId.should.include(util.format('https://%s%s/certificates/%s/', testVault.toLowerCase(), subscription.keyVaultDnsSuffix, certificateName));
+            certificate.should.have.property('cer');            
+            listCertificatesMustSucceed();
+          });
+        }
+
+        function listCertificatesMustSucceed() {
+          suite.execute('keyvault certificate list %s --json', testVault, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificateId.indexOf(certificate.id + '/') === 0;
+            }).should.be.true;
+            listCertificateVersionsMustSucceed();
+          });
+        }
+
+        function listCertificateVersionsMustSucceed() {
+          suite.execute('keyvault certificate list-versions %s -c %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificates = JSON.parse(result.text);
+            certificates.some(function(certificate) {
+              return certificate.id === certificateId;
+            }).should.be.true;
+            getCertificatePolicyMustSucceed();
+          });
+        }
+
+        function getCertificatePolicyMustSucceed() {
+          suite.execute('keyvault certificate policy show %s -c %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificatePolicy = JSON.parse(result.text);
+            certificatePolicy.x509CertificateProperties.validityInMonths.should.be.equal(298);
+
+            // Update validity to 300
+            certificatePolicy.x509CertificateProperties.validityInMonths = 300;
+            certificatePolicyFile = 'policy.js';
+            fs.writeFileSync(certificatePolicyFile, JSON.stringify(certificatePolicy));
+            updateCertificatePolicyMustSucceed();
+          });
+        }
+
+        function updateCertificatePolicyMustSucceed() {
+          suite.execute('keyvault certificate policy set %s -c %s --certificate-policy-file %s --json', testVault, certificateName, certificatePolicyFile, function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificatePolicy = JSON.parse(result.text);
+            certificatePolicy.x509CertificateProperties.validityInMonths.should.be.equal(300);
+            fs.unlinkSync(certificatePolicyFile);
+            getUpdatedCertificatePolicyMustSucceed();
+          });
+        }
+
+        function getUpdatedCertificatePolicyMustSucceed() {
+          suite.execute('keyvault certificate policy show %s -c %s --json', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificatePolicy = JSON.parse(result.text);
+            certificatePolicy.x509CertificateProperties.validityInMonths.should.be.equal(300);
+            deleteCertificateMustSucceed();
+          });
+        }
+
+        function deleteCertificateMustSucceed() {
+          suite.execute('keyvault certificate delete %s %s --quiet', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            showCertificateMustFail();
+          });
+        }
+
+        function showCertificateMustFail() {
+          suite.execute('keyvault certificate show %s %s', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(1);
+            result.errorText.should.include(util.format('Certificate %s not found', certificateName));
+            done();
+          });
+        }
+
+      });
+
+      it('certificate contact and management commands should work', function(done) {
+
+        addCertificateContactMustSucceed();
+
+        function addCertificateContactMustSucceed() {
+          suite.execute('keyvault certificate contact add %s --email-address john.doe@contoso.com --json', testVault, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificateContacts = JSON.parse(result.text);
+            certificateContacts.some(function(contact) {
+              return contact.emailAddress == "john.doe@contoso.com";
+            }).should.be.true;
+            listCertificateContactMustSucceed();
+          });
+        }
+
+        function listCertificateContactMustSucceed() {
+          suite.execute('keyvault certificate contact list %s --json', testVault, function(result) {
+            result.exitStatus.should.be.equal(0);
+            var certificateContacts = JSON.parse(result.text);
+            certificateContacts.some(function(contact) {
+              return contact.emailAddress == "john.doe@contoso.com";
+            }).should.be.true;
+            deleteCertificateContactMustSucceed();
+          });
+        }
+
+        function deleteCertificateContactMustSucceed() {
+          suite.execute('keyvault certificate contact delete %s --email-address john.doe@contoso.com --quiet', testVault, function(result) {
+            result.exitStatus.should.be.equal(0);
+            listCertificateContactsMustFail();
+          });
+        }
+
+        function listCertificateContactsMustFail() {
+          suite.execute('keyvault certificate contact list %s', testVault, function(result) {
+            result.exitStatus.should.be.equal(1);
+            result.errorText.should.include('Contacts not found');
+            done();
+          });
+        }
+
+      });
+
+      it('incorrect certificate merge should fail', function(done) {
+        var certificateName = suite.generateId(certificatePrefix, knownNames);
+        var certificateContent = '[ \"MIICODCCAeagAwIBAgIQqHmpBAv+CY9IJFoUhlbziTAJBgUrDgMCHQUAMBYxFDASBgNVBAMTC1Jvb3QgQWdlbmN5MB4XDTE1MDQyOTIxNTM0MVoXDTM5MTIzMTIzNTk1OVowFzEVMBMGA1UEAxMMS2V5VmF1bHRUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5bVAT73zr4+N4WVv2+SvTunAw08ksS4BrJW/nNliz3S9XuzMBMXvmYzU5HJ8TtEgluBiZZYd5qsMJD+OXHSNbsLdmMhni0jYX09h3XlC2VJw2sGKeYF+xEaavXm337aZZaZyjrFBrrUl51UePaN+kVFXNlBb3N3TYpqa7KokXenJQuR+i9Gv9a77c0UsSsDSryxppYhKK7HvTZCpKrhVtulF5iPMswWe9np3uggfMamyIsK/0L7X9w9B2qN7993RR0A00nOk4H6CnkuwO77dSsD0KJsk6FyAoZBzRXDZh9+d9R76zCL506NcQy/jl0lCiQYwsUX73PG5pxOh02OwKwIDAQABo0swSTBHBgNVHQEEQDA+gBAS5AktBh0dTwCNYSHcFmRjoRgwFjEUMBIGA1UEAxMLUm9vdCBBZ2VuY3mCEAY3bACqAGSKEc+41KpcNfQwCQYFKw4DAh0FAANBAGqIjo2geVagzuzaZOe1ClGKhZeiCKfWAxklaGN+qlGUbVS4IN4V1lot3VKnzabasmkEHeNxPwLn1qvSD0cX9CE=\" ]'
+
+        var certificatePolicy, certificatePolicyFile;
+
+        incorrectCertificateMergeShouldFail();
+
+        function incorrectCertificateMergeShouldFail() {
+          suite.execute('keyvault certificate policy create --issuer-name Unknown --subject-name CN=Test --json', function(result) {
+            result.exitStatus.should.be.equal(0);
+            certificatePolicy = JSON.parse(result.text);
+            certificatePolicyFile = 'policy.js';
+            fs.writeFileSync(certificatePolicyFile, JSON.stringify(certificatePolicy));
+            createCertificateForMergeMustSucceed();
+          });
+        }
+
+        function createCertificateForMergeMustSucceed() {
+          suite.execute('keyvault certificate create %s -c %s --certificate-policy-file %s --json', testVault, certificateName, certificatePolicyFile, function(result) {
+            result.exitStatus.should.be.equal(0);
+            fs.unlinkSync(certificatePolicyFile);
+            mergeCertificateMustFail();
+          });
+        }
+
+        function mergeCertificateMustFail() {
+          suite.execute('keyvault certificate merge %s -c %s --content %s', testVault, certificateName, certificateContent, function(result) {
+            result.exitStatus.should.be.equal(1);
+            result.errorText.should.include("Public key from x509 certificate and key of this instance doesn't match");
+            deleteCertificateMustSucceed();
+          });
+        }
+
+        function deleteCertificateMustSucceed() {
+          suite.execute('keyvault certificate delete %s %s --quiet', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(0);
+            showCertificateMustFail();
+          });
+        }
+
+        function showCertificateMustFail() {
+          suite.execute('keyvault certificate show %s %s', testVault, certificateName, function(result) {
+            result.exitStatus.should.be.equal(1);
+            result.errorText.should.include(util.format('Certificate %s not found', certificateName));
+            done();
+          });
+        }
+
+      });
+
+    });
+
+  });
+});

--- a/test/testlist-arm-keyvault-live.txt
+++ b/test/testlist-arm-keyvault-live.txt
@@ -2,4 +2,4 @@
 commands/arm/keyvault/arm.keyvault-tests.js
 commands/arm/keyvault/arm.keyvault-key-tests.js
 commands/arm/keyvault/arm.keyvault-secret-tests.js
-
+commands/arm/keyvault/arm.keyvault-certificate-tests.js


### PR DESCRIPTION
The content to be added to Changelog is as follows:
1. Move to autorest base node SDK
2. Add support for Key Vault certificates
3. Key Vault certificates tests