### PR TITLE
Fix #2601: 'vm set' command to support '--new-os-disk-size' input

### DIFF
--- a/lib/commands/arm/vm/vm._js
+++ b/lib/commands/arm/vm/vm._js
@@ -402,6 +402,7 @@ exports.init = function (cli) {
     .option('-t, --tags <tags>', $('Tags to set to the resource group. Can be multiple. ' +
             'In the format of \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))
     .option('-T, --no-tags', $('Remove all tags'))
+    .option('--new-os-disk-size <new-os-disk-size>', $('new OS disk size in GB'))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .option('--disable-boot-diagnostics', $('The switch parameter to disable the boot diagnostics for VM.'))
     .option('--enable-boot-diagnostics', $('The switch parameter to enable the boot diagnostics for VM.'))

--- a/lib/commands/arm/vm/vmProfile._js
+++ b/lib/commands/arm/vm/vmProfile._js
@@ -151,7 +151,7 @@ __.extend(VMProfile.prototype, {
         throw new Error($('Either only "--disable-boot-diagnostics" or "--enable-boot-diagnostics" with "--boot-diagnostics-storage-uri" can be specified.'));
       }
     }
-    else if (!utils.atLeastOneParameIsSet([this.params.nicIds, this.params.nicNames, this.params.vmSize]) && this.params.tags === true) {
+    else if (!utils.atLeastOneParameIsSet([this.params.nicIds, this.params.nicNames, this.params.vmSize, this.params.newOsDiskSize]) && this.params.tags === true) {
       throw new Error($('At least one optional parameter should be specified.'));
     }
 
@@ -179,6 +179,16 @@ __.extend(VMProfile.prototype, {
       var vmDiagnosticsProfile = new VMDiagnosticsProfile(this.cli, this.params);
       var diagnosticsProfileResult = vmDiagnosticsProfile.generateDiagnosticsProfile();
       virtualMachine.diagnosticsProfile = diagnosticsProfileResult.profile;
+    }
+    
+    if (this.params.newOsDiskSize) {
+      if (!virtualMachine.storageProfile) {
+        virtualMachine.storageProfile = {};
+      }
+      if (!virtualMachine.storageProfile.osDisk) {
+        virtualMachine.storageProfile.osDisk = {};
+      }
+      virtualMachine.storageProfile.osDisk.diskSizeGB = parseInt(this.params.newOsDiskSize);
     }
 
     return virtualMachine;

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -32389,6 +32389,14 @@
               "description": "Remove all tags"
             },
             {
+              "flags": "--new-os-disk-size <new-os-disk-size>",
+              "required": -20,
+              "optional": 0,
+              "bool": true,
+              "long": "--new-os-disk-size",
+              "description": "new OS disk size in GB"
+            },
+            {
               "flags": "-s, --subscription <subscription>",
               "required": -20,
               "optional": 0,


### PR DESCRIPTION
Fix #2601: 'vm set' command to support '--new-os-disk-size' input