### PR TITLE
switch to use file based token storage (enable creds sharing with new…

### DIFF
--- a/lib/util/authentication/adalAuth.js
+++ b/lib/util/authentication/adalAuth.js
@@ -25,15 +25,13 @@ var adal = require('adal-node');
 var utils = require('../utils');
 var defaultTokenCacheFile = path.join(utils.azureDir(), 'accessTokens.json');
 
-var useFileTokenStorage = !!process.env['AZURE_USE_FILE_TOKEN_STORAGE']; 
+var useSecureTokenStorage = process.env['AZURE_USE_SECURE_TOKEN_STORAGE']; 
 var TokenStorage;
-if (useFileTokenStorage) {
-  TokenStorage = require('./file-token-storage');
-} else if (os.platform() === 'darwin') {
+if (useSecureTokenStorage && os.platform() === 'darwin') {
   TokenStorage = require('./osx-token-storage');
-} else if (os.platform() === 'win32') {
+} else if (useSecureTokenStorage && os.platform() === 'win32') {
   TokenStorage = require('./win-token-storage');
-} else { //we should never come to here, but just in case.
+} else {
   TokenStorage = require('./file-token-storage');
 }
 var TokenCache = require('./token-cache');


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* By default azure-cli will now save access tokens to ~/.azure/accessTokens.json for OSX and Window, like it does on Linux. When you install this version, please run `login` to re-establish the credentials. If you prefer old behaviors of using secure storage, you can turn on the env variable of `AZURE_USE_SECURE_TOKEN_STORAGE`

