### PR TITLE
upgrade azure-common package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "adal-node": "0.1.21",
     "async": "1.4.2",
-    "azure-common": "0.9.17",
+    "azure-common": "0.9.18",
     "azure-arm-authorization": "2.0.0",
     "azure-arm-cdn": "0.2.1",
     "azure-arm-commerce": "0.1.1",


### PR DESCRIPTION
The content to be added to Changelog is as follows:
- to resolve npm deprecated package warn from usage of tough-cookie@2.2.2

This resolves the last of such warnings mentioned at https://github.com/Azure/azure-xplat-cli/issues/3108 and hence closes the bug.