### PR TITLE
Added support for IP filtering rule commands in IotHub

### DIFF
--- a/lib/commands/arm/iothub/iothub._js
+++ b/lib/commands/arm/iothub/iothub._js
@@ -496,7 +496,7 @@ exports.init = function (cli) {
     .option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
     .option('-n --name <name>', $('The name of the IoT hub'))
     .option('-s --subscription [subscription]', $('The subscription identifier'))
-	.fileRelatedOption('-f --output-file [output-file]', $('the path to the JSON-formatted output IP filter rules file in the file system'))
+    .fileRelatedOption('-f --output-file [output-file]', $('the path to the JSON-formatted output IP filter rules file in the file system'))
     .execute(function (resourceGroup, name, options, _) {
 
       ////////////////////////////
@@ -510,8 +510,8 @@ exports.init = function (cli) {
       if (!name) {
         return cli.missingArgument('name');
       }
-	  
-	  /////////////////////////
+      
+      /////////////////////////
       // Create the client.  //
       /////////////////////////
 
@@ -520,7 +520,7 @@ exports.init = function (cli) {
       var progress = cli.interaction.progress($('Getting the IP filter rules.'));
       var iothubDescription;
 
-	  ////////////////////////////////////////
+      ////////////////////////////////////////
       // Load existing iothub description.  //
       ////////////////////////////////////////
       try {
@@ -532,19 +532,24 @@ exports.init = function (cli) {
       ////////////////////////////////////////
       // Output the result.                 //
       ////////////////////////////////////////
-	 
-	  if (iothubDescription) { 
-		if (options.outputFile) {
-			var fs = require('fs');
-			fs.writeFileSync(options.outputFile, JSON.stringify(iothubDescription.properties.ipFilterRules, null, 2));
-		}
+     
+      if (iothubDescription) { 
+        if (options.outputFile) {
+          try {
+            var fs = require('fs');
+            fs.writeFileSync(options.outputFile, JSON.stringify(iothubDescription.properties.ipFilterRules, null, 2));
+          } catch (e) {
+		    log.error('Could not write to file ' + options.outputFile + ' Error Details :');
+			throw e;
+		  }
+        }
 
-		cli.interaction.formatOutput(iothubDescription.properties.ipFilterRules, function (ipFilterRules) {
-			log.table(ipFilterRules, function (row, rule) {
-				row.cell($('FilterName'), rule.filterName);
-				row.cell($('Action'), rule.action);
-				row.cell($('IpMask'), rule.ipMask);
-			});
+        cli.interaction.formatOutput(iothubDescription.properties.ipFilterRules, function (ipFilterRules) {
+            log.table(ipFilterRules, function (row, rule) {
+                row.cell($('FilterName'), rule.filterName);
+                row.cell($('Action'), rule.action);
+                row.cell($('IpMask'), rule.ipMask);
+            });
         });
       }
     });
@@ -552,14 +557,14 @@ exports.init = function (cli) {
   /**
    * Set the Iot Hub IP Filter Rules
    */
-  iotHubIpFilterRules.command('set [resource-group] [name]')
+  iotHubIpFilterRules.command('set [resource-group] [name] [inputFile]')
     .description($('set the IoT hub IP filter rules'))
     .usage('<resourceGroup> <name> <inputFile> [options]')
     .option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
     .option('-n --name <name>', $('The name of the IoT hub'))
     .option('-s --subscription [subscription]', $('The subscription identifier'))
     .fileRelatedOption('-f --input-file <inputFile>', $('the path to the JSON-formatted input IP filter rules file in the file system'))
-    .execute(function (resourceGroup, name, options, _) {
+    .execute(function (resourceGroup, name, inputFile, options, _) {
 
       ////////////////////////////
       // Argument Validations.  //
@@ -573,11 +578,11 @@ exports.init = function (cli) {
         return cli.missingArgument('name');
       }
 
-	  if (!options.inputFile) {
-        return cli.missingArgument('ipfilter-rules');
+      if (!inputFile) {
+        return cli.missingArgument('inputFile');
       }
 
-	  /////////////////////////
+      /////////////////////////
       // Create the client.  //
       /////////////////////////
 
@@ -586,7 +591,7 @@ exports.init = function (cli) {
       var progress = cli.interaction.progress($('Getting the IP filter rules.'));
       var iothubDescription;
 
-	  ////////////////////////////////////////
+      ////////////////////////////////////////
       // Load existing iothub description.  //
       ////////////////////////////////////////
       try {
@@ -595,16 +600,21 @@ exports.init = function (cli) {
         progress.end();
       }
 
-	  ////////////////////////////////////////
+      ////////////////////////////////////////
       // Setting the properties.            //
       ////////////////////////////////////////
 
-	  if (iothubDescription) {  	  
-		var fs = require('fs');
-		var jsonFile = fs.readFileSync(options.inputFile);
-		iothubDescription.properties.ipFilterRules= JSON.parse(utils.stripBOM(jsonFile));
-	  }
-	  
+      if (iothubDescription) {
+	    try {
+          var fs = require('fs');
+          var jsonFile = fs.readFileSync(inputFile);
+          iothubDescription.properties.ipFilterRules= JSON.parse(utils.stripBOM(jsonFile));
+		} catch (e) {
+		  log.error('Could not read from file ' + options.outputFile + ' Error Details :');
+		  throw e;
+		}
+      }
+      
       ////////////////////////////////////////
       // Issue the update.                  //
       ////////////////////////////////////////
@@ -794,7 +804,7 @@ exports.init = function (cli) {
   iotHubfuproperties.command('set [resource-group] [name]')
     .description($('Set the File upload Properties of an IoT hub'))
     .usage('<resourceGroup> <name> [options]')
-	.option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
+    .option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
     .option('-n --name <name>', $('The name of the IoT hub'))
     .option('-x --enable-fileupload-notifications [enableFileuploadNotifications]', $('The flag that specifies if the file upload notifications should be turned on, one of true, false'))
     .option('-S --fileupload-storage-connectionstring [fileuploadStorageConnectionstring]', $('The storage connection string where the files are to be uploaded'))
@@ -1180,7 +1190,7 @@ exports.init = function (cli) {
   iotHubehcg.command('list [resource-group] [name]')
     .description($('List the event hub consumer groups of an IoT hub'))
     .usage('<resourceGroup> <name> [options]')
-	.option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
+    .option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
     .option('-n --name <name>', $('The name of the IoT hub'))
     .option('-e --eh-endpoint-type <ehEndpointType>', $('The type of the event hub endpoint. One of events, operationsMonitoringEvents'))
     .option('-s --subscription [subscription]', $('The subscription identifier'))
@@ -1239,7 +1249,7 @@ exports.init = function (cli) {
   iotHubehcg.command('create [resource-group] [name]')
     .description($('Add an Event Hub consumer groups for an IoT hub'))
     .usage('<resourceGroup> <name> [options]')
-	.option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
+    .option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
     .option('-n --name <name>', $('The name of the IoT hub'))
     .option('-e --eh-endpoint-type <ehEndpointType>', $('The type of the event hub endpoint. One of events, operationsMonitoringEvents'))
     .option('-c --eh-consumer-group <ehConsumerGroup>', $('The name of the event hub consumer group'))
@@ -1289,7 +1299,7 @@ exports.init = function (cli) {
   iotHubehcg.command('delete [resource-group] [name]')
     .description($('Delete an Event Hub consumer group for an IoT hub'))
     .usage('<resourceGroup> <name> [options]')
-	.option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
+    .option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
     .option('-n --name <name>', $('The name of the IoT hub'))
     .option('-e --eh-endpoint-type <ehEndpointType>', $('The type of the event hub endpoint. One of events, operationsMonitoringEvents'))
     .option('-c --eh-consumer-group <ehConsumerGroup>', $('The name of the event hub consumer group'))
@@ -1712,7 +1722,7 @@ exports.init = function (cli) {
   iotHubOpMon.command('set [resource-group] [name]')
     .description($('Update the operations monitoring properties for an IoT hub'))
     .usage('<resourceGroup> <name> [options]')
-	.option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
+    .option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
     .option('-n --name <name>', $('The name of the IotHub'))
     .option('-c --opmon-category <opmonCategory>', $('The name of the operations monitoring category. One of Connections, DeviceTelemetry, C2DCommands, DeviceIdentityOperations, FileUploadOperations'))
     .option('-l --diagnostic-level <diagnosticLevel>', $('The diagnostic level. None, Error, Information.'))

--- a/lib/commands/arm/iothub/iothub._js
+++ b/lib/commands/arm/iothub/iothub._js
@@ -484,6 +484,148 @@ exports.init = function (cli) {
       }
     });
 
+  var iotHubIpFilterRules = cli.category('iothub').category('ipfilter-rules')
+    .description($('Commands to manage the IP filter rules of an IoT hub'));
+
+  /**
+   * List the Iot Hub IP Filter Rules
+   */
+  iotHubIpFilterRules.command('list [resource-group] [name]')
+    .description($('List the IoT hub IP filter rules'))
+    .usage('<resourceGroup> <name> [options]')
+    .option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
+    .option('-n --name <name>', $('The name of the IoT hub'))
+    .option('-s --subscription [subscription]', $('The subscription identifier'))
+	.fileRelatedOption('-f --output-file [output-file]', $('the path to the JSON-formatted output IP filter rules file in the file system'))
+    .execute(function (resourceGroup, name, options, _) {
+
+      ////////////////////////////
+      // Argument Validations.  //
+      ////////////////////////////
+
+      if (!resourceGroup) {
+        return cli.missingArgument('resource-group');
+      }
+
+      if (!name) {
+        return cli.missingArgument('name');
+      }
+	  
+	  /////////////////////////
+      // Create the client.  //
+      /////////////////////////
+
+      var subscription = profile.current.getSubscription(options.subscription);
+      var client = utils.getiotHubClient(subscription);
+      var progress = cli.interaction.progress($('Getting the IP filter rules.'));
+      var iothubDescription;
+
+	  ////////////////////////////////////////
+      // Load existing iothub description.  //
+      ////////////////////////////////////////
+      try {
+        iothubDescription = client.iotHubResource.get(resourceGroup, name, _);
+      } finally {
+        progress.end();
+      }
+
+      ////////////////////////////////////////
+      // Output the result.                 //
+      ////////////////////////////////////////
+	 
+	  if (iothubDescription) { 
+		if (options.outputFile) {
+			var fs = require('fs');
+			fs.writeFileSync(options.outputFile, JSON.stringify(iothubDescription.properties.ipFilterRules, null, 2));
+		}
+
+		cli.interaction.formatOutput(iothubDescription.properties.ipFilterRules, function (ipFilterRules) {
+			log.table(ipFilterRules, function (row, rule) {
+				row.cell($('FilterName'), rule.filterName);
+				row.cell($('Action'), rule.action);
+				row.cell($('IpMask'), rule.ipMask);
+			});
+        });
+      }
+    });
+
+  /**
+   * Set the Iot Hub IP Filter Rules
+   */
+  iotHubIpFilterRules.command('set [resource-group] [name]')
+    .description($('set the IoT hub IP filter rules'))
+    .usage('<resourceGroup> <name> <inputFile> [options]')
+    .option('-g --resource-group <resourceGroup>', $('The name of the resource group'))
+    .option('-n --name <name>', $('The name of the IoT hub'))
+    .option('-s --subscription [subscription]', $('The subscription identifier'))
+    .fileRelatedOption('-f --input-file <inputFile>', $('the path to the JSON-formatted input IP filter rules file in the file system'))
+    .execute(function (resourceGroup, name, options, _) {
+
+      ////////////////////////////
+      // Argument Validations.  //
+      ////////////////////////////
+
+      if (!resourceGroup) {
+        return cli.missingArgument('resource-group');
+      }
+
+      if (!name) {
+        return cli.missingArgument('name');
+      }
+
+	  if (!options.inputFile) {
+        return cli.missingArgument('ipfilter-rules');
+      }
+
+	  /////////////////////////
+      // Create the client.  //
+      /////////////////////////
+
+      var subscription = profile.current.getSubscription(options.subscription);
+      var client = utils.getiotHubClient(subscription);
+      var progress = cli.interaction.progress($('Getting the IP filter rules.'));
+      var iothubDescription;
+
+	  ////////////////////////////////////////
+      // Load existing iothub description.  //
+      ////////////////////////////////////////
+      try {
+        iothubDescription = client.iotHubResource.get(resourceGroup, name, _);
+      } finally {
+        progress.end();
+      }
+
+	  ////////////////////////////////////////
+      // Setting the properties.            //
+      ////////////////////////////////////////
+
+	  if (iothubDescription) {  	  
+		var fs = require('fs');
+		var jsonFile = fs.readFileSync(options.inputFile);
+		iothubDescription.properties.ipFilterRules= JSON.parse(utils.stripBOM(jsonFile));
+	  }
+	  
+      ////////////////////////////////////////
+      // Issue the update.                  //
+      ////////////////////////////////////////
+
+      var progress = cli.interaction.progress(util.format($('Updating IoT hub %s'), name));
+      var result;
+      try {
+        result = client.iotHubResource.createOrUpdate(resourceGroup, name, iothubDescription, _);
+      } finally {
+        progress.end();
+      }
+
+      ////////////////////////////////////////
+      // Output the result.                 //
+      ////////////////////////////////////////
+
+      if (result) {
+        showResource(result);
+      }
+    });
+
   var iotHubd2cproperties = cli.category('iothub').category('device-to-cloud-properties')
     .description($('Commands to manage the Device to Cloud Properties of an IoT hub'));
 
@@ -2020,7 +2162,7 @@ exports.init = function (cli) {
 
     });
 
-  function notFoundError(resourceGroup, name) {
+  function notFoundError(resourceGroup, name) { 
     var msg;
     if (resourceGroup) {
       msg = util.format($('IoT hub not found on resource group %s: %s'), resourceGroup, name);

--- a/lib/commands/arm/iothub/iothub._js
+++ b/lib/commands/arm/iothub/iothub._js
@@ -609,7 +609,7 @@ exports.init = function (cli) {
       // Issue the update.                  //
       ////////////////////////////////////////
 
-      var progress = cli.interaction.progress(util.format($('Updating IoT hub %s'), name));
+      progress = cli.interaction.progress(util.format($('Updating IoT hub %s'), name));
       var result;
       try {
         result = client.iotHubResource.createOrUpdate(resourceGroup, name, iothubDescription, _);

--- a/lib/plugins.arm.json
+++ b/lib/plugins.arm.json
@@ -50275,6 +50275,158 @@
         }
       ],
       "categories": {
+        "ipfilter-rules": {
+          "name": "ipfilter-rules",
+          "description": "Commands to manage the IP filter rules of an IoT hub",
+          "fullName": "iothub ipfilter-rules",
+          "usage": "[options] [command]",
+          "options": [],
+          "commands": [
+            {
+              "name": "list",
+              "description": "List the IoT hub IP filter rules",
+              "fullName": "iothub ipfilter-rules list",
+              "usage": "<resourceGroup> <name> [options]",
+              "filePath": "commands/arm/iothub/iothub._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-g --resource-group <resourceGroup>",
+                  "required": -21,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-g",
+                  "long": "--resource-group",
+                  "description": "The name of the resource group"
+                },
+                {
+                  "flags": "-n --name <name>",
+                  "required": -11,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-n",
+                  "long": "--name",
+                  "description": "The name of the IoT hub"
+                },
+                {
+                  "flags": "-s --subscription [subscription]",
+                  "required": 0,
+                  "optional": -19,
+                  "bool": true,
+                  "short": "-s",
+                  "long": "--subscription",
+                  "description": "The subscription identifier"
+                },
+                {
+                  "flags": "-f --output-file [output-file]",
+                  "required": 0,
+                  "optional": -18,
+                  "bool": true,
+                  "short": "-f",
+                  "long": "--output-file",
+                  "description": "the path to the JSON-formatted output IP filter rules file in the file system",
+                  "fileRelatedOption": true
+                }
+              ]
+            },
+            {
+              "name": "set",
+              "description": "set the IoT hub IP filter rules",
+              "fullName": "iothub ipfilter-rules set",
+              "usage": "<resourceGroup> <name> <inputFile> [options]",
+              "filePath": "commands/arm/iothub/iothub._js",
+              "options": [
+                {
+                  "flags": "-v, --verbose",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-v",
+                  "long": "--verbose",
+                  "description": "use verbose output"
+                },
+                {
+                  "flags": "-vv",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "-vv",
+                  "description": "more verbose with debug output"
+                },
+                {
+                  "flags": "--json",
+                  "required": 0,
+                  "optional": 0,
+                  "bool": true,
+                  "long": "--json",
+                  "description": "use json output"
+                },
+                {
+                  "flags": "-g --resource-group <resourceGroup>",
+                  "required": -21,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-g",
+                  "long": "--resource-group",
+                  "description": "The name of the resource group"
+                },
+                {
+                  "flags": "-n --name <name>",
+                  "required": -11,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-n",
+                  "long": "--name",
+                  "description": "The name of the IoT hub"
+                },
+                {
+                  "flags": "-s --subscription [subscription]",
+                  "required": 0,
+                  "optional": -19,
+                  "bool": true,
+                  "short": "-s",
+                  "long": "--subscription",
+                  "description": "The subscription identifier"
+                },
+                {
+                  "flags": "-f --input-file <inputFile>",
+                  "required": -17,
+                  "optional": 0,
+                  "bool": true,
+                  "short": "-f",
+                  "long": "--input-file",
+                  "description": "the path to the JSON-formatted input IP filter rules file in the file system",
+                  "fileRelatedOption": true
+                }
+              ]
+            }
+          ],
+          "categories": {}
+        },
         "device-to-cloud-properties": {
           "name": "device-to-cloud-properties",
           "description": "Commands to manage the Device to Cloud Properties of an IoT hub",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "azure-arm-hdinsight": "0.2.0",
     "azure-arm-hdinsight-jobs": "0.1.0",
     "azure-arm-insights": "0.11.3",
-    "azure-arm-iothub": "0.1.1",
+    "azure-arm-iothub": "0.1.4",
     "azure-arm-servermanagement": "0.1.2",
     "azure-arm-network": "0.17.0",
     "azure-arm-powerbiembedded": "0.1.0",

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -19,7 +19,7 @@ var should = require('should');
 
 var path = require('path');
 var util = require('util');
-var fs = require('fs')
+var fs = require('fs');
 
 var CLITest = require('../../../framework/arm-cli-test');
 var log = require('../../../framework/test-logger');
@@ -28,7 +28,7 @@ var utils = require('../../../../lib/util/utils');
 
 var testPrefix = 'arm-cli-iothub-tests';
 var iothubPrefix = 'xplattestiothub';
-var ipFilterRulesFile = 'ipfilterrules.txt';
+var ipFilterRulesFile = path.join(__dirname, '/ipfilterrules.txt');
 var knownNames = [];
 
 var requiredEnvironment = [{
@@ -143,31 +143,30 @@ describe('arm', function () {
 
           listAndSetIpFilterRulesMustSucceed();
 
+          function listAndSetIpFilterRulesMustSucceed() {
+              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
+                  result.exitStatus.should.be.equal(0);
+                  var jsonFile = fs.readFileSync(ipFilterRulesFile);
+                  var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
+                  ipFilterRules.length.should.be.equal(0);
+                  fs.writeFileSync(ipFilterRulesFile, '[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]');
+                  setIpFilterRulesMustSucceed();
+              });
+          }
+
           function setIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules set --name %s --resource-group %s --input-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
                   result.exitStatus.should.be.equal(0);
+                  listIpFilterRulesMustSucceed();
               });
           }
 
           function listIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
                   result.exitStatus.should.be.equal(0);
-                  jsonFile = fs.readFileSync(ipFilterRulesFile);
-                  ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
-                  ipFilterRules.length.should.be.equal(2);
-              });
-          }
-
-          function listAndSetIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
-                  result.exitStatus.should.be.equal(0);
-                  var fs = require("fs");
                   var jsonFile = fs.readFileSync(ipFilterRulesFile);
                   var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
-                  ipFilterRules.length.should.be.equal(0);
-                  fs.writeFileSync(ipFilterRulesFile, '[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]');
-                  setIpFilterRulesMustSucceed();
-                  listIpFilterRulesMustSucceed();
+                  ipFilterRules.length.should.be.equal(2);
                   done();
               });
           }

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -142,13 +142,13 @@ describe('arm', function () {
           listAndSetIpFilterRulesMustSucceed();
 
           function setIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules set --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (setResult) {
+              suite.execute('iothub ipfilter-rules set --name %s --resource-group %s --input-file %s', iothubName, testResourceGroup, 'ipfilterrules.txt', function (setResult) {
                   setResult.exitStatus.should.be.equal(0);
               });
           }
 
           function listIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (listResult) {
+              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, 'ipfilterrules.txt', function (listResult) {
                   listResult.exitStatus.should.be.equal(0);
                   jsonFile = fs.readFileSync("ipfilterrules.txt");
                   ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
@@ -157,13 +157,13 @@ describe('arm', function () {
           }
 
           function listAndSetIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (result) {
-                  result.exitStatus.should.be.equal(0);
+              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, 'ipfilterrules.txt', function (listAndSetResult) {
+                  listAndSetResult.exitStatus.should.be.equal(0);
                   var fs = require("fs");
-                  var jsonFile = fs.readFileSync("ipfilterrules.txt");
+                  var jsonFile = fs.readFileSync('ipfilterrules.txt');
                   var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
                   ipFilterRules.length.should.be.equal(0);
-                  fs.writeFileSync("ipfilterrules.txt", "[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]");
+                  fs.writeFileSync('ipfilterrules.txt', '[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]');
                   setIpFilterRulesMustSucceed();
                   listIpFilterRulesMustSucceed();
                   done();

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -158,7 +158,6 @@ describe('arm', function () {
           function setIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules set --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function(result) {
                   result.exitStatus.should.be.equal(0);
-                  done();
               });
           }
 

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -142,7 +142,7 @@ describe('arm', function () {
           listAndSetIpFilterRulesMustSucceed();
 
           function listAndSetIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --json -f ipfilterrules.txt', iothubName, testResourceGroup, function (result) {
+              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (result) {
                   result.exitStatus.should.be.equal(0);
                   var fs = require("fs");
                   var jsonFile = fs.readFileSync("ipfilterrules.txt");

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -141,6 +141,21 @@ describe('arm', function () {
       it('ip filter rules set and list command using files should work', function (done) {
           listAndSetIpFilterRulesMustSucceed();
 
+          function setIpFilterRulesMustSucceed() {
+              suite.execute('iothub ipfilter-rules set --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (setResult) {
+                  setResult.exitStatus.should.be.equal(0);
+              });
+          }
+
+          function listIpFilterRulesMustSucceed() {
+              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (listResult) {
+                  listResult.exitStatus.should.be.equal(0);
+                  jsonFile = fs.readFileSync("ipfilterrules.txt");
+                  ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
+                  ipFilterRules.length.should.be.equal(2);
+              });
+          }
+
           function listAndSetIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules list --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (result) {
                   result.exitStatus.should.be.equal(0);
@@ -151,23 +166,8 @@ describe('arm', function () {
                   fs.writeFileSync("ipfilterrules.txt", "[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]");
                   setIpFilterRulesMustSucceed();
                   listIpFilterRulesMustSucceed();
-              });
-          }
-
-          function setIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules set --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function(result) {
-                  result.exitStatus.should.be.equal(0);
-              });
-          }
-
-          function listIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (result) {
-                  result.exitStatus.should.be.equal(0);
-                  jsonFile = fs.readFileSync("ipfilterrules.txt");
-                  ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
-                  ipFilterRules.length.should.be.equal(2);
                   done();
-             });
+              });
           }
       });
     });

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -138,6 +138,40 @@ describe('arm', function () {
         });
       });
 
+      it('ip filter rules set and list command using files should work', function (done) {
+          listAndSetIpFilterRulesMustSucceed();
+
+          function listAndSetIpFilterRulesMustSucceed() {
+              var fs = require("fs");
+              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --json -f ipfilterrules.txt', iothubName, testResourceGroup, function (result) {
+                  result.exitStatus.should.be.equal(0);
+                  var jsonFile = fs.readFileSync("ipfilterrules.txt");
+                  var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
+                  ipFilterRules.length.should.be.equal(0);
+                  fs.writeFileSync("ipfilterrules.txt",
+                      "[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]");
+                  setIpFilterRulesMustSucceed();
+                  listIpFilterRulesMustSucceed();
+              });
+          }
+
+          function setIpFilterRulesMustSucceed() {
+              suite.execute('iothub ipfilter-rules set --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function(result) {
+                  result.exitStatus.should.be.equal(0);
+                  done();
+              });
+          }
+
+          function listIpFilterRulesMustSucceed() {
+              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (result) {
+                  result.exitStatus.should.be.equal(0);
+                  var jsonFile = fs.readFileSync("ipfilterrules.txt");
+                  var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
+                  ipFilterRules.length.should.be.equal(2);
+                  done();
+             });
+          }
+      });
     });
 
     describe.skip('All Tests', function () {

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -145,6 +145,7 @@ describe('arm', function () {
 
           function listAndSetIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
+                  console.log(">>>>>>>>>>>>>> IPFilterRules 1 " + util.inspect(result, { depth: null }));
                   result.exitStatus.should.be.equal(0);
                   var jsonFile = fs.readFileSync(ipFilterRulesFile);
                   var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
@@ -156,6 +157,7 @@ describe('arm', function () {
 
           function setIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules set --name %s --resource-group %s --input-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
+                  console.log(">>>>>>>>>>>>>> IPFilterRules 2 " + util.inspect(result, { depth: null }));
                   result.exitStatus.should.be.equal(0);
                   listIpFilterRulesMustSucceed();
               });
@@ -163,6 +165,7 @@ describe('arm', function () {
 
           function listIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
+                  console.log(">>>>>>>>>>>>>> IPFilterRules 3 " + util.inspect(result, { depth: null }));
                   result.exitStatus.should.be.equal(0);
                   var jsonFile = fs.readFileSync(ipFilterRulesFile);
                   var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -167,16 +167,14 @@ describe('arm', function () {
                   ipFilterRules.length.should.be.equal(0);
                   fs.writeFileSync(ipFilterRulesFile, '[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]');
                   setIpFilterRulesMustSucceed();
-                  fs.unlinkSync(ipFilterRulesFile);
                   listIpFilterRulesMustSucceed();
-                  fs.unlinkSync(ipFilterRulesFile);
                   done();
               });
           }
       });
     });
 
-    describe('All Tests', function () {
+    describe.skip('All Tests', function () {
 
       it('create command should work', function (done) {
         iothubName = suite.generateId(iothubPrefix, knownNames);

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -28,6 +28,7 @@ var utils = require('../../../../lib/util/utils');
 
 var testPrefix = 'arm-cli-iothub-tests';
 var iothubPrefix = 'xplattestiothub';
+var ipFilterRulesFile = 'ipfilterrules.txt';
 var knownNames = [];
 
 var requiredEnvironment = [{
@@ -139,31 +140,32 @@ describe('arm', function () {
       });
 
       it('ip filter rules set and list command using files should work', function (done) {
+          var fs = require("fs");
+          fs.unlinkSync(ipFilterRulesFile);
           listAndSetIpFilterRulesMustSucceed();
 
           function setIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules set --name %s --resource-group %s --input-file %s', iothubName, testResourceGroup, 'ipfilterrules.txt', function (setResult) {
-                  setResult.exitStatus.should.be.equal(0);
+              suite.execute('iothub ipfilter-rules set --name %s --resource-group %s --input-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
+                  result.exitStatus.should.be.equal(0);
               });
           }
 
           function listIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, 'ipfilterrules.txt', function (listResult) {
-                  listResult.exitStatus.should.be.equal(0);
-                  jsonFile = fs.readFileSync("ipfilterrules.txt");
+              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
+                  result.exitStatus.should.be.equal(0);
+                  jsonFile = fs.readFileSync(ipFilterRulesFile);
                   ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
                   ipFilterRules.length.should.be.equal(2);
               });
           }
 
           function listAndSetIpFilterRulesMustSucceed() {
-              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, 'ipfilterrules.txt', function (listAndSetResult) {
-                  listAndSetResult.exitStatus.should.be.equal(0);
-                  var fs = require("fs");
-                  var jsonFile = fs.readFileSync('ipfilterrules.txt');
+              suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
+                  result.exitStatus.should.be.equal(0);
+                  var jsonFile = fs.readFileSync(ipFilterRulesFile);
                   var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
                   ipFilterRules.length.should.be.equal(0);
-                  fs.writeFileSync('ipfilterrules.txt', '[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]');
+                  fs.writeFileSync(ipFilterRulesFile, '[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]');
                   setIpFilterRulesMustSucceed();
                   listIpFilterRulesMustSucceed();
                   done();
@@ -172,7 +174,7 @@ describe('arm', function () {
       });
     });
 
-    describe.skip('All Tests', function () {
+    describe('All Tests', function () {
 
       it('create command should work', function (done) {
         iothubName = suite.generateId(iothubPrefix, knownNames);

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -142,14 +142,13 @@ describe('arm', function () {
           listAndSetIpFilterRulesMustSucceed();
 
           function listAndSetIpFilterRulesMustSucceed() {
-              var fs = require("fs");
               suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --json -f ipfilterrules.txt', iothubName, testResourceGroup, function (result) {
                   result.exitStatus.should.be.equal(0);
+                  var fs = require("fs");
                   var jsonFile = fs.readFileSync("ipfilterrules.txt");
                   var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
                   ipFilterRules.length.should.be.equal(0);
-                  fs.writeFileSync("ipfilterrules.txt",
-                      "[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]");
+                  fs.writeFileSync("ipfilterrules.txt", "[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]");
                   setIpFilterRulesMustSucceed();
                   listIpFilterRulesMustSucceed();
               });
@@ -164,8 +163,8 @@ describe('arm', function () {
           function listIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules list --name %s --resource-group %s -f ipfilterrules.txt', iothubName, testResourceGroup, function (result) {
                   result.exitStatus.should.be.equal(0);
-                  var jsonFile = fs.readFileSync("ipfilterrules.txt");
-                  var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
+                  jsonFile = fs.readFileSync("ipfilterrules.txt");
+                  ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
                   ipFilterRules.length.should.be.equal(2);
                   done();
              });

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -145,7 +145,6 @@ describe('arm', function () {
 
           function listAndSetIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
-                  console.log(">>>>>>>>>>>>>> IPFilterRules 1 " + util.inspect(result, { depth: null }));
                   result.exitStatus.should.be.equal(0);
                   var jsonFile = fs.readFileSync(ipFilterRulesFile);
                   var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
@@ -157,7 +156,6 @@ describe('arm', function () {
 
           function setIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules set --name %s --resource-group %s --input-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
-                  console.log(">>>>>>>>>>>>>> IPFilterRules 2 " + util.inspect(result, { depth: null }));
                   result.exitStatus.should.be.equal(0);
                   listIpFilterRulesMustSucceed();
               });
@@ -165,7 +163,6 @@ describe('arm', function () {
 
           function listIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
-                  console.log(">>>>>>>>>>>>>> IPFilterRules 3 " + util.inspect(result, { depth: null }));
                   result.exitStatus.should.be.equal(0);
                   var jsonFile = fs.readFileSync(ipFilterRulesFile);
                   var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));

--- a/test/commands/arm/iothub/arm.iothub-tests.js
+++ b/test/commands/arm/iothub/arm.iothub-tests.js
@@ -140,8 +140,7 @@ describe('arm', function () {
       });
 
       it('ip filter rules set and list command using files should work', function (done) {
-          var fs = require("fs");
-          fs.unlinkSync(ipFilterRulesFile);
+
           listAndSetIpFilterRulesMustSucceed();
 
           function setIpFilterRulesMustSucceed() {
@@ -162,12 +161,15 @@ describe('arm', function () {
           function listAndSetIpFilterRulesMustSucceed() {
               suite.execute('iothub ipfilter-rules list --name %s --resource-group %s --output-file %s', iothubName, testResourceGroup, ipFilterRulesFile, function (result) {
                   result.exitStatus.should.be.equal(0);
+                  var fs = require("fs");
                   var jsonFile = fs.readFileSync(ipFilterRulesFile);
                   var ipFilterRules = JSON.parse(utils.stripBOM(jsonFile));
                   ipFilterRules.length.should.be.equal(0);
                   fs.writeFileSync(ipFilterRulesFile, '[ { \"filterName\": \"deny\",  \"action\": \"Accept\", \"ipMask\": \"0.0.0.0/0\" }, { \"filterName\": \"test\",  \"action\": \"Reject\", \"ipMask\": \"0.0.0.0/0\" } ]');
                   setIpFilterRulesMustSucceed();
+                  fs.unlinkSync(ipFilterRulesFile);
                   listIpFilterRulesMustSucceed();
+                  fs.unlinkSync(ipFilterRulesFile);
                   done();
               });
           }

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_create_command_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_create_command_should_work.nock.js
@@ -31,298 +31,334 @@ exports.scopes = [[function (nock) {
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03', '*')
-  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03', '*')
+  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '836',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
-  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo',
+  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '4999',
-  'x-ms-request-id': '6c100815-8534-4109-a4c9-d3c35444567b',
-  'x-ms-correlation-request-id': '6c100815-8534-4109-a4c9-d3c35444567b',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203019Z:6c100815-8534-4109-a4c9-d3c35444567b',
+  'x-ms-request-id': '50a87d52-abd7-4e38-a3f7-d04a9178f824',
+  'x-ms-correlation-request-id': '50a87d52-abd7-4e38-a3f7-d04a9178f824',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T172746Z:50a87d52-abd7-4e38-a3f7-d04a9178f824',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:30:19 GMT',
+  date: 'Thu, 20 Oct 2016 17:27:46 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03', '*')
-  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03', '*')
+  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '836',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
-  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo',
+  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '4999',
-  'x-ms-request-id': '6c100815-8534-4109-a4c9-d3c35444567b',
-  'x-ms-correlation-request-id': '6c100815-8534-4109-a4c9-d3c35444567b',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203019Z:6c100815-8534-4109-a4c9-d3c35444567b',
+  'x-ms-request-id': '50a87d52-abd7-4e38-a3f7-d04a9178f824',
+  'x-ms-correlation-request-id': '50a87d52-abd7-4e38-a3f7-d04a9178f824',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T172746Z:50a87d52-abd7-4e38-a3f7-d04a9178f824',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:30:19 GMT',
+  date: 'Thu, 20 Oct 2016 17:27:46 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14935',
-  'x-ms-request-id': '6c4c4789-be70-4e7d-9a4c-a6171154f80f',
-  'x-ms-correlation-request-id': '6c4c4789-be70-4e7d-9a4c-a6171154f80f',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203050Z:6c4c4789-be70-4e7d-9a4c-a6171154f80f',
+  'x-ms-ratelimit-remaining-subscription-reads': '14986',
+  'x-ms-request-id': '190aa3f2-b8c6-490b-adb8-63e5cc9f9029',
+  'x-ms-correlation-request-id': '190aa3f2-b8c6-490b-adb8-63e5cc9f9029',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T172817Z:190aa3f2-b8c6-490b-adb8-63e5cc9f9029',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:30:49 GMT',
+  date: 'Thu, 20 Oct 2016 17:28:16 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14935',
-  'x-ms-request-id': '6c4c4789-be70-4e7d-9a4c-a6171154f80f',
-  'x-ms-correlation-request-id': '6c4c4789-be70-4e7d-9a4c-a6171154f80f',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203050Z:6c4c4789-be70-4e7d-9a4c-a6171154f80f',
+  'x-ms-ratelimit-remaining-subscription-reads': '14986',
+  'x-ms-request-id': '190aa3f2-b8c6-490b-adb8-63e5cc9f9029',
+  'x-ms-correlation-request-id': '190aa3f2-b8c6-490b-adb8-63e5cc9f9029',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T172817Z:190aa3f2-b8c6-490b-adb8-63e5cc9f9029',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:30:49 GMT',
+  date: 'Thu, 20 Oct 2016 17:28:16 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14987',
-  'x-ms-request-id': 'cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
-  'x-ms-correlation-request-id': 'cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203121Z:cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
+  'x-ms-ratelimit-remaining-subscription-reads': '14994',
+  'x-ms-request-id': '26291a7d-65f2-425c-83a8-e69062853038',
+  'x-ms-correlation-request-id': '26291a7d-65f2-425c-83a8-e69062853038',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T172847Z:26291a7d-65f2-425c-83a8-e69062853038',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:31:20 GMT',
+  date: 'Thu, 20 Oct 2016 17:28:47 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14987',
-  'x-ms-request-id': 'cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
-  'x-ms-correlation-request-id': 'cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203121Z:cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
+  'x-ms-ratelimit-remaining-subscription-reads': '14994',
+  'x-ms-request-id': '26291a7d-65f2-425c-83a8-e69062853038',
+  'x-ms-correlation-request-id': '26291a7d-65f2-425c-83a8-e69062853038',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T172847Z:26291a7d-65f2-425c-83a8-e69062853038',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:31:20 GMT',
+  date: 'Thu, 20 Oct 2016 17:28:47 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14985',
-  'x-ms-request-id': 'a0269169-28e5-43ca-9b9f-8e1bc1606378',
-  'x-ms-correlation-request-id': 'a0269169-28e5-43ca-9b9f-8e1bc1606378',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203151Z:a0269169-28e5-43ca-9b9f-8e1bc1606378',
+  'x-ms-ratelimit-remaining-subscription-reads': '14990',
+  'x-ms-request-id': 'e5e688d8-19f8-4707-9b2c-c31187497b24',
+  'x-ms-correlation-request-id': 'e5e688d8-19f8-4707-9b2c-c31187497b24',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T172918Z:e5e688d8-19f8-4707-9b2c-c31187497b24',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:31:51 GMT',
+  date: 'Thu, 20 Oct 2016 17:29:17 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14985',
-  'x-ms-request-id': 'a0269169-28e5-43ca-9b9f-8e1bc1606378',
-  'x-ms-correlation-request-id': 'a0269169-28e5-43ca-9b9f-8e1bc1606378',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203151Z:a0269169-28e5-43ca-9b9f-8e1bc1606378',
+  'x-ms-ratelimit-remaining-subscription-reads': '14990',
+  'x-ms-request-id': 'e5e688d8-19f8-4707-9b2c-c31187497b24',
+  'x-ms-correlation-request-id': 'e5e688d8-19f8-4707-9b2c-c31187497b24',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T172918Z:e5e688d8-19f8-4707-9b2c-c31187497b24',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:31:51 GMT',
+  date: 'Thu, 20 Oct 2016 17:29:17 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14956',
-  'x-ms-request-id': 'bbe0e754-2c29-4782-9b26-57382ff9cf26',
-  'x-ms-correlation-request-id': 'bbe0e754-2c29-4782-9b26-57382ff9cf26',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203222Z:bbe0e754-2c29-4782-9b26-57382ff9cf26',
+  'x-ms-ratelimit-remaining-subscription-reads': '14982',
+  'x-ms-request-id': '7e0168f2-eb5e-4610-b2b8-f2dcdd1e29ff',
+  'x-ms-correlation-request-id': '7e0168f2-eb5e-4610-b2b8-f2dcdd1e29ff',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T172948Z:7e0168f2-eb5e-4610-b2b8-f2dcdd1e29ff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:32:22 GMT',
+  date: 'Thu, 20 Oct 2016 17:29:48 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14956',
-  'x-ms-request-id': 'bbe0e754-2c29-4782-9b26-57382ff9cf26',
-  'x-ms-correlation-request-id': 'bbe0e754-2c29-4782-9b26-57382ff9cf26',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203222Z:bbe0e754-2c29-4782-9b26-57382ff9cf26',
+  'x-ms-ratelimit-remaining-subscription-reads': '14982',
+  'x-ms-request-id': '7e0168f2-eb5e-4610-b2b8-f2dcdd1e29ff',
+  'x-ms-correlation-request-id': '7e0168f2-eb5e-4610-b2b8-f2dcdd1e29ff',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T172948Z:7e0168f2-eb5e-4610-b2b8-f2dcdd1e29ff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:32:22 GMT',
+  date: 'Thu, 20 Oct 2016 17:29:48 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14985',
-  'x-ms-request-id': '45f7df05-9328-4452-8915-b77a91186d00',
-  'x-ms-correlation-request-id': '45f7df05-9328-4452-8915-b77a91186d00',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203253Z:45f7df05-9328-4452-8915-b77a91186d00',
+  'x-ms-ratelimit-remaining-subscription-reads': '14990',
+  'x-ms-request-id': '0977360c-0f72-40f0-8eb0-b9736cddbd60',
+  'x-ms-correlation-request-id': '0977360c-0f72-40f0-8eb0-b9736cddbd60',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173018Z:0977360c-0f72-40f0-8eb0-b9736cddbd60',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:32:52 GMT',
+  date: 'Thu, 20 Oct 2016 17:30:18 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14985',
-  'x-ms-request-id': '45f7df05-9328-4452-8915-b77a91186d00',
-  'x-ms-correlation-request-id': '45f7df05-9328-4452-8915-b77a91186d00',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203253Z:45f7df05-9328-4452-8915-b77a91186d00',
+  'x-ms-ratelimit-remaining-subscription-reads': '14990',
+  'x-ms-request-id': '0977360c-0f72-40f0-8eb0-b9736cddbd60',
+  'x-ms-correlation-request-id': '0977360c-0f72-40f0-8eb0-b9736cddbd60',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173018Z:0977360c-0f72-40f0-8eb0-b9736cddbd60',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:32:52 GMT',
+  date: 'Thu, 20 Oct 2016 17:30:18 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14980',
-  'x-ms-request-id': 'd93c6a5d-9cd2-4c08-9c72-109d75a360e2',
-  'x-ms-correlation-request-id': 'd93c6a5d-9cd2-4c08-9c72-109d75a360e2',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203323Z:d93c6a5d-9cd2-4c08-9c72-109d75a360e2',
+  'x-ms-ratelimit-remaining-subscription-reads': '14944',
+  'x-ms-request-id': 'bcafa5e0-41d9-4046-bce3-95236eb3b68e',
+  'x-ms-correlation-request-id': 'bcafa5e0-41d9-4046-bce3-95236eb3b68e',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173049Z:bcafa5e0-41d9-4046-bce3-95236eb3b68e',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:33:23 GMT',
+  date: 'Thu, 20 Oct 2016 17:30:49 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14980',
-  'x-ms-request-id': 'd93c6a5d-9cd2-4c08-9c72-109d75a360e2',
-  'x-ms-correlation-request-id': 'd93c6a5d-9cd2-4c08-9c72-109d75a360e2',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203323Z:d93c6a5d-9cd2-4c08-9c72-109d75a360e2',
+  'x-ms-ratelimit-remaining-subscription-reads': '14944',
+  'x-ms-request-id': 'bcafa5e0-41d9-4046-bce3-95236eb3b68e',
+  'x-ms-correlation-request-id': 'bcafa5e0-41d9-4046-bce3-95236eb3b68e',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173049Z:bcafa5e0-41d9-4046-bce3-95236eb3b68e',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:33:23 GMT',
+  date: 'Thu, 20 Oct 2016 17:30:49 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14955',
-  'x-ms-request-id': '2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
-  'x-ms-correlation-request-id': '2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203354Z:2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
+  'x-ms-ratelimit-remaining-subscription-reads': '14993',
+  'x-ms-request-id': '6262f268-e3c2-428d-8dc4-ada0e882daad',
+  'x-ms-correlation-request-id': '6262f268-e3c2-428d-8dc4-ada0e882daad',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T173119Z:6262f268-e3c2-428d-8dc4-ada0e882daad',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:33:54 GMT',
+  date: 'Thu, 20 Oct 2016 17:31:19 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14955',
-  'x-ms-request-id': '2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
-  'x-ms-correlation-request-id': '2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203354Z:2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
+  'x-ms-ratelimit-remaining-subscription-reads': '14993',
+  'x-ms-request-id': '6262f268-e3c2-428d-8dc4-ada0e882daad',
+  'x-ms-correlation-request-id': '6262f268-e3c2-428d-8dc4-ada0e882daad',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T173119Z:6262f268-e3c2-428d-8dc4-ada0e882daad',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:33:54 GMT',
+  date: 'Thu, 20 Oct 2016 17:31:19 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14983',
+  'x-ms-request-id': 'c72c7ded-1dff-4b5b-83ea-e4ba28e7a12f',
+  'x-ms-correlation-request-id': 'c72c7ded-1dff-4b5b-83ea-e4ba28e7a12f',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T173150Z:c72c7ded-1dff-4b5b-83ea-e4ba28e7a12f',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:31:49 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14983',
+  'x-ms-request-id': 'c72c7ded-1dff-4b5b-83ea-e4ba28e7a12f',
+  'x-ms-correlation-request-id': 'c72c7ded-1dff-4b5b-83ea-e4ba28e7a12f',
+  'x-ms-routing-request-id': 'NORTHCENTRALUS:20161020T173150Z:c72c7ded-1dff-4b5b-83ea-e4ba28e7a12f',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:31:49 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '22',
@@ -330,17 +366,17 @@ nock('http://management.azure.com:443')
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-reads': '14986',
-  'x-ms-request-id': '56587c9a-963f-453a-bfe5-9c2b3975dd97',
-  'x-ms-correlation-request-id': '56587c9a-963f-453a-bfe5-9c2b3975dd97',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203425Z:56587c9a-963f-453a-bfe5-9c2b3975dd97',
+  'x-ms-request-id': '6d526c3d-9d2f-4b8a-92b2-baa42a1d09ce',
+  'x-ms-correlation-request-id': '6d526c3d-9d2f-4b8a-92b2-baa42a1d09ce',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173220Z:6d526c3d-9d2f-4b8a-92b2-baa42a1d09ce',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:25 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:20 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/NTU3NjJhOTQtZTdmMi00ZTRiLWJkNDktMTI0ZWQ3MmQ4YzMz?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '22',
@@ -348,83 +384,83 @@ nock('https://management.azure.com:443')
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-reads': '14986',
-  'x-ms-request-id': '56587c9a-963f-453a-bfe5-9c2b3975dd97',
-  'x-ms-correlation-request-id': '56587c9a-963f-453a-bfe5-9c2b3975dd97',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203425Z:56587c9a-963f-453a-bfe5-9c2b3975dd97',
+  'x-ms-request-id': '6d526c3d-9d2f-4b8a-92b2-baa42a1d09ce',
+  'x-ms-correlation-request-id': '6d526c3d-9d2f-4b8a-92b2-baa42a1d09ce',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173220Z:6d526c3d-9d2f-4b8a-92b2-baa42a1d09ce',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:25 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:20 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14984',
-  'x-ms-request-id': '56cb55c3-7b55-4138-9656-7e0c4449cb2c',
-  'x-ms-correlation-request-id': '56cb55c3-7b55-4138-9656-7e0c4449cb2c',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203426Z:56cb55c3-7b55-4138-9656-7e0c4449cb2c',
+  'x-ms-ratelimit-remaining-subscription-reads': '14992',
+  'x-ms-request-id': '49b14e80-f70c-455d-a609-e4a5894e9931',
+  'x-ms-correlation-request-id': '49b14e80-f70c-455d-a609-e4a5894e9931',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173221Z:49b14e80-f70c-455d-a609-e4a5894e9931',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:25 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:21 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14984',
-  'x-ms-request-id': '56cb55c3-7b55-4138-9656-7e0c4449cb2c',
-  'x-ms-correlation-request-id': '56cb55c3-7b55-4138-9656-7e0c4449cb2c',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203426Z:56cb55c3-7b55-4138-9656-7e0c4449cb2c',
+  'x-ms-ratelimit-remaining-subscription-reads': '14992',
+  'x-ms-request-id': '49b14e80-f70c-455d-a609-e4a5894e9931',
+  'x-ms-correlation-request-id': '49b14e80-f70c-455d-a609-e4a5894e9931',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173221Z:49b14e80-f70c-455d-a609-e4a5894e9931',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:25 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:21 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14984',
-  'x-ms-request-id': '6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
-  'x-ms-correlation-request-id': '6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203427Z:6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
+  'x-ms-ratelimit-remaining-subscription-reads': '14987',
+  'x-ms-request-id': 'c2046733-2d7e-4e73-b40a-31cb751bcee1',
+  'x-ms-correlation-request-id': 'c2046733-2d7e-4e73-b40a-31cb751bcee1',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173222Z:c2046733-2d7e-4e73-b40a-31cb751bcee1',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:26 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:22 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14984',
-  'x-ms-request-id': '6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
-  'x-ms-correlation-request-id': '6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203427Z:6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
+  'x-ms-ratelimit-remaining-subscription-reads': '14987',
+  'x-ms-request-id': 'c2046733-2d7e-4e73-b40a-31cb751bcee1',
+  'x-ms-correlation-request-id': 'c2046733-2d7e-4e73-b40a-31cb751bcee1',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173222Z:c2046733-2d7e-4e73-b40a-31cb751bcee1',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:26 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:22 GMT',
   connection: 'close' });
  return result; }]];
- exports.randomTestIdsGenerated = function() { return ['xplattestiothub1819'];};
+ exports.randomTestIdsGenerated = function() { return ['xplattestiothub4423'];};

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_create_command_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_create_command_should_work.nock.js
@@ -6,13 +6,13 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: 'e0b81f36-36ba-44f7-b550-7c9344a35893',
-    name: 'IOTHUB_PERF_1',
+    id: '9690a5bf-d489-4fd8-8c26-640da72502bd',
+    name: 'Windows Azure MSDN - Visual Studio Ultimate',
     user: {
       name: 'user@domain.example',
-      type: 'servicePrincipal'
+      type: 'user'
     },
-    tenantId: 'microsoft.com',
+    tenantId: '461e517d-31f6-4789-9060-c6e4162eaf38',
     state: 'Enabled',
     registeredProviders: [],
     _eventsCount: '1',
@@ -23,7 +23,7 @@ exports.getMockedProfile = function () {
 };
 
 exports.setEnvironment = function() {
-  process.env['AZURE_ARM_TEST_LOCATION'] = 'West US';
+  process.env['AZURE_ARM_IOTHUB_TEST_LOCATION'] = 'West US';
   process.env['AZURE_ARM_TEST_RESOURCE_GROUP'] = 'xplattestiothubrg';
 };
 
@@ -31,118 +31,118 @@ exports.scopes = [[function (nock) {
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360?api-version=2016-02-03', '*')
-  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360\",\"name\":\"xplattestiothub4360\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+.put('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03', '*')
+  .reply(201, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '836',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
-  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo',
+  'azure-asyncoperation': 'https://management.azure.com/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '4999',
-  'x-ms-request-id': 'ae308612-d7e7-4239-943d-d27a37d48776',
-  'x-ms-correlation-request-id': 'ae308612-d7e7-4239-943d-d27a37d48776',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T003908Z:ae308612-d7e7-4239-943d-d27a37d48776',
+  'x-ms-request-id': '165502bb-cce2-42a0-8933-5fefd14cf6c8',
+  'x-ms-correlation-request-id': '165502bb-cce2-42a0-8933-5fefd14cf6c8',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220406Z:165502bb-cce2-42a0-8933-5fefd14cf6c8',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:39:07 GMT',
+  date: 'Mon, 17 Oct 2016 22:04:06 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360?api-version=2016-02-03', '*')
-  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360\",\"name\":\"xplattestiothub4360\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+.put('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03', '*')
+  .reply(201, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '836',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
-  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo',
+  'azure-asyncoperation': 'https://management.azure.com/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '4999',
-  'x-ms-request-id': 'ae308612-d7e7-4239-943d-d27a37d48776',
-  'x-ms-correlation-request-id': 'ae308612-d7e7-4239-943d-d27a37d48776',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T003908Z:ae308612-d7e7-4239-943d-d27a37d48776',
+  'x-ms-request-id': '165502bb-cce2-42a0-8933-5fefd14cf6c8',
+  'x-ms-correlation-request-id': '165502bb-cce2-42a0-8933-5fefd14cf6c8',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220406Z:165502bb-cce2-42a0-8933-5fefd14cf6c8',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:39:07 GMT',
+  date: 'Mon, 17 Oct 2016 22:04:06 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14993',
-  'x-ms-request-id': '6ed4f19b-aa85-45d1-b07a-788bacd4d262',
-  'x-ms-correlation-request-id': '6ed4f19b-aa85-45d1-b07a-788bacd4d262',
-  'x-ms-routing-request-id': 'CENTRALUS:20160913T003938Z:6ed4f19b-aa85-45d1-b07a-788bacd4d262',
+  'x-ms-ratelimit-remaining-subscription-reads': '14998',
+  'x-ms-request-id': '69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
+  'x-ms-correlation-request-id': '69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220437Z:69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:39:38 GMT',
+  date: 'Mon, 17 Oct 2016 22:04:36 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14993',
-  'x-ms-request-id': '6ed4f19b-aa85-45d1-b07a-788bacd4d262',
-  'x-ms-correlation-request-id': '6ed4f19b-aa85-45d1-b07a-788bacd4d262',
-  'x-ms-routing-request-id': 'CENTRALUS:20160913T003938Z:6ed4f19b-aa85-45d1-b07a-788bacd4d262',
+  'x-ms-ratelimit-remaining-subscription-reads': '14998',
+  'x-ms-request-id': '69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
+  'x-ms-correlation-request-id': '69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220437Z:69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:39:38 GMT',
+  date: 'Mon, 17 Oct 2016 22:04:36 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14992',
-  'x-ms-request-id': 'e2c4e06c-1319-4b8b-90ba-7bb01a49c6f2',
-  'x-ms-correlation-request-id': 'e2c4e06c-1319-4b8b-90ba-7bb01a49c6f2',
-  'x-ms-routing-request-id': 'CENTRALUS:20160913T004009Z:e2c4e06c-1319-4b8b-90ba-7bb01a49c6f2',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': '80968cdd-5038-4a48-ad6f-97331d8c4fab',
+  'x-ms-correlation-request-id': '80968cdd-5038-4a48-ad6f-97331d8c4fab',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220507Z:80968cdd-5038-4a48-ad6f-97331d8c4fab',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:40:08 GMT',
+  date: 'Mon, 17 Oct 2016 22:05:07 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14992',
-  'x-ms-request-id': 'e2c4e06c-1319-4b8b-90ba-7bb01a49c6f2',
-  'x-ms-correlation-request-id': 'e2c4e06c-1319-4b8b-90ba-7bb01a49c6f2',
-  'x-ms-routing-request-id': 'CENTRALUS:20160913T004009Z:e2c4e06c-1319-4b8b-90ba-7bb01a49c6f2',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': '80968cdd-5038-4a48-ad6f-97331d8c4fab',
+  'x-ms-correlation-request-id': '80968cdd-5038-4a48-ad6f-97331d8c4fab',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220507Z:80968cdd-5038-4a48-ad6f-97331d8c4fab',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:40:08 GMT',
+  date: 'Mon, 17 Oct 2016 22:05:07 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
@@ -150,17 +150,17 @@ nock('http://management.azure.com:443')
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': '3495ab1a-7c52-4b4f-9ee0-0ee94f21f82c',
-  'x-ms-correlation-request-id': '3495ab1a-7c52-4b4f-9ee0-0ee94f21f82c',
-  'x-ms-routing-request-id': 'CENTRALUS:20160913T004040Z:3495ab1a-7c52-4b4f-9ee0-0ee94f21f82c',
+  'x-ms-request-id': 'b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
+  'x-ms-correlation-request-id': 'b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220538Z:b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:40:39 GMT',
+  date: 'Mon, 17 Oct 2016 22:05:37 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
@@ -168,155 +168,335 @@ nock('https://management.azure.com:443')
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': '3495ab1a-7c52-4b4f-9ee0-0ee94f21f82c',
-  'x-ms-correlation-request-id': '3495ab1a-7c52-4b4f-9ee0-0ee94f21f82c',
-  'x-ms-routing-request-id': 'CENTRALUS:20160913T004040Z:3495ab1a-7c52-4b4f-9ee0-0ee94f21f82c',
+  'x-ms-request-id': 'b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
+  'x-ms-correlation-request-id': 'b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220538Z:b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:40:39 GMT',
+  date: 'Mon, 17 Oct 2016 22:05:37 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14991',
-  'x-ms-request-id': 'e9f831d0-405b-4580-9e35-c31c0c344201',
-  'x-ms-correlation-request-id': 'e9f831d0-405b-4580-9e35-c31c0c344201',
-  'x-ms-routing-request-id': 'CENTRALUS:20160913T004110Z:e9f831d0-405b-4580-9e35-c31c0c344201',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': '08cedcbe-d133-4996-9f00-6c4e0749f1dc',
+  'x-ms-correlation-request-id': '08cedcbe-d133-4996-9f00-6c4e0749f1dc',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220608Z:08cedcbe-d133-4996-9f00-6c4e0749f1dc',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:10 GMT',
+  date: 'Mon, 17 Oct 2016 22:06:08 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14991',
-  'x-ms-request-id': 'e9f831d0-405b-4580-9e35-c31c0c344201',
-  'x-ms-correlation-request-id': 'e9f831d0-405b-4580-9e35-c31c0c344201',
-  'x-ms-routing-request-id': 'CENTRALUS:20160913T004110Z:e9f831d0-405b-4580-9e35-c31c0c344201',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': '08cedcbe-d133-4996-9f00-6c4e0749f1dc',
+  'x-ms-correlation-request-id': '08cedcbe-d133-4996-9f00-6c4e0749f1dc',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220608Z:08cedcbe-d133-4996-9f00-6c4e0749f1dc',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:10 GMT',
+  date: 'Mon, 17 Oct 2016 22:06:08 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14997',
+  'x-ms-request-id': '288932da-6f1b-4acb-9ffc-da217866a68a',
+  'x-ms-correlation-request-id': '288932da-6f1b-4acb-9ffc-da217866a68a',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220638Z:288932da-6f1b-4acb-9ffc-da217866a68a',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:06:38 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14997',
+  'x-ms-request-id': '288932da-6f1b-4acb-9ffc-da217866a68a',
+  'x-ms-correlation-request-id': '288932da-6f1b-4acb-9ffc-da217866a68a',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220638Z:288932da-6f1b-4acb-9ffc-da217866a68a',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:06:38 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14997',
+  'x-ms-request-id': '300f1c70-100c-4f64-a749-459c4041a322',
+  'x-ms-correlation-request-id': '300f1c70-100c-4f64-a749-459c4041a322',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220709Z:300f1c70-100c-4f64-a749-459c4041a322',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:07:08 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14997',
+  'x-ms-request-id': '300f1c70-100c-4f64-a749-459c4041a322',
+  'x-ms-correlation-request-id': '300f1c70-100c-4f64-a749-459c4041a322',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220709Z:300f1c70-100c-4f64-a749-459c4041a322',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:07:08 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14998',
+  'x-ms-request-id': '341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
+  'x-ms-correlation-request-id': '341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220739Z:341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:07:38 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14998',
+  'x-ms-request-id': '341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
+  'x-ms-correlation-request-id': '341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220739Z:341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:07:38 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': 'b6309f4a-48c6-413c-9719-5e810d4221bf',
+  'x-ms-correlation-request-id': 'b6309f4a-48c6-413c-9719-5e810d4221bf',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220810Z:b6309f4a-48c6-413c-9719-5e810d4221bf',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:08:09 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': 'b6309f4a-48c6-413c-9719-5e810d4221bf',
+  'x-ms-correlation-request-id': 'b6309f4a-48c6-413c-9719-5e810d4221bf',
+  'x-ms-routing-request-id': 'WESTUS2:20161017T220810Z:b6309f4a-48c6-413c-9719-5e810d4221bf',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:08:09 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14997',
+  'x-ms-request-id': '9e8eb812-f58c-423d-888c-e3ed8c400f4b',
+  'x-ms-correlation-request-id': '9e8eb812-f58c-423d-888c-e3ed8c400f4b',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220840Z:9e8eb812-f58c-423d-888c-e3ed8c400f4b',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:08:40 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '20',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14997',
+  'x-ms-request-id': '9e8eb812-f58c-423d-888c-e3ed8c400f4b',
+  'x-ms-correlation-request-id': '9e8eb812-f58c-423d-888c-e3ed8c400f4b',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220840Z:9e8eb812-f58c-423d-888c-e3ed8c400f4b',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Mon, 17 Oct 2016 22:08:40 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '22',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14987',
-  'x-ms-request-id': '9f0823f9-53b1-41c9-8791-75fc0f9544b5',
-  'x-ms-correlation-request-id': '9f0823f9-53b1-41c9-8791-75fc0f9544b5',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004141Z:9f0823f9-53b1-41c9-8791-75fc0f9544b5',
+  'x-ms-ratelimit-remaining-subscription-reads': '14995',
+  'x-ms-request-id': '035f1fb5-6300-41ae-ac25-08e46822f044',
+  'x-ms-correlation-request-id': '035f1fb5-6300-41ae-ac25-08e46822f044',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220911Z:035f1fb5-6300-41ae-ac25-08e46822f044',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:40 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:11 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/operationResults/ZGQ3NWRlMGItNjI1Mi00NWE2LThiM2EtMDJkODA0YmJiYTI5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '22',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14987',
-  'x-ms-request-id': '9f0823f9-53b1-41c9-8791-75fc0f9544b5',
-  'x-ms-correlation-request-id': '9f0823f9-53b1-41c9-8791-75fc0f9544b5',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004141Z:9f0823f9-53b1-41c9-8791-75fc0f9544b5',
+  'x-ms-ratelimit-remaining-subscription-reads': '14995',
+  'x-ms-request-id': '035f1fb5-6300-41ae-ac25-08e46822f044',
+  'x-ms-correlation-request-id': '035f1fb5-6300-41ae-ac25-08e46822f044',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220911Z:035f1fb5-6300-41ae-ac25-08e46822f044',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:40 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:11 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360\",\"name\":\"xplattestiothub4360\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABgtSY=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"hostName\":\"xplattestiothub4360.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
-  'content-length': '1605',
+  'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14993',
-  'x-ms-request-id': '103c906c-0658-4e81-a41c-25c1db265233',
-  'x-ms-correlation-request-id': '103c906c-0658-4e81-a41c-25c1db265233',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004141Z:103c906c-0658-4e81-a41c-25c1db265233',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': 'a46fa456-f15a-4ed8-a131-f79b248ddd2e',
+  'x-ms-correlation-request-id': 'a46fa456-f15a-4ed8-a131-f79b248ddd2e',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220912Z:a46fa456-f15a-4ed8-a131-f79b248ddd2e',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:41 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:11 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360\",\"name\":\"xplattestiothub4360\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABgtSY=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"hostName\":\"xplattestiothub4360.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
-  'content-length': '1605',
+  'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14993',
-  'x-ms-request-id': '103c906c-0658-4e81-a41c-25c1db265233',
-  'x-ms-correlation-request-id': '103c906c-0658-4e81-a41c-25c1db265233',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004141Z:103c906c-0658-4e81-a41c-25c1db265233',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': 'a46fa456-f15a-4ed8-a131-f79b248ddd2e',
+  'x-ms-correlation-request-id': 'a46fa456-f15a-4ed8-a131-f79b248ddd2e',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220912Z:a46fa456-f15a-4ed8-a131-f79b248ddd2e',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:41 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:11 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360\",\"name\":\"xplattestiothub4360\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABgtSY=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"hostName\":\"xplattestiothub4360.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
-  'content-length': '1605',
+  'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14995',
-  'x-ms-request-id': '3aff3aa4-1950-4907-a608-06c47d34a5d2',
-  'x-ms-correlation-request-id': '3aff3aa4-1950-4907-a608-06c47d34a5d2',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004142Z:3aff3aa4-1950-4907-a608-06c47d34a5d2',
+  'x-ms-ratelimit-remaining-subscription-reads': '14993',
+  'x-ms-request-id': '436b3c14-fb06-4615-b482-7e2a9a011bf9',
+  'x-ms-correlation-request-id': '436b3c14-fb06-4615-b482-7e2a9a011bf9',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220913Z:436b3c14-fb06-4615-b482-7e2a9a011bf9',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:41 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:13 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360\",\"name\":\"xplattestiothub4360\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABgtSY=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"hostName\":\"xplattestiothub4360.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
-  'content-length': '1605',
+  'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14995',
-  'x-ms-request-id': '3aff3aa4-1950-4907-a608-06c47d34a5d2',
-  'x-ms-correlation-request-id': '3aff3aa4-1950-4907-a608-06c47d34a5d2',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004142Z:3aff3aa4-1950-4907-a608-06c47d34a5d2',
+  'x-ms-ratelimit-remaining-subscription-reads': '14993',
+  'x-ms-request-id': '436b3c14-fb06-4615-b482-7e2a9a011bf9',
+  'x-ms-correlation-request-id': '436b3c14-fb06-4615-b482-7e2a9a011bf9',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220913Z:436b3c14-fb06-4615-b482-7e2a9a011bf9',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:41 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:13 GMT',
   connection: 'close' });
  return result; }]];
- exports.randomTestIdsGenerated = function() { return ['xplattestiothub4360'];};
+ exports.randomTestIdsGenerated = function() { return ['xplattestiothub1856'];};

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_create_command_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_create_command_should_work.nock.js
@@ -6,13 +6,13 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '9690a5bf-d489-4fd8-8c26-640da72502bd',
-    name: 'Windows Azure MSDN - Visual Studio Ultimate',
+    id: 'e0b81f36-36ba-44f7-b550-7c9344a35893',
+    name: 'IOTHUB_PERF_1',
     user: {
       name: 'user@domain.example',
-      type: 'user'
+      type: 'servicePrincipal'
     },
-    tenantId: '461e517d-31f6-4789-9060-c6e4162eaf38',
+    tenantId: 'microsoft.com',
     state: 'Enabled',
     registeredProviders: [],
     _eventsCount: '1',
@@ -31,472 +31,400 @@ exports.scopes = [[function (nock) {
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03', '*')
-  .reply(201, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03', '*')
+  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '836',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
-  'azure-asyncoperation': 'https://management.azure.com/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo',
+  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '4999',
-  'x-ms-request-id': '165502bb-cce2-42a0-8933-5fefd14cf6c8',
-  'x-ms-correlation-request-id': '165502bb-cce2-42a0-8933-5fefd14cf6c8',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220406Z:165502bb-cce2-42a0-8933-5fefd14cf6c8',
+  'x-ms-request-id': '6c100815-8534-4109-a4c9-d3c35444567b',
+  'x-ms-correlation-request-id': '6c100815-8534-4109-a4c9-d3c35444567b',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203019Z:6c100815-8534-4109-a4c9-d3c35444567b',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:04:06 GMT',
+  date: 'Wed, 19 Oct 2016 20:30:19 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03', '*')
-  .reply(201, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03', '*')
+  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"properties\":{\"state\":\"Activating\",\"provisioningState\":\"Accepted\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '836',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
-  'azure-asyncoperation': 'https://management.azure.com/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo',
+  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '4999',
-  'x-ms-request-id': '165502bb-cce2-42a0-8933-5fefd14cf6c8',
-  'x-ms-correlation-request-id': '165502bb-cce2-42a0-8933-5fefd14cf6c8',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220406Z:165502bb-cce2-42a0-8933-5fefd14cf6c8',
+  'x-ms-request-id': '6c100815-8534-4109-a4c9-d3c35444567b',
+  'x-ms-correlation-request-id': '6c100815-8534-4109-a4c9-d3c35444567b',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203019Z:6c100815-8534-4109-a4c9-d3c35444567b',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:04:06 GMT',
+  date: 'Wed, 19 Oct 2016 20:30:19 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14998',
-  'x-ms-request-id': '69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
-  'x-ms-correlation-request-id': '69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220437Z:69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
+  'x-ms-ratelimit-remaining-subscription-reads': '14935',
+  'x-ms-request-id': '6c4c4789-be70-4e7d-9a4c-a6171154f80f',
+  'x-ms-correlation-request-id': '6c4c4789-be70-4e7d-9a4c-a6171154f80f',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203050Z:6c4c4789-be70-4e7d-9a4c-a6171154f80f',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:04:36 GMT',
+  date: 'Wed, 19 Oct 2016 20:30:49 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14998',
-  'x-ms-request-id': '69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
-  'x-ms-correlation-request-id': '69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220437Z:69d6605a-9d3f-4d8d-9cd1-f08f68fef17b',
+  'x-ms-ratelimit-remaining-subscription-reads': '14935',
+  'x-ms-request-id': '6c4c4789-be70-4e7d-9a4c-a6171154f80f',
+  'x-ms-correlation-request-id': '6c4c4789-be70-4e7d-9a4c-a6171154f80f',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203050Z:6c4c4789-be70-4e7d-9a4c-a6171154f80f',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:04:36 GMT',
+  date: 'Wed, 19 Oct 2016 20:30:49 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': '80968cdd-5038-4a48-ad6f-97331d8c4fab',
-  'x-ms-correlation-request-id': '80968cdd-5038-4a48-ad6f-97331d8c4fab',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220507Z:80968cdd-5038-4a48-ad6f-97331d8c4fab',
+  'x-ms-ratelimit-remaining-subscription-reads': '14987',
+  'x-ms-request-id': 'cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
+  'x-ms-correlation-request-id': 'cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203121Z:cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:05:07 GMT',
+  date: 'Wed, 19 Oct 2016 20:31:20 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': '80968cdd-5038-4a48-ad6f-97331d8c4fab',
-  'x-ms-correlation-request-id': '80968cdd-5038-4a48-ad6f-97331d8c4fab',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220507Z:80968cdd-5038-4a48-ad6f-97331d8c4fab',
+  'x-ms-ratelimit-remaining-subscription-reads': '14987',
+  'x-ms-request-id': 'cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
+  'x-ms-correlation-request-id': 'cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203121Z:cc0c8a02-c557-4097-a8d4-a8b1157b2efd',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:05:07 GMT',
+  date: 'Wed, 19 Oct 2016 20:31:20 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': 'b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
-  'x-ms-correlation-request-id': 'b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220538Z:b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
+  'x-ms-ratelimit-remaining-subscription-reads': '14985',
+  'x-ms-request-id': 'a0269169-28e5-43ca-9b9f-8e1bc1606378',
+  'x-ms-correlation-request-id': 'a0269169-28e5-43ca-9b9f-8e1bc1606378',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203151Z:a0269169-28e5-43ca-9b9f-8e1bc1606378',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:05:37 GMT',
+  date: 'Wed, 19 Oct 2016 20:31:51 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': 'b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
-  'x-ms-correlation-request-id': 'b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220538Z:b92accb5-2a1a-446d-8ec5-8f61eb3701e5',
+  'x-ms-ratelimit-remaining-subscription-reads': '14985',
+  'x-ms-request-id': 'a0269169-28e5-43ca-9b9f-8e1bc1606378',
+  'x-ms-correlation-request-id': 'a0269169-28e5-43ca-9b9f-8e1bc1606378',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203151Z:a0269169-28e5-43ca-9b9f-8e1bc1606378',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:05:37 GMT',
+  date: 'Wed, 19 Oct 2016 20:31:51 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': '08cedcbe-d133-4996-9f00-6c4e0749f1dc',
-  'x-ms-correlation-request-id': '08cedcbe-d133-4996-9f00-6c4e0749f1dc',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220608Z:08cedcbe-d133-4996-9f00-6c4e0749f1dc',
+  'x-ms-ratelimit-remaining-subscription-reads': '14956',
+  'x-ms-request-id': 'bbe0e754-2c29-4782-9b26-57382ff9cf26',
+  'x-ms-correlation-request-id': 'bbe0e754-2c29-4782-9b26-57382ff9cf26',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203222Z:bbe0e754-2c29-4782-9b26-57382ff9cf26',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:06:08 GMT',
+  date: 'Wed, 19 Oct 2016 20:32:22 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': '08cedcbe-d133-4996-9f00-6c4e0749f1dc',
-  'x-ms-correlation-request-id': '08cedcbe-d133-4996-9f00-6c4e0749f1dc',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220608Z:08cedcbe-d133-4996-9f00-6c4e0749f1dc',
+  'x-ms-ratelimit-remaining-subscription-reads': '14956',
+  'x-ms-request-id': 'bbe0e754-2c29-4782-9b26-57382ff9cf26',
+  'x-ms-correlation-request-id': 'bbe0e754-2c29-4782-9b26-57382ff9cf26',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203222Z:bbe0e754-2c29-4782-9b26-57382ff9cf26',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:06:08 GMT',
+  date: 'Wed, 19 Oct 2016 20:32:22 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': '288932da-6f1b-4acb-9ffc-da217866a68a',
-  'x-ms-correlation-request-id': '288932da-6f1b-4acb-9ffc-da217866a68a',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220638Z:288932da-6f1b-4acb-9ffc-da217866a68a',
+  'x-ms-ratelimit-remaining-subscription-reads': '14985',
+  'x-ms-request-id': '45f7df05-9328-4452-8915-b77a91186d00',
+  'x-ms-correlation-request-id': '45f7df05-9328-4452-8915-b77a91186d00',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203253Z:45f7df05-9328-4452-8915-b77a91186d00',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:06:38 GMT',
+  date: 'Wed, 19 Oct 2016 20:32:52 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': '288932da-6f1b-4acb-9ffc-da217866a68a',
-  'x-ms-correlation-request-id': '288932da-6f1b-4acb-9ffc-da217866a68a',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220638Z:288932da-6f1b-4acb-9ffc-da217866a68a',
+  'x-ms-ratelimit-remaining-subscription-reads': '14985',
+  'x-ms-request-id': '45f7df05-9328-4452-8915-b77a91186d00',
+  'x-ms-correlation-request-id': '45f7df05-9328-4452-8915-b77a91186d00',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203253Z:45f7df05-9328-4452-8915-b77a91186d00',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:06:38 GMT',
+  date: 'Wed, 19 Oct 2016 20:32:52 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': '300f1c70-100c-4f64-a749-459c4041a322',
-  'x-ms-correlation-request-id': '300f1c70-100c-4f64-a749-459c4041a322',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220709Z:300f1c70-100c-4f64-a749-459c4041a322',
+  'x-ms-ratelimit-remaining-subscription-reads': '14980',
+  'x-ms-request-id': 'd93c6a5d-9cd2-4c08-9c72-109d75a360e2',
+  'x-ms-correlation-request-id': 'd93c6a5d-9cd2-4c08-9c72-109d75a360e2',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203323Z:d93c6a5d-9cd2-4c08-9c72-109d75a360e2',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:07:08 GMT',
+  date: 'Wed, 19 Oct 2016 20:33:23 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': '300f1c70-100c-4f64-a749-459c4041a322',
-  'x-ms-correlation-request-id': '300f1c70-100c-4f64-a749-459c4041a322',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220709Z:300f1c70-100c-4f64-a749-459c4041a322',
+  'x-ms-ratelimit-remaining-subscription-reads': '14980',
+  'x-ms-request-id': 'd93c6a5d-9cd2-4c08-9c72-109d75a360e2',
+  'x-ms-correlation-request-id': 'd93c6a5d-9cd2-4c08-9c72-109d75a360e2',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203323Z:d93c6a5d-9cd2-4c08-9c72-109d75a360e2',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:07:08 GMT',
+  date: 'Wed, 19 Oct 2016 20:33:23 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14998',
-  'x-ms-request-id': '341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
-  'x-ms-correlation-request-id': '341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220739Z:341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
+  'x-ms-ratelimit-remaining-subscription-reads': '14955',
+  'x-ms-request-id': '2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
+  'x-ms-correlation-request-id': '2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203354Z:2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:07:38 GMT',
+  date: 'Wed, 19 Oct 2016 20:33:54 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '20',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14998',
-  'x-ms-request-id': '341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
-  'x-ms-correlation-request-id': '341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220739Z:341e7f61-92ca-4aa7-a5ac-4e1eebe82f8b',
+  'x-ms-ratelimit-remaining-subscription-reads': '14955',
+  'x-ms-request-id': '2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
+  'x-ms-correlation-request-id': '2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203354Z:2415b82e-0c36-4404-a49a-efa7ae3fdbfb',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:07:38 GMT',
+  date: 'Wed, 19 Oct 2016 20:33:54 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
-  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
-  pragma: 'no-cache',
-  'content-length': '20',
-  'content-type': 'application/json; charset=utf-8',
-  expires: '-1',
-  server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': 'b6309f4a-48c6-413c-9719-5e810d4221bf',
-  'x-ms-correlation-request-id': 'b6309f4a-48c6-413c-9719-5e810d4221bf',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220810Z:b6309f4a-48c6-413c-9719-5e810d4221bf',
-  'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:08:09 GMT',
-  connection: 'close' });
- return result; },
-function (nock) { 
-var result = 
-nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
-  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
-  pragma: 'no-cache',
-  'content-length': '20',
-  'content-type': 'application/json; charset=utf-8',
-  expires: '-1',
-  server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': 'b6309f4a-48c6-413c-9719-5e810d4221bf',
-  'x-ms-correlation-request-id': 'b6309f4a-48c6-413c-9719-5e810d4221bf',
-  'x-ms-routing-request-id': 'WESTUS2:20161017T220810Z:b6309f4a-48c6-413c-9719-5e810d4221bf',
-  'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:08:09 GMT',
-  connection: 'close' });
- return result; },
-function (nock) { 
-var result = 
-nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
-  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
-  pragma: 'no-cache',
-  'content-length': '20',
-  'content-type': 'application/json; charset=utf-8',
-  expires: '-1',
-  server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': '9e8eb812-f58c-423d-888c-e3ed8c400f4b',
-  'x-ms-correlation-request-id': '9e8eb812-f58c-423d-888c-e3ed8c400f4b',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220840Z:9e8eb812-f58c-423d-888c-e3ed8c400f4b',
-  'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:08:40 GMT',
-  connection: 'close' });
- return result; },
-function (nock) { 
-var result = 
-nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
-  .reply(200, "{\"status\":\"Running\"}", { 'cache-control': 'no-cache',
-  pragma: 'no-cache',
-  'content-length': '20',
-  'content-type': 'application/json; charset=utf-8',
-  expires: '-1',
-  server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14997',
-  'x-ms-request-id': '9e8eb812-f58c-423d-888c-e3ed8c400f4b',
-  'x-ms-correlation-request-id': '9e8eb812-f58c-423d-888c-e3ed8c400f4b',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220840Z:9e8eb812-f58c-423d-888c-e3ed8c400f4b',
-  'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:08:40 GMT',
-  connection: 'close' });
- return result; },
-function (nock) { 
-var result = 
-nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '22',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14995',
-  'x-ms-request-id': '035f1fb5-6300-41ae-ac25-08e46822f044',
-  'x-ms-correlation-request-id': '035f1fb5-6300-41ae-ac25-08e46822f044',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220911Z:035f1fb5-6300-41ae-ac25-08e46822f044',
+  'x-ms-ratelimit-remaining-subscription-reads': '14986',
+  'x-ms-request-id': '56587c9a-963f-453a-bfe5-9c2b3975dd97',
+  'x-ms-correlation-request-id': '56587c9a-963f-453a-bfe5-9c2b3975dd97',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203425Z:56587c9a-963f-453a-bfe5-9c2b3975dd97',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:11 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:25 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/operationResults/NmM0MTg1N2EtNjc5MC00YTliLTlhOTMtNjQ4OGJjMGVlZDM5?api-version=2016-02-03&asyncinfo')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/operationResults/ODM1MGUxMGItZDNmNy00Y2U5LWE5N2EtYjFjZTcwMmNiODBm?api-version=2016-02-03&asyncinfo')
   .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '22',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14995',
-  'x-ms-request-id': '035f1fb5-6300-41ae-ac25-08e46822f044',
-  'x-ms-correlation-request-id': '035f1fb5-6300-41ae-ac25-08e46822f044',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220911Z:035f1fb5-6300-41ae-ac25-08e46822f044',
+  'x-ms-ratelimit-remaining-subscription-reads': '14986',
+  'x-ms-request-id': '56587c9a-963f-453a-bfe5-9c2b3975dd97',
+  'x-ms-correlation-request-id': '56587c9a-963f-453a-bfe5-9c2b3975dd97',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203425Z:56587c9a-963f-453a-bfe5-9c2b3975dd97',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:11 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:25 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': 'a46fa456-f15a-4ed8-a131-f79b248ddd2e',
-  'x-ms-correlation-request-id': 'a46fa456-f15a-4ed8-a131-f79b248ddd2e',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220912Z:a46fa456-f15a-4ed8-a131-f79b248ddd2e',
+  'x-ms-ratelimit-remaining-subscription-reads': '14984',
+  'x-ms-request-id': '56cb55c3-7b55-4138-9656-7e0c4449cb2c',
+  'x-ms-correlation-request-id': '56cb55c3-7b55-4138-9656-7e0c4449cb2c',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203426Z:56cb55c3-7b55-4138-9656-7e0c4449cb2c',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:11 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:25 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': 'a46fa456-f15a-4ed8-a131-f79b248ddd2e',
-  'x-ms-correlation-request-id': 'a46fa456-f15a-4ed8-a131-f79b248ddd2e',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220912Z:a46fa456-f15a-4ed8-a131-f79b248ddd2e',
+  'x-ms-ratelimit-remaining-subscription-reads': '14984',
+  'x-ms-request-id': '56cb55c3-7b55-4138-9656-7e0c4449cb2c',
+  'x-ms-correlation-request-id': '56cb55c3-7b55-4138-9656-7e0c4449cb2c',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203426Z:56cb55c3-7b55-4138-9656-7e0c4449cb2c',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:11 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:25 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14993',
-  'x-ms-request-id': '436b3c14-fb06-4615-b482-7e2a9a011bf9',
-  'x-ms-correlation-request-id': '436b3c14-fb06-4615-b482-7e2a9a011bf9',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220913Z:436b3c14-fb06-4615-b482-7e2a9a011bf9',
+  'x-ms-ratelimit-remaining-subscription-reads': '14984',
+  'x-ms-request-id': '6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
+  'x-ms-correlation-request-id': '6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203427Z:6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:13 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:26 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14993',
-  'x-ms-request-id': '436b3c14-fb06-4615-b482-7e2a9a011bf9',
-  'x-ms-correlation-request-id': '436b3c14-fb06-4615-b482-7e2a9a011bf9',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220913Z:436b3c14-fb06-4615-b482-7e2a9a011bf9',
+  'x-ms-ratelimit-remaining-subscription-reads': '14984',
+  'x-ms-request-id': '6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
+  'x-ms-correlation-request-id': '6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203427Z:6aad3ba6-ea0e-4c3e-91df-acbbacf736c7',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:13 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:26 GMT',
   connection: 'close' });
  return result; }]];
- exports.randomTestIdsGenerated = function() { return ['xplattestiothub1856'];};
+ exports.randomTestIdsGenerated = function() { return ['xplattestiothub1819'];};

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_default_connection_string_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_default_connection_string_should_work.nock.js
@@ -30,72 +30,72 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14934',
-  'x-ms-request-id': '6110f436-f435-4d68-b637-221043aa6ca0',
-  'x-ms-correlation-request-id': '6110f436-f435-4d68-b637-221043aa6ca0',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203428Z:6110f436-f435-4d68-b637-221043aa6ca0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14994',
+  'x-ms-request-id': 'a312ea2f-628b-4889-84ca-945e855b6973',
+  'x-ms-correlation-request-id': 'a312ea2f-628b-4889-84ca-945e855b6973',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173223Z:a312ea2f-628b-4889-84ca-945e855b6973',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:27 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:22 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14934',
-  'x-ms-request-id': '6110f436-f435-4d68-b637-221043aa6ca0',
-  'x-ms-correlation-request-id': '6110f436-f435-4d68-b637-221043aa6ca0',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203428Z:6110f436-f435-4d68-b637-221043aa6ca0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14994',
+  'x-ms-request-id': 'a312ea2f-628b-4889-84ca-945e855b6973',
+  'x-ms-correlation-request-id': 'a312ea2f-628b-4889-84ca-945e855b6973',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173223Z:a312ea2f-628b-4889-84ca-945e855b6973',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:27 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:22 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"xMPxsws71MvMWc+hBePxFOQrggsKepJK1yMFHI962dA=\",\"secondaryKey\":\"B4ANZGhR1hkuLtdVKNBNK5XiOW3NGNK2/Z9fUSrJ/H8=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"aZ+FPEwc8B2GkvyFkwMQDm/S43aHJI9QuS8I+pVMDdg=\",\"secondaryKey\":\"MtWjHP5msJeK3o7+TQg9HbNQ49oWfKAy+lAY2s8bVp8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"YChWYf2IxCpaKTxC8QWTzuIQyilAPu6Th2R9bZcMX2s=\",\"secondaryKey\":\"9j6pfvtTQQNMVb/Gk1n2nHE5WBIDI1veZt05zYwZlNM=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"P/BB7XV9cUn4s45Kr2eq8tGzWm7dav469g8xpCko2Ws=\",\"secondaryKey\":\"szpKxJF0KRe7/Ln1qlfo6AbUpwlnRArSi+7Eyz9t2r0=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"3a/teS3GtQZUE1u4oeOe9yLAzONiEFAMEZIMYCLw9PY=\",\"secondaryKey\":\"VSLyYF1XLWTOB1hqKseNghURoBLDm7djh4XJXzFMYrk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"ihzg6Ptf4dtdHEw0f5L7L4pMCQO0qrfVVATz4ifOOus=\",\"secondaryKey\":\"yRtoSC42YC9yG2Fzvi80FNa85tqEUKuo5XAi6BbXfkc=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"arUTkZHsfQ49M7H2nW2hiZkkei0+hsipL5bpUi2bPSw=\",\"secondaryKey\":\"gw0YGXXyi8wwf6IZYq6K5apUgaNrJiXjMkaHeNTSPM8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"tC2v7TTAL8QEyhznrLJL6PGZ2rYJZ6J5sJkt7cqdId4=\",\"secondaryKey\":\"IaIHpP9mkQkldQPLK2zJh6R+KEc1wGm3njqVF3dO3Zc=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"PIX4GYK5bFdKTdWOBlKAE+eBZRMQyst5njoirJFTcaQ=\",\"secondaryKey\":\"4Hlo/KwpjxePyYsRY2AGFf7MtIJXGPSzltMai81Wcvg=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"CHKC6iL+1iPmwTLxddiuWLzVzKjUFB7TAxb8OSfZ3qI=\",\"secondaryKey\":\"ueKT77pRORxapv8wWNU52dBOQG5yNw9CtmbI6VLvFr4=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': 'd013a61b-f11e-46a5-94f6-754352f7c183',
-  'x-ms-correlation-request-id': 'd013a61b-f11e-46a5-94f6-754352f7c183',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203429Z:d013a61b-f11e-46a5-94f6-754352f7c183',
+  'x-ms-request-id': '769296de-efbf-4c97-b0af-96b551f0ab52',
+  'x-ms-correlation-request-id': '769296de-efbf-4c97-b0af-96b551f0ab52',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173223Z:769296de-efbf-4c97-b0af-96b551f0ab52',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:28 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:23 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"xMPxsws71MvMWc+hBePxFOQrggsKepJK1yMFHI962dA=\",\"secondaryKey\":\"B4ANZGhR1hkuLtdVKNBNK5XiOW3NGNK2/Z9fUSrJ/H8=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"aZ+FPEwc8B2GkvyFkwMQDm/S43aHJI9QuS8I+pVMDdg=\",\"secondaryKey\":\"MtWjHP5msJeK3o7+TQg9HbNQ49oWfKAy+lAY2s8bVp8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"YChWYf2IxCpaKTxC8QWTzuIQyilAPu6Th2R9bZcMX2s=\",\"secondaryKey\":\"9j6pfvtTQQNMVb/Gk1n2nHE5WBIDI1veZt05zYwZlNM=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"P/BB7XV9cUn4s45Kr2eq8tGzWm7dav469g8xpCko2Ws=\",\"secondaryKey\":\"szpKxJF0KRe7/Ln1qlfo6AbUpwlnRArSi+7Eyz9t2r0=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"3a/teS3GtQZUE1u4oeOe9yLAzONiEFAMEZIMYCLw9PY=\",\"secondaryKey\":\"VSLyYF1XLWTOB1hqKseNghURoBLDm7djh4XJXzFMYrk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"ihzg6Ptf4dtdHEw0f5L7L4pMCQO0qrfVVATz4ifOOus=\",\"secondaryKey\":\"yRtoSC42YC9yG2Fzvi80FNa85tqEUKuo5XAi6BbXfkc=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"arUTkZHsfQ49M7H2nW2hiZkkei0+hsipL5bpUi2bPSw=\",\"secondaryKey\":\"gw0YGXXyi8wwf6IZYq6K5apUgaNrJiXjMkaHeNTSPM8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"tC2v7TTAL8QEyhznrLJL6PGZ2rYJZ6J5sJkt7cqdId4=\",\"secondaryKey\":\"IaIHpP9mkQkldQPLK2zJh6R+KEc1wGm3njqVF3dO3Zc=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"PIX4GYK5bFdKTdWOBlKAE+eBZRMQyst5njoirJFTcaQ=\",\"secondaryKey\":\"4Hlo/KwpjxePyYsRY2AGFf7MtIJXGPSzltMai81Wcvg=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"CHKC6iL+1iPmwTLxddiuWLzVzKjUFB7TAxb8OSfZ3qI=\",\"secondaryKey\":\"ueKT77pRORxapv8wWNU52dBOQG5yNw9CtmbI6VLvFr4=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': 'd013a61b-f11e-46a5-94f6-754352f7c183',
-  'x-ms-correlation-request-id': 'd013a61b-f11e-46a5-94f6-754352f7c183',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203429Z:d013a61b-f11e-46a5-94f6-754352f7c183',
+  'x-ms-request-id': '769296de-efbf-4c97-b0af-96b551f0ab52',
+  'x-ms-correlation-request-id': '769296de-efbf-4c97-b0af-96b551f0ab52',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173223Z:769296de-efbf-4c97-b0af-96b551f0ab52',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:28 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:23 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_default_connection_string_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_default_connection_string_should_work.nock.js
@@ -6,13 +6,13 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '9690a5bf-d489-4fd8-8c26-640da72502bd',
-    name: 'Windows Azure MSDN - Visual Studio Ultimate',
+    id: 'e0b81f36-36ba-44f7-b550-7c9344a35893',
+    name: 'IOTHUB_PERF_1',
     user: {
       name: 'user@domain.example',
-      type: 'user'
+      type: 'servicePrincipal'
     },
-    tenantId: '461e517d-31f6-4789-9060-c6e4162eaf38',
+    tenantId: 'microsoft.com',
     state: 'Enabled',
     registeredProviders: [],
     _eventsCount: '1',
@@ -30,72 +30,72 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': '037df3d5-45b5-4971-9f8a-6fde0d737988',
-  'x-ms-correlation-request-id': '037df3d5-45b5-4971-9f8a-6fde0d737988',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220914Z:037df3d5-45b5-4971-9f8a-6fde0d737988',
+  'x-ms-ratelimit-remaining-subscription-reads': '14934',
+  'x-ms-request-id': '6110f436-f435-4d68-b637-221043aa6ca0',
+  'x-ms-correlation-request-id': '6110f436-f435-4d68-b637-221043aa6ca0',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203428Z:6110f436-f435-4d68-b637-221043aa6ca0',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:27 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': '037df3d5-45b5-4971-9f8a-6fde0d737988',
-  'x-ms-correlation-request-id': '037df3d5-45b5-4971-9f8a-6fde0d737988',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220914Z:037df3d5-45b5-4971-9f8a-6fde0d737988',
+  'x-ms-ratelimit-remaining-subscription-reads': '14934',
+  'x-ms-request-id': '6110f436-f435-4d68-b637-221043aa6ca0',
+  'x-ms-correlation-request-id': '6110f436-f435-4d68-b637-221043aa6ca0',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203428Z:6110f436-f435-4d68-b637-221043aa6ca0',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:27 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .post('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"T0K6XYY99kqNbTmrsEvtLXdLFV+F+HEoTENfIjGAhLA=\",\"secondaryKey\":\"lRgkuypCkCMudF6FftyLgv8psYgwtcnod8922P4mb1c=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"ptriP7oEMdF95UjQfOMCHEgFZV8G4VxZpo98+FFq1ro=\",\"secondaryKey\":\"hIzfoSsCVsoXVouaW9+KWcCH//odUQzE8O6k5dMgMqw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"mnVqusYiZep1VOCKH3BCKYIhGjWZ1+oN8DcnCZgGqWw=\",\"secondaryKey\":\"MfxHA42ti+j5HWIOQrTckKoZn5gI8I8U2IcuJZw66Q0=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"5XggslvWsumhasWwGNey8Xpzgt0WJWQ+57HOK5kBslk=\",\"secondaryKey\":\"V1oBzK3+0bu/moDRSgSq3QzkiyymsSiIKO+flJza6ww=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"7BE8F5ovBUO0SPC1w/RVXTGxWFPv8sAk5Yp8LzdMNEA=\",\"secondaryKey\":\"4mVEBJEiu7KhQEWvefxfrGBwDPqqCMudhyY4Aw+Jlbs=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"xMPxsws71MvMWc+hBePxFOQrggsKepJK1yMFHI962dA=\",\"secondaryKey\":\"B4ANZGhR1hkuLtdVKNBNK5XiOW3NGNK2/Z9fUSrJ/H8=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"aZ+FPEwc8B2GkvyFkwMQDm/S43aHJI9QuS8I+pVMDdg=\",\"secondaryKey\":\"MtWjHP5msJeK3o7+TQg9HbNQ49oWfKAy+lAY2s8bVp8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"YChWYf2IxCpaKTxC8QWTzuIQyilAPu6Th2R9bZcMX2s=\",\"secondaryKey\":\"9j6pfvtTQQNMVb/Gk1n2nHE5WBIDI1veZt05zYwZlNM=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"P/BB7XV9cUn4s45Kr2eq8tGzWm7dav469g8xpCko2Ws=\",\"secondaryKey\":\"szpKxJF0KRe7/Ln1qlfo6AbUpwlnRArSi+7Eyz9t2r0=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"3a/teS3GtQZUE1u4oeOe9yLAzONiEFAMEZIMYCLw9PY=\",\"secondaryKey\":\"VSLyYF1XLWTOB1hqKseNghURoBLDm7djh4XJXzFMYrk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-writes': '1198',
-  'x-ms-request-id': 'a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
-  'x-ms-correlation-request-id': 'a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220914Z:a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
+  'x-ms-ratelimit-remaining-subscription-writes': '1199',
+  'x-ms-request-id': 'd013a61b-f11e-46a5-94f6-754352f7c183',
+  'x-ms-correlation-request-id': 'd013a61b-f11e-46a5-94f6-754352f7c183',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203429Z:d013a61b-f11e-46a5-94f6-754352f7c183',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:28 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .post('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"T0K6XYY99kqNbTmrsEvtLXdLFV+F+HEoTENfIjGAhLA=\",\"secondaryKey\":\"lRgkuypCkCMudF6FftyLgv8psYgwtcnod8922P4mb1c=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"ptriP7oEMdF95UjQfOMCHEgFZV8G4VxZpo98+FFq1ro=\",\"secondaryKey\":\"hIzfoSsCVsoXVouaW9+KWcCH//odUQzE8O6k5dMgMqw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"mnVqusYiZep1VOCKH3BCKYIhGjWZ1+oN8DcnCZgGqWw=\",\"secondaryKey\":\"MfxHA42ti+j5HWIOQrTckKoZn5gI8I8U2IcuJZw66Q0=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"5XggslvWsumhasWwGNey8Xpzgt0WJWQ+57HOK5kBslk=\",\"secondaryKey\":\"V1oBzK3+0bu/moDRSgSq3QzkiyymsSiIKO+flJza6ww=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"7BE8F5ovBUO0SPC1w/RVXTGxWFPv8sAk5Yp8LzdMNEA=\",\"secondaryKey\":\"4mVEBJEiu7KhQEWvefxfrGBwDPqqCMudhyY4Aw+Jlbs=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"xMPxsws71MvMWc+hBePxFOQrggsKepJK1yMFHI962dA=\",\"secondaryKey\":\"B4ANZGhR1hkuLtdVKNBNK5XiOW3NGNK2/Z9fUSrJ/H8=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"aZ+FPEwc8B2GkvyFkwMQDm/S43aHJI9QuS8I+pVMDdg=\",\"secondaryKey\":\"MtWjHP5msJeK3o7+TQg9HbNQ49oWfKAy+lAY2s8bVp8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"YChWYf2IxCpaKTxC8QWTzuIQyilAPu6Th2R9bZcMX2s=\",\"secondaryKey\":\"9j6pfvtTQQNMVb/Gk1n2nHE5WBIDI1veZt05zYwZlNM=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"P/BB7XV9cUn4s45Kr2eq8tGzWm7dav469g8xpCko2Ws=\",\"secondaryKey\":\"szpKxJF0KRe7/Ln1qlfo6AbUpwlnRArSi+7Eyz9t2r0=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"3a/teS3GtQZUE1u4oeOe9yLAzONiEFAMEZIMYCLw9PY=\",\"secondaryKey\":\"VSLyYF1XLWTOB1hqKseNghURoBLDm7djh4XJXzFMYrk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-writes': '1198',
-  'x-ms-request-id': 'a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
-  'x-ms-correlation-request-id': 'a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220914Z:a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
+  'x-ms-ratelimit-remaining-subscription-writes': '1199',
+  'x-ms-request-id': 'd013a61b-f11e-46a5-94f6-754352f7c183',
+  'x-ms-correlation-request-id': 'd013a61b-f11e-46a5-94f6-754352f7c183',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203429Z:d013a61b-f11e-46a5-94f6-754352f7c183',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:28 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_default_connection_string_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_default_connection_string_should_work.nock.js
@@ -6,13 +6,13 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: 'e0b81f36-36ba-44f7-b550-7c9344a35893',
-    name: 'IOTHUB_PERF_1',
+    id: '9690a5bf-d489-4fd8-8c26-640da72502bd',
+    name: 'Windows Azure MSDN - Visual Studio Ultimate',
     user: {
       name: 'user@domain.example',
-      type: 'servicePrincipal'
+      type: 'user'
     },
-    tenantId: 'microsoft.com',
+    tenantId: '461e517d-31f6-4789-9060-c6e4162eaf38',
     state: 'Enabled',
     registeredProviders: [],
     _eventsCount: '1',
@@ -23,79 +23,79 @@ exports.getMockedProfile = function () {
 };
 
 exports.setEnvironment = function() {
-  process.env['AZURE_ARM_TEST_LOCATION'] = 'West US';
+  process.env['AZURE_ARM_IOTHUB_TEST_LOCATION'] = 'West US';
   process.env['AZURE_ARM_TEST_RESOURCE_GROUP'] = 'xplattestiothubrg';
 };
 
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360\",\"name\":\"xplattestiothub4360\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABgtSY=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"hostName\":\"xplattestiothub4360.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
-  'content-length': '1605',
+  'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14990',
-  'x-ms-request-id': '6ce91c30-ef97-45c4-8489-85ad2b97d8ab',
-  'x-ms-correlation-request-id': '6ce91c30-ef97-45c4-8489-85ad2b97d8ab',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004142Z:6ce91c30-ef97-45c4-8489-85ad2b97d8ab',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': '037df3d5-45b5-4971-9f8a-6fde0d737988',
+  'x-ms-correlation-request-id': '037df3d5-45b5-4971-9f8a-6fde0d737988',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220914Z:037df3d5-45b5-4971-9f8a-6fde0d737988',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:42 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360\",\"name\":\"xplattestiothub4360\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABgtSY=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"hostName\":\"xplattestiothub4360.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4360-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-67354-aad4a180b7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
-  'content-length': '1605',
+  'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14990',
-  'x-ms-request-id': '6ce91c30-ef97-45c4-8489-85ad2b97d8ab',
-  'x-ms-correlation-request-id': '6ce91c30-ef97-45c4-8489-85ad2b97d8ab',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004142Z:6ce91c30-ef97-45c4-8489-85ad2b97d8ab',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': '037df3d5-45b5-4971-9f8a-6fde0d737988',
+  'x-ms-correlation-request-id': '037df3d5-45b5-4971-9f8a-6fde0d737988',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220914Z:037df3d5-45b5-4971-9f8a-6fde0d737988',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:42 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"IXD+XhhRSRo14KeDeUOHXsFPSL7iP+xomUbYLDfm9QY=\",\"secondaryKey\":\"o0v6y5bcGxdu9AYnwRczI50JYWb7pBODuwdXGzC2e14=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"DJ2OKLdl5nIrXOOPyhYzbLB4UTD8+cwJ6+ktkTPyp3k=\",\"secondaryKey\":\"0mAwrEbM5GqlGLb9hs/15vSJ/bY2VgvwfXZJ5jxsPHw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"LpNrFjal765kC9lkYZo7IYjGqnoPs+GkNtiC/pLuN4A=\",\"secondaryKey\":\"xJ0rqm0SmexmFOGFHpesrOVOekRCrIdYe4i18z+7O7w=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"+M96WP5Tf0Fg/ALAn4p7lHSbv3l+J2+EGAfSMeE0IkY=\",\"secondaryKey\":\"h3w5/nW6a6n4IV0jukOxd5DTYchiGmcUuZ3GoP2lHSQ=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"U75Dd7OD1r0oMRKwJ+6p3lCazrR5myFRYgd/V4oeIQ4=\",\"secondaryKey\":\"zsjGMk36HiWE6SlNMQ4eaZAW/cKVHQtXGiXCcpUlyvk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"T0K6XYY99kqNbTmrsEvtLXdLFV+F+HEoTENfIjGAhLA=\",\"secondaryKey\":\"lRgkuypCkCMudF6FftyLgv8psYgwtcnod8922P4mb1c=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"ptriP7oEMdF95UjQfOMCHEgFZV8G4VxZpo98+FFq1ro=\",\"secondaryKey\":\"hIzfoSsCVsoXVouaW9+KWcCH//odUQzE8O6k5dMgMqw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"mnVqusYiZep1VOCKH3BCKYIhGjWZ1+oN8DcnCZgGqWw=\",\"secondaryKey\":\"MfxHA42ti+j5HWIOQrTckKoZn5gI8I8U2IcuJZw66Q0=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"5XggslvWsumhasWwGNey8Xpzgt0WJWQ+57HOK5kBslk=\",\"secondaryKey\":\"V1oBzK3+0bu/moDRSgSq3QzkiyymsSiIKO+flJza6ww=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"7BE8F5ovBUO0SPC1w/RVXTGxWFPv8sAk5Yp8LzdMNEA=\",\"secondaryKey\":\"4mVEBJEiu7KhQEWvefxfrGBwDPqqCMudhyY4Aw+Jlbs=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': '829879a9-d638-4221-963f-1a92144a5600',
-  'x-ms-correlation-request-id': '829879a9-d638-4221-963f-1a92144a5600',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004143Z:829879a9-d638-4221-963f-1a92144a5600',
+  'x-ms-ratelimit-remaining-subscription-writes': '1198',
+  'x-ms-request-id': 'a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
+  'x-ms-correlation-request-id': 'a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220914Z:a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:42 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4360/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"IXD+XhhRSRo14KeDeUOHXsFPSL7iP+xomUbYLDfm9QY=\",\"secondaryKey\":\"o0v6y5bcGxdu9AYnwRczI50JYWb7pBODuwdXGzC2e14=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"DJ2OKLdl5nIrXOOPyhYzbLB4UTD8+cwJ6+ktkTPyp3k=\",\"secondaryKey\":\"0mAwrEbM5GqlGLb9hs/15vSJ/bY2VgvwfXZJ5jxsPHw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"LpNrFjal765kC9lkYZo7IYjGqnoPs+GkNtiC/pLuN4A=\",\"secondaryKey\":\"xJ0rqm0SmexmFOGFHpesrOVOekRCrIdYe4i18z+7O7w=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"+M96WP5Tf0Fg/ALAn4p7lHSbv3l+J2+EGAfSMeE0IkY=\",\"secondaryKey\":\"h3w5/nW6a6n4IV0jukOxd5DTYchiGmcUuZ3GoP2lHSQ=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"U75Dd7OD1r0oMRKwJ+6p3lCazrR5myFRYgd/V4oeIQ4=\",\"secondaryKey\":\"zsjGMk36HiWE6SlNMQ4eaZAW/cKVHQtXGiXCcpUlyvk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"T0K6XYY99kqNbTmrsEvtLXdLFV+F+HEoTENfIjGAhLA=\",\"secondaryKey\":\"lRgkuypCkCMudF6FftyLgv8psYgwtcnod8922P4mb1c=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"ptriP7oEMdF95UjQfOMCHEgFZV8G4VxZpo98+FFq1ro=\",\"secondaryKey\":\"hIzfoSsCVsoXVouaW9+KWcCH//odUQzE8O6k5dMgMqw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"mnVqusYiZep1VOCKH3BCKYIhGjWZ1+oN8DcnCZgGqWw=\",\"secondaryKey\":\"MfxHA42ti+j5HWIOQrTckKoZn5gI8I8U2IcuJZw66Q0=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"5XggslvWsumhasWwGNey8Xpzgt0WJWQ+57HOK5kBslk=\",\"secondaryKey\":\"V1oBzK3+0bu/moDRSgSq3QzkiyymsSiIKO+flJza6ww=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"7BE8F5ovBUO0SPC1w/RVXTGxWFPv8sAk5Yp8LzdMNEA=\",\"secondaryKey\":\"4mVEBJEiu7KhQEWvefxfrGBwDPqqCMudhyY4Aw+Jlbs=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': '829879a9-d638-4221-963f-1a92144a5600',
-  'x-ms-correlation-request-id': '829879a9-d638-4221-963f-1a92144a5600',
-  'x-ms-routing-request-id': 'WESTUS2:20160913T004143Z:829879a9-d638-4221-963f-1a92144a5600',
+  'x-ms-ratelimit-remaining-subscription-writes': '1198',
+  'x-ms-request-id': 'a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
+  'x-ms-correlation-request-id': 'a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220914Z:a60b4aa5-9d45-46e1-8960-77c7b15d8f99',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Tue, 13 Sep 2016 00:41:42 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_specific_connection_string_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_specific_connection_string_should_work.nock.js
@@ -6,13 +6,13 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '9690a5bf-d489-4fd8-8c26-640da72502bd',
-    name: 'Windows Azure MSDN - Visual Studio Ultimate',
+    id: 'e0b81f36-36ba-44f7-b550-7c9344a35893',
+    name: 'IOTHUB_PERF_1',
     user: {
       name: 'user@domain.example',
-      type: 'user'
+      type: 'servicePrincipal'
     },
-    tenantId: '461e517d-31f6-4789-9060-c6e4162eaf38',
+    tenantId: 'microsoft.com',
     state: 'Enabled',
     registeredProviders: [],
     _eventsCount: '1',
@@ -30,72 +30,72 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14995',
-  'x-ms-request-id': 'e18162f2-e788-4f8f-97a2-b2c9553fcac6',
-  'x-ms-correlation-request-id': 'e18162f2-e788-4f8f-97a2-b2c9553fcac6',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220915Z:e18162f2-e788-4f8f-97a2-b2c9553fcac6',
+  'x-ms-ratelimit-remaining-subscription-reads': '14984',
+  'x-ms-request-id': '12d10d50-88c9-4391-a398-18c126637b9a',
+  'x-ms-correlation-request-id': '12d10d50-88c9-4391-a398-18c126637b9a',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203430Z:12d10d50-88c9-4391-a398-18c126637b9a',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:30 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14995',
-  'x-ms-request-id': 'e18162f2-e788-4f8f-97a2-b2c9553fcac6',
-  'x-ms-correlation-request-id': 'e18162f2-e788-4f8f-97a2-b2c9553fcac6',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220915Z:e18162f2-e788-4f8f-97a2-b2c9553fcac6',
+  'x-ms-ratelimit-remaining-subscription-reads': '14984',
+  'x-ms-request-id': '12d10d50-88c9-4391-a398-18c126637b9a',
+  'x-ms-correlation-request-id': '12d10d50-88c9-4391-a398-18c126637b9a',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203430Z:12d10d50-88c9-4391-a398-18c126637b9a',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:30 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .post('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"T0K6XYY99kqNbTmrsEvtLXdLFV+F+HEoTENfIjGAhLA=\",\"secondaryKey\":\"lRgkuypCkCMudF6FftyLgv8psYgwtcnod8922P4mb1c=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"ptriP7oEMdF95UjQfOMCHEgFZV8G4VxZpo98+FFq1ro=\",\"secondaryKey\":\"hIzfoSsCVsoXVouaW9+KWcCH//odUQzE8O6k5dMgMqw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"mnVqusYiZep1VOCKH3BCKYIhGjWZ1+oN8DcnCZgGqWw=\",\"secondaryKey\":\"MfxHA42ti+j5HWIOQrTckKoZn5gI8I8U2IcuJZw66Q0=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"5XggslvWsumhasWwGNey8Xpzgt0WJWQ+57HOK5kBslk=\",\"secondaryKey\":\"V1oBzK3+0bu/moDRSgSq3QzkiyymsSiIKO+flJza6ww=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"7BE8F5ovBUO0SPC1w/RVXTGxWFPv8sAk5Yp8LzdMNEA=\",\"secondaryKey\":\"4mVEBJEiu7KhQEWvefxfrGBwDPqqCMudhyY4Aw+Jlbs=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"xMPxsws71MvMWc+hBePxFOQrggsKepJK1yMFHI962dA=\",\"secondaryKey\":\"B4ANZGhR1hkuLtdVKNBNK5XiOW3NGNK2/Z9fUSrJ/H8=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"aZ+FPEwc8B2GkvyFkwMQDm/S43aHJI9QuS8I+pVMDdg=\",\"secondaryKey\":\"MtWjHP5msJeK3o7+TQg9HbNQ49oWfKAy+lAY2s8bVp8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"YChWYf2IxCpaKTxC8QWTzuIQyilAPu6Th2R9bZcMX2s=\",\"secondaryKey\":\"9j6pfvtTQQNMVb/Gk1n2nHE5WBIDI1veZt05zYwZlNM=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"P/BB7XV9cUn4s45Kr2eq8tGzWm7dav469g8xpCko2Ws=\",\"secondaryKey\":\"szpKxJF0KRe7/Ln1qlfo6AbUpwlnRArSi+7Eyz9t2r0=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"3a/teS3GtQZUE1u4oeOe9yLAzONiEFAMEZIMYCLw9PY=\",\"secondaryKey\":\"VSLyYF1XLWTOB1hqKseNghURoBLDm7djh4XJXzFMYrk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': '2246b585-15c0-4cbf-9245-625d59b44d13',
-  'x-ms-correlation-request-id': '2246b585-15c0-4cbf-9245-625d59b44d13',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220916Z:2246b585-15c0-4cbf-9245-625d59b44d13',
+  'x-ms-request-id': '43f3ebe2-e7f9-4999-9433-9ba024d03404',
+  'x-ms-correlation-request-id': '43f3ebe2-e7f9-4999-9433-9ba024d03404',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203430Z:43f3ebe2-e7f9-4999-9433-9ba024d03404',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:16 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:30 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .post('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"T0K6XYY99kqNbTmrsEvtLXdLFV+F+HEoTENfIjGAhLA=\",\"secondaryKey\":\"lRgkuypCkCMudF6FftyLgv8psYgwtcnod8922P4mb1c=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"ptriP7oEMdF95UjQfOMCHEgFZV8G4VxZpo98+FFq1ro=\",\"secondaryKey\":\"hIzfoSsCVsoXVouaW9+KWcCH//odUQzE8O6k5dMgMqw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"mnVqusYiZep1VOCKH3BCKYIhGjWZ1+oN8DcnCZgGqWw=\",\"secondaryKey\":\"MfxHA42ti+j5HWIOQrTckKoZn5gI8I8U2IcuJZw66Q0=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"5XggslvWsumhasWwGNey8Xpzgt0WJWQ+57HOK5kBslk=\",\"secondaryKey\":\"V1oBzK3+0bu/moDRSgSq3QzkiyymsSiIKO+flJza6ww=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"7BE8F5ovBUO0SPC1w/RVXTGxWFPv8sAk5Yp8LzdMNEA=\",\"secondaryKey\":\"4mVEBJEiu7KhQEWvefxfrGBwDPqqCMudhyY4Aw+Jlbs=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"xMPxsws71MvMWc+hBePxFOQrggsKepJK1yMFHI962dA=\",\"secondaryKey\":\"B4ANZGhR1hkuLtdVKNBNK5XiOW3NGNK2/Z9fUSrJ/H8=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"aZ+FPEwc8B2GkvyFkwMQDm/S43aHJI9QuS8I+pVMDdg=\",\"secondaryKey\":\"MtWjHP5msJeK3o7+TQg9HbNQ49oWfKAy+lAY2s8bVp8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"YChWYf2IxCpaKTxC8QWTzuIQyilAPu6Th2R9bZcMX2s=\",\"secondaryKey\":\"9j6pfvtTQQNMVb/Gk1n2nHE5WBIDI1veZt05zYwZlNM=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"P/BB7XV9cUn4s45Kr2eq8tGzWm7dav469g8xpCko2Ws=\",\"secondaryKey\":\"szpKxJF0KRe7/Ln1qlfo6AbUpwlnRArSi+7Eyz9t2r0=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"3a/teS3GtQZUE1u4oeOe9yLAzONiEFAMEZIMYCLw9PY=\",\"secondaryKey\":\"VSLyYF1XLWTOB1hqKseNghURoBLDm7djh4XJXzFMYrk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': '2246b585-15c0-4cbf-9245-625d59b44d13',
-  'x-ms-correlation-request-id': '2246b585-15c0-4cbf-9245-625d59b44d13',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220916Z:2246b585-15c0-4cbf-9245-625d59b44d13',
+  'x-ms-request-id': '43f3ebe2-e7f9-4999-9433-9ba024d03404',
+  'x-ms-correlation-request-id': '43f3ebe2-e7f9-4999-9433-9ba024d03404',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203430Z:43f3ebe2-e7f9-4999-9433-9ba024d03404',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:16 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:30 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_specific_connection_string_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_get_specific_connection_string_should_work.nock.js
@@ -30,72 +30,72 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14984',
-  'x-ms-request-id': '12d10d50-88c9-4391-a398-18c126637b9a',
-  'x-ms-correlation-request-id': '12d10d50-88c9-4391-a398-18c126637b9a',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203430Z:12d10d50-88c9-4391-a398-18c126637b9a',
+  'x-ms-ratelimit-remaining-subscription-reads': '14986',
+  'x-ms-request-id': '426a3f18-8e63-4ba4-b5b8-11065ba6d95e',
+  'x-ms-correlation-request-id': '426a3f18-8e63-4ba4-b5b8-11065ba6d95e',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173224Z:426a3f18-8e63-4ba4-b5b8-11065ba6d95e',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:30 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:23 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14984',
-  'x-ms-request-id': '12d10d50-88c9-4391-a398-18c126637b9a',
-  'x-ms-correlation-request-id': '12d10d50-88c9-4391-a398-18c126637b9a',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203430Z:12d10d50-88c9-4391-a398-18c126637b9a',
+  'x-ms-ratelimit-remaining-subscription-reads': '14986',
+  'x-ms-request-id': '426a3f18-8e63-4ba4-b5b8-11065ba6d95e',
+  'x-ms-correlation-request-id': '426a3f18-8e63-4ba4-b5b8-11065ba6d95e',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173224Z:426a3f18-8e63-4ba4-b5b8-11065ba6d95e',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:30 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:23 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"xMPxsws71MvMWc+hBePxFOQrggsKepJK1yMFHI962dA=\",\"secondaryKey\":\"B4ANZGhR1hkuLtdVKNBNK5XiOW3NGNK2/Z9fUSrJ/H8=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"aZ+FPEwc8B2GkvyFkwMQDm/S43aHJI9QuS8I+pVMDdg=\",\"secondaryKey\":\"MtWjHP5msJeK3o7+TQg9HbNQ49oWfKAy+lAY2s8bVp8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"YChWYf2IxCpaKTxC8QWTzuIQyilAPu6Th2R9bZcMX2s=\",\"secondaryKey\":\"9j6pfvtTQQNMVb/Gk1n2nHE5WBIDI1veZt05zYwZlNM=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"P/BB7XV9cUn4s45Kr2eq8tGzWm7dav469g8xpCko2Ws=\",\"secondaryKey\":\"szpKxJF0KRe7/Ln1qlfo6AbUpwlnRArSi+7Eyz9t2r0=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"3a/teS3GtQZUE1u4oeOe9yLAzONiEFAMEZIMYCLw9PY=\",\"secondaryKey\":\"VSLyYF1XLWTOB1hqKseNghURoBLDm7djh4XJXzFMYrk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"ihzg6Ptf4dtdHEw0f5L7L4pMCQO0qrfVVATz4ifOOus=\",\"secondaryKey\":\"yRtoSC42YC9yG2Fzvi80FNa85tqEUKuo5XAi6BbXfkc=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"arUTkZHsfQ49M7H2nW2hiZkkei0+hsipL5bpUi2bPSw=\",\"secondaryKey\":\"gw0YGXXyi8wwf6IZYq6K5apUgaNrJiXjMkaHeNTSPM8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"tC2v7TTAL8QEyhznrLJL6PGZ2rYJZ6J5sJkt7cqdId4=\",\"secondaryKey\":\"IaIHpP9mkQkldQPLK2zJh6R+KEc1wGm3njqVF3dO3Zc=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"PIX4GYK5bFdKTdWOBlKAE+eBZRMQyst5njoirJFTcaQ=\",\"secondaryKey\":\"4Hlo/KwpjxePyYsRY2AGFf7MtIJXGPSzltMai81Wcvg=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"CHKC6iL+1iPmwTLxddiuWLzVzKjUFB7TAxb8OSfZ3qI=\",\"secondaryKey\":\"ueKT77pRORxapv8wWNU52dBOQG5yNw9CtmbI6VLvFr4=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': '43f3ebe2-e7f9-4999-9433-9ba024d03404',
-  'x-ms-correlation-request-id': '43f3ebe2-e7f9-4999-9433-9ba024d03404',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203430Z:43f3ebe2-e7f9-4999-9433-9ba024d03404',
+  'x-ms-request-id': '90f591a6-14a1-4cbe-86ea-eea911d47776',
+  'x-ms-correlation-request-id': '90f591a6-14a1-4cbe-86ea-eea911d47776',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173224Z:90f591a6-14a1-4cbe-86ea-eea911d47776',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:30 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:24 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"xMPxsws71MvMWc+hBePxFOQrggsKepJK1yMFHI962dA=\",\"secondaryKey\":\"B4ANZGhR1hkuLtdVKNBNK5XiOW3NGNK2/Z9fUSrJ/H8=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"aZ+FPEwc8B2GkvyFkwMQDm/S43aHJI9QuS8I+pVMDdg=\",\"secondaryKey\":\"MtWjHP5msJeK3o7+TQg9HbNQ49oWfKAy+lAY2s8bVp8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"YChWYf2IxCpaKTxC8QWTzuIQyilAPu6Th2R9bZcMX2s=\",\"secondaryKey\":\"9j6pfvtTQQNMVb/Gk1n2nHE5WBIDI1veZt05zYwZlNM=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"P/BB7XV9cUn4s45Kr2eq8tGzWm7dav469g8xpCko2Ws=\",\"secondaryKey\":\"szpKxJF0KRe7/Ln1qlfo6AbUpwlnRArSi+7Eyz9t2r0=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"3a/teS3GtQZUE1u4oeOe9yLAzONiEFAMEZIMYCLw9PY=\",\"secondaryKey\":\"VSLyYF1XLWTOB1hqKseNghURoBLDm7djh4XJXzFMYrk=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .post('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/listkeys?api-version=2016-02-03')
+  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"ihzg6Ptf4dtdHEw0f5L7L4pMCQO0qrfVVATz4ifOOus=\",\"secondaryKey\":\"yRtoSC42YC9yG2Fzvi80FNa85tqEUKuo5XAi6BbXfkc=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"arUTkZHsfQ49M7H2nW2hiZkkei0+hsipL5bpUi2bPSw=\",\"secondaryKey\":\"gw0YGXXyi8wwf6IZYq6K5apUgaNrJiXjMkaHeNTSPM8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"tC2v7TTAL8QEyhznrLJL6PGZ2rYJZ6J5sJkt7cqdId4=\",\"secondaryKey\":\"IaIHpP9mkQkldQPLK2zJh6R+KEc1wGm3njqVF3dO3Zc=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"PIX4GYK5bFdKTdWOBlKAE+eBZRMQyst5njoirJFTcaQ=\",\"secondaryKey\":\"4Hlo/KwpjxePyYsRY2AGFf7MtIJXGPSzltMai81Wcvg=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"CHKC6iL+1iPmwTLxddiuWLzVzKjUFB7TAxb8OSfZ3qI=\",\"secondaryKey\":\"ueKT77pRORxapv8wWNU52dBOQG5yNw9CtmbI6VLvFr4=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '905',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
   'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': '43f3ebe2-e7f9-4999-9433-9ba024d03404',
-  'x-ms-correlation-request-id': '43f3ebe2-e7f9-4999-9433-9ba024d03404',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203430Z:43f3ebe2-e7f9-4999-9433-9ba024d03404',
+  'x-ms-request-id': '90f591a6-14a1-4cbe-86ea-eea911d47776',
+  'x-ms-correlation-request-id': '90f591a6-14a1-4cbe-86ea-eea911d47776',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173224Z:90f591a6-14a1-4cbe-86ea-eea911d47776',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:30 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:24 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_ip_filter_rules_set_and_list_command_using_files_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_ip_filter_rules_set_and_list_command_using_files_should_work.nock.js
@@ -37,12 +37,12 @@ nock('http://management.azure.com:443')
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14995',
-  'x-ms-request-id': 'e18162f2-e788-4f8f-97a2-b2c9553fcac6',
-  'x-ms-correlation-request-id': 'e18162f2-e788-4f8f-97a2-b2c9553fcac6',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220915Z:e18162f2-e788-4f8f-97a2-b2c9553fcac6',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': '7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
+  'x-ms-correlation-request-id': '7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220917Z:7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:17 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
@@ -55,47 +55,47 @@ nock('https://management.azure.com:443')
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14995',
-  'x-ms-request-id': 'e18162f2-e788-4f8f-97a2-b2c9553fcac6',
-  'x-ms-correlation-request-id': 'e18162f2-e788-4f8f-97a2-b2c9553fcac6',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220915Z:e18162f2-e788-4f8f-97a2-b2c9553fcac6',
+  'x-ms-ratelimit-remaining-subscription-reads': '14996',
+  'x-ms-request-id': '7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
+  'x-ms-correlation-request-id': '7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220917Z:7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:14 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:17 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .post('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"T0K6XYY99kqNbTmrsEvtLXdLFV+F+HEoTENfIjGAhLA=\",\"secondaryKey\":\"lRgkuypCkCMudF6FftyLgv8psYgwtcnod8922P4mb1c=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"ptriP7oEMdF95UjQfOMCHEgFZV8G4VxZpo98+FFq1ro=\",\"secondaryKey\":\"hIzfoSsCVsoXVouaW9+KWcCH//odUQzE8O6k5dMgMqw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"mnVqusYiZep1VOCKH3BCKYIhGjWZ1+oN8DcnCZgGqWw=\",\"secondaryKey\":\"MfxHA42ti+j5HWIOQrTckKoZn5gI8I8U2IcuJZw66Q0=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"5XggslvWsumhasWwGNey8Xpzgt0WJWQ+57HOK5kBslk=\",\"secondaryKey\":\"V1oBzK3+0bu/moDRSgSq3QzkiyymsSiIKO+flJza6ww=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"7BE8F5ovBUO0SPC1w/RVXTGxWFPv8sAk5Yp8LzdMNEA=\",\"secondaryKey\":\"4mVEBJEiu7KhQEWvefxfrGBwDPqqCMudhyY4Aw+Jlbs=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
-  'content-length': '905',
+  'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': '2246b585-15c0-4cbf-9245-625d59b44d13',
-  'x-ms-correlation-request-id': '2246b585-15c0-4cbf-9245-625d59b44d13',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220916Z:2246b585-15c0-4cbf-9245-625d59b44d13',
+  'x-ms-ratelimit-remaining-subscription-reads': '14993',
+  'x-ms-request-id': '7c0e086b-39d8-429c-96f9-4b01f2cc3449',
+  'x-ms-correlation-request-id': '7c0e086b-39d8-429c-96f9-4b01f2cc3449',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220918Z:7c0e086b-39d8-429c-96f9-4b01f2cc3449',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:16 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:18 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .post('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856/listkeys?api-version=2016-02-03')
-  .reply(200, "{\"value\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"T0K6XYY99kqNbTmrsEvtLXdLFV+F+HEoTENfIjGAhLA=\",\"secondaryKey\":\"lRgkuypCkCMudF6FftyLgv8psYgwtcnod8922P4mb1c=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"ptriP7oEMdF95UjQfOMCHEgFZV8G4VxZpo98+FFq1ro=\",\"secondaryKey\":\"hIzfoSsCVsoXVouaW9+KWcCH//odUQzE8O6k5dMgMqw=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"mnVqusYiZep1VOCKH3BCKYIhGjWZ1+oN8DcnCZgGqWw=\",\"secondaryKey\":\"MfxHA42ti+j5HWIOQrTckKoZn5gI8I8U2IcuJZw66Q0=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"5XggslvWsumhasWwGNey8Xpzgt0WJWQ+57HOK5kBslk=\",\"secondaryKey\":\"V1oBzK3+0bu/moDRSgSq3QzkiyymsSiIKO+flJza6ww=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"7BE8F5ovBUO0SPC1w/RVXTGxWFPv8sAk5Yp8LzdMNEA=\",\"secondaryKey\":\"4mVEBJEiu7KhQEWvefxfrGBwDPqqCMudhyY4Aw+Jlbs=\",\"rights\":\"RegistryWrite\"}]}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
-  'content-length': '905',
+  'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-writes': '1199',
-  'x-ms-request-id': '2246b585-15c0-4cbf-9245-625d59b44d13',
-  'x-ms-correlation-request-id': '2246b585-15c0-4cbf-9245-625d59b44d13',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220916Z:2246b585-15c0-4cbf-9245-625d59b44d13',
+  'x-ms-ratelimit-remaining-subscription-reads': '14993',
+  'x-ms-request-id': '7c0e086b-39d8-429c-96f9-4b01f2cc3449',
+  'x-ms-correlation-request-id': '7c0e086b-39d8-429c-96f9-4b01f2cc3449',
+  'x-ms-routing-request-id': 'CENTRALUS:20161017T220918Z:7c0e086b-39d8-429c-96f9-4b01f2cc3449',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:16 GMT',
+  date: 'Mon, 17 Oct 2016 22:09:18 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_ip_filter_rules_set_and_list_command_using_files_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_ip_filter_rules_set_and_list_command_using_files_should_work.nock.js
@@ -30,36 +30,220 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14954',
-  'x-ms-request-id': '8c98d00c-2937-49c0-9047-9102bfb5932a',
-  'x-ms-correlation-request-id': '8c98d00c-2937-49c0-9047-9102bfb5932a',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203431Z:8c98d00c-2937-49c0-9047-9102bfb5932a',
+  'x-ms-ratelimit-remaining-subscription-reads': '14988',
+  'x-ms-request-id': 'fba54f3f-1885-4510-9d34-5aeed31cf458',
+  'x-ms-correlation-request-id': 'fba54f3f-1885-4510-9d34-5aeed31cf458',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173225Z:fba54f3f-1885-4510-9d34-5aeed31cf458',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:31 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:24 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14954',
-  'x-ms-request-id': '8c98d00c-2937-49c0-9047-9102bfb5932a',
-  'x-ms-correlation-request-id': '8c98d00c-2937-49c0-9047-9102bfb5932a',
-  'x-ms-routing-request-id': 'CENTRALUS:20161019T203431Z:8c98d00c-2937-49c0-9047-9102bfb5932a',
+  'x-ms-ratelimit-remaining-subscription-reads': '14988',
+  'x-ms-request-id': 'fba54f3f-1885-4510-9d34-5aeed31cf458',
+  'x-ms-correlation-request-id': 'fba54f3f-1885-4510-9d34-5aeed31cf458',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173225Z:fba54f3f-1885-4510-9d34-5aeed31cf458',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Wed, 19 Oct 2016 20:34:31 GMT',
+  date: 'Thu, 20 Oct 2016 17:32:24 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '1624',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14985',
+  'x-ms-request-id': '7d0f2943-5e38-4629-9ea7-57a850ff2350',
+  'x-ms-correlation-request-id': '7d0f2943-5e38-4629-9ea7-57a850ff2350',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173226Z:7d0f2943-5e38-4629-9ea7-57a850ff2350',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:25 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '1624',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14985',
+  'x-ms-request-id': '7d0f2943-5e38-4629-9ea7-57a850ff2350',
+  'x-ms-correlation-request-id': '7d0f2943-5e38-4629-9ea7-57a850ff2350',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173226Z:7d0f2943-5e38-4629-9ea7-57a850ff2350',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:25 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .filteringRequestBody(function (path) { return '*';})
+.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03', '*')
+  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"provisioningState\":\"Accepted\",\"authorizationPolicies\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"ihzg6Ptf4dtdHEw0f5L7L4pMCQO0qrfVVATz4ifOOus=\",\"secondaryKey\":\"yRtoSC42YC9yG2Fzvi80FNa85tqEUKuo5XAi6BbXfkc=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"arUTkZHsfQ49M7H2nW2hiZkkei0+hsipL5bpUi2bPSw=\",\"secondaryKey\":\"gw0YGXXyi8wwf6IZYq6K5apUgaNrJiXjMkaHeNTSPM8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"tC2v7TTAL8QEyhznrLJL6PGZ2rYJZ6J5sJkt7cqdId4=\",\"secondaryKey\":\"IaIHpP9mkQkldQPLK2zJh6R+KEc1wGm3njqVF3dO3Zc=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"PIX4GYK5bFdKTdWOBlKAE+eBZRMQyst5njoirJFTcaQ=\",\"secondaryKey\":\"4Hlo/KwpjxePyYsRY2AGFf7MtIJXGPSzltMai81Wcvg=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"CHKC6iL+1iPmwTLxddiuWLzVzKjUFB7TAxb8OSfZ3qI=\",\"secondaryKey\":\"ueKT77pRORxapv8wWNU52dBOQG5yNw9CtmbI6VLvFr4=\",\"rights\":\"RegistryWrite\"}],\"ipFilterRules\":[{\"filterName\":\"deny\",\"action\":\"Accept\",\"ipMask\":\"0.0.0.0/0\"},{\"filterName\":\"test\",\"action\":\"Reject\",\"ipMask\":\"0.0.0.0/0\"}],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '2647',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/YmQ0ZmE4YTItZWZkMC00ZDE5LWI2NTAtZGJiYzU0YzIyMDM3?api-version=2016-02-03&asyncinfo',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-resource-requests': '4999',
+  'x-ms-request-id': 'abd68388-f3d1-4504-984e-9d96398627d1',
+  'x-ms-correlation-request-id': 'abd68388-f3d1-4504-984e-9d96398627d1',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173228Z:abd68388-f3d1-4504-984e-9d96398627d1',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:27 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .filteringRequestBody(function (path) { return '*';})
+.put('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03', '*')
+  .reply(201, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQl0=\",\"properties\":{\"provisioningState\":\"Accepted\",\"authorizationPolicies\":[{\"keyName\":\"iothubowner\",\"primaryKey\":\"ihzg6Ptf4dtdHEw0f5L7L4pMCQO0qrfVVATz4ifOOus=\",\"secondaryKey\":\"yRtoSC42YC9yG2Fzvi80FNa85tqEUKuo5XAi6BbXfkc=\",\"rights\":\"RegistryWrite, ServiceConnect, DeviceConnect\"},{\"keyName\":\"service\",\"primaryKey\":\"arUTkZHsfQ49M7H2nW2hiZkkei0+hsipL5bpUi2bPSw=\",\"secondaryKey\":\"gw0YGXXyi8wwf6IZYq6K5apUgaNrJiXjMkaHeNTSPM8=\",\"rights\":\"ServiceConnect\"},{\"keyName\":\"device\",\"primaryKey\":\"tC2v7TTAL8QEyhznrLJL6PGZ2rYJZ6J5sJkt7cqdId4=\",\"secondaryKey\":\"IaIHpP9mkQkldQPLK2zJh6R+KEc1wGm3njqVF3dO3Zc=\",\"rights\":\"DeviceConnect\"},{\"keyName\":\"registryRead\",\"primaryKey\":\"PIX4GYK5bFdKTdWOBlKAE+eBZRMQyst5njoirJFTcaQ=\",\"secondaryKey\":\"4Hlo/KwpjxePyYsRY2AGFf7MtIJXGPSzltMai81Wcvg=\",\"rights\":\"RegistryRead\"},{\"keyName\":\"registryReadWrite\",\"primaryKey\":\"CHKC6iL+1iPmwTLxddiuWLzVzKjUFB7TAxb8OSfZ3qI=\",\"secondaryKey\":\"ueKT77pRORxapv8wWNU52dBOQG5yNw9CtmbI6VLvFr4=\",\"rights\":\"RegistryWrite\"}],\"ipFilterRules\":[{\"filterName\":\"deny\",\"action\":\"Accept\",\"ipMask\":\"0.0.0.0/0\"},{\"filterName\":\"test\",\"action\":\"Reject\",\"ipMask\":\"0.0.0.0/0\"}],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '2647',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  'azure-asyncoperation': 'https://management.azure.com/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/YmQ0ZmE4YTItZWZkMC00ZDE5LWI2NTAtZGJiYzU0YzIyMDM3?api-version=2016-02-03&asyncinfo',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-resource-requests': '4999',
+  'x-ms-request-id': 'abd68388-f3d1-4504-984e-9d96398627d1',
+  'x-ms-correlation-request-id': 'abd68388-f3d1-4504-984e-9d96398627d1',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173228Z:abd68388-f3d1-4504-984e-9d96398627d1',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:27 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/YmQ0ZmE4YTItZWZkMC00ZDE5LWI2NTAtZGJiYzU0YzIyMDM3?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '22',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14989',
+  'x-ms-request-id': 'cdb0e684-1157-4651-8485-8e4217f07d05',
+  'x-ms-correlation-request-id': 'cdb0e684-1157-4651-8485-8e4217f07d05',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173258Z:cdb0e684-1157-4651-8485-8e4217f07d05',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:57 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423/operationResults/YmQ0ZmE4YTItZWZkMC00ZDE5LWI2NTAtZGJiYzU0YzIyMDM3?api-version=2016-02-03&asyncinfo')
+  .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '22',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14989',
+  'x-ms-request-id': 'cdb0e684-1157-4651-8485-8e4217f07d05',
+  'x-ms-correlation-request-id': 'cdb0e684-1157-4651-8485-8e4217f07d05',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173258Z:cdb0e684-1157-4651-8485-8e4217f07d05',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:57 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQmI=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[{\"filterName\":\"deny\",\"action\":\"Accept\",\"ipMask\":\"0.0.0.0/0\"},{\"filterName\":\"test\",\"action\":\"Reject\",\"ipMask\":\"0.0.0.0/0\"}],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '1745',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14985',
+  'x-ms-request-id': 'e2f01b75-e100-4266-985e-fb3eac8760ce',
+  'x-ms-correlation-request-id': 'e2f01b75-e100-4266-985e-fb3eac8760ce',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173258Z:e2f01b75-e100-4266-985e-fb3eac8760ce',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:58 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQmI=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[{\"filterName\":\"deny\",\"action\":\"Accept\",\"ipMask\":\"0.0.0.0/0\"},{\"filterName\":\"test\",\"action\":\"Reject\",\"ipMask\":\"0.0.0.0/0\"}],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '1745',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14985',
+  'x-ms-request-id': 'e2f01b75-e100-4266-985e-fb3eac8760ce',
+  'x-ms-correlation-request-id': 'e2f01b75-e100-4266-985e-fb3eac8760ce',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173258Z:e2f01b75-e100-4266-985e-fb3eac8760ce',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:58 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('http://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQmI=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[{\"filterName\":\"deny\",\"action\":\"Accept\",\"ipMask\":\"0.0.0.0/0\"},{\"filterName\":\"test\",\"action\":\"Reject\",\"ipMask\":\"0.0.0.0/0\"}],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '1745',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14989',
+  'x-ms-request-id': '256ac7f2-9830-4abf-8139-116893ce6906',
+  'x-ms-correlation-request-id': '256ac7f2-9830-4abf-8139-116893ce6906',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173259Z:256ac7f2-9830-4abf-8139-116893ce6906',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:58 GMT',
+  connection: 'close' });
+ return result; },
+function (nock) { 
+var result = 
+nock('https://management.azure.com:443')
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub4423\",\"name\":\"xplattestiothub4423\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABxQmI=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[{\"filterName\":\"deny\",\"action\":\"Accept\",\"ipMask\":\"0.0.0.0/0\"},{\"filterName\":\"test\",\"action\":\"Reject\",\"ipMask\":\"0.0.0.0/0\"}],\"hostName\":\"xplattestiothub4423.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub4423-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77564-05a1ed38f7.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  pragma: 'no-cache',
+  'content-length': '1745',
+  'content-type': 'application/json; charset=utf-8',
+  expires: '-1',
+  server: 'Microsoft-HTTPAPI/2.0',
+  'x-ms-ratelimit-remaining-subscription-reads': '14989',
+  'x-ms-request-id': '256ac7f2-9830-4abf-8139-116893ce6906',
+  'x-ms-correlation-request-id': '256ac7f2-9830-4abf-8139-116893ce6906',
+  'x-ms-routing-request-id': 'WESTUS2:20161020T173259Z:256ac7f2-9830-4abf-8139-116893ce6906',
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  date: 'Thu, 20 Oct 2016 17:32:58 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_ip_filter_rules_set_and_list_command_using_files_should_work.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/arm_iothub_Connection_String_Tests_ip_filter_rules_set_and_list_command_using_files_should_work.nock.js
@@ -6,13 +6,13 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '9690a5bf-d489-4fd8-8c26-640da72502bd',
-    name: 'Windows Azure MSDN - Visual Studio Ultimate',
+    id: 'e0b81f36-36ba-44f7-b550-7c9344a35893',
+    name: 'IOTHUB_PERF_1',
     user: {
       name: 'user@domain.example',
-      type: 'user'
+      type: 'servicePrincipal'
     },
-    tenantId: '461e517d-31f6-4789-9060-c6e4162eaf38',
+    tenantId: 'microsoft.com',
     state: 'Enabled',
     registeredProviders: [],
     _eventsCount: '1',
@@ -30,72 +30,36 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': '7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
-  'x-ms-correlation-request-id': '7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220917Z:7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
+  'x-ms-ratelimit-remaining-subscription-reads': '14954',
+  'x-ms-request-id': '8c98d00c-2937-49c0-9047-9102bfb5932a',
+  'x-ms-correlation-request-id': '8c98d00c-2937-49c0-9047-9102bfb5932a',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203431Z:8c98d00c-2937-49c0-9047-9102bfb5932a',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:17 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:31 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
+  .get('/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819?api-version=2016-02-03')
+  .reply(200, "{\"id\":\"/subscriptions/e0b81f36-36ba-44f7-b550-7c9344a35893/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1819\",\"name\":\"xplattestiothub1819\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"e0b81f36-36ba-44f7-b550-7c9344a35893\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABwsqQ=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1819.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1819-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-77204-b199a3c1ec.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '1624',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14996',
-  'x-ms-request-id': '7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
-  'x-ms-correlation-request-id': '7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220917Z:7cbab24f-1b02-4a79-9f34-5aba53ff3e3a',
+  'x-ms-ratelimit-remaining-subscription-reads': '14954',
+  'x-ms-request-id': '8c98d00c-2937-49c0-9047-9102bfb5932a',
+  'x-ms-correlation-request-id': '8c98d00c-2937-49c0-9047-9102bfb5932a',
+  'x-ms-routing-request-id': 'CENTRALUS:20161019T203431Z:8c98d00c-2937-49c0-9047-9102bfb5932a',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:17 GMT',
-  connection: 'close' });
- return result; },
-function (nock) { 
-var result = 
-nock('http://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
-  pragma: 'no-cache',
-  'content-length': '1624',
-  'content-type': 'application/json; charset=utf-8',
-  expires: '-1',
-  server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14993',
-  'x-ms-request-id': '7c0e086b-39d8-429c-96f9-4b01f2cc3449',
-  'x-ms-correlation-request-id': '7c0e086b-39d8-429c-96f9-4b01f2cc3449',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220918Z:7c0e086b-39d8-429c-96f9-4b01f2cc3449',
-  'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:18 GMT',
-  connection: 'close' });
- return result; },
-function (nock) { 
-var result = 
-nock('https://management.azure.com:443')
-  .get('/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856?api-version=2016-02-03')
-  .reply(200, "{\"id\":\"/subscriptions/9690a5bf-d489-4fd8-8c26-640da72502bd/resourceGroups/xplattestiothubrg/providers/Microsoft.Devices/IotHubs/xplattestiothub1856\",\"name\":\"xplattestiothub1856\",\"type\":\"Microsoft.Devices/IotHubs\",\"location\":\"westus\",\"tags\":{},\"subscriptionid\":\"9690a5bf-d489-4fd8-8c26-640da72502bd\",\"resourcegroup\":\"xplattestiothubrg\",\"etag\":\"AAAAAABvhT4=\",\"properties\":{\"state\":\"Active\",\"provisioningState\":\"Succeeded\",\"ipFilterRules\":[],\"hostName\":\"xplattestiothub1856.azure-devices.net\",\"eventHubEndpoints\":{\"events\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"},\"operationsMonitoringEvents\":{\"retentionTimeInDays\":1,\"partitionCount\":2,\"partitionIds\":[\"0\",\"1\"],\"path\":\"xplattestiothub1856-operationmonitoring\",\"endpoint\":\"sb://iothub-ns-xplattesti-76458-3cb1221e2f.servicebus.windows.net/\"}},\"storageEndpoints\":{\"$default\":{\"sasTtlAsIso8601\":\"PT1H\",\"connectionString\":\"\",\"containerName\":\"\"}},\"messagingEndpoints\":{\"fileNotifications\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":10}},\"enableFileUploadNotifications\":false,\"cloudToDevice\":{\"maxDeliveryCount\":10,\"defaultTtlAsIso8601\":\"PT1H\",\"feedback\":{\"lockDurationAsIso8601\":\"PT1M\",\"ttlAsIso8601\":\"PT1H\",\"maxDeliveryCount\":1}},\"operationsMonitoringProperties\":{\"events\":{\"None\":\"None\",\"Connections\":\"None\",\"DeviceTelemetry\":\"None\",\"C2DCommands\":\"None\",\"DeviceIdentityOperations\":\"None\",\"FileUploadOperations\":\"None\"}},\"features\":\"None\",\"generationNumber\":0},\"sku\":{\"name\":\"S1\",\"tier\":\"Standard\",\"capacity\":1}}", { 'cache-control': 'no-cache',
-  pragma: 'no-cache',
-  'content-length': '1624',
-  'content-type': 'application/json; charset=utf-8',
-  expires: '-1',
-  server: 'Microsoft-HTTPAPI/2.0',
-  'x-ms-ratelimit-remaining-subscription-reads': '14993',
-  'x-ms-request-id': '7c0e086b-39d8-429c-96f9-4b01f2cc3449',
-  'x-ms-correlation-request-id': '7c0e086b-39d8-429c-96f9-4b01f2cc3449',
-  'x-ms-routing-request-id': 'CENTRALUS:20161017T220918Z:7c0e086b-39d8-429c-96f9-4b01f2cc3449',
-  'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Mon, 17 Oct 2016 22:09:18 GMT',
+  date: 'Wed, 19 Oct 2016 20:34:31 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-cli-iothub-tests/suite.arm-cli-iothub-tests.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/suite.arm-cli-iothub-tests.nock.js
@@ -6,15 +6,16 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: '9690a5bf-d489-4fd8-8c26-640da72502bd',
+    name: 'Windows Azure MSDN - Visual Studio Ultimate',
     user: {
       name: 'user@domain.example',
-      type: 'servicePrincipal'
+      type: 'user'
     },
-    tenantId: 'microsoft.com',
+    tenantId: '461e517d-31f6-4789-9060-c6e4162eaf38',
     state: 'Enabled',
-    registeredProviders: ['mobileservice'],
+    registeredProviders: [],
+    _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));
 

--- a/test/recordings/arm-cli-iothub-tests/suite.arm-cli-iothub-tests.nock.js
+++ b/test/recordings/arm-cli-iothub-tests/suite.arm-cli-iothub-tests.nock.js
@@ -6,13 +6,13 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '9690a5bf-d489-4fd8-8c26-640da72502bd',
-    name: 'Windows Azure MSDN - Visual Studio Ultimate',
+    id: 'e0b81f36-36ba-44f7-b550-7c9344a35893',
+    name: 'IOTHUB_PERF_1',
     user: {
       name: 'user@domain.example',
-      type: 'user'
+      type: 'servicePrincipal'
     },
-    tenantId: '461e517d-31f6-4789-9060-c6e4162eaf38',
+    tenantId: 'microsoft.com',
     state: 'Enabled',
     registeredProviders: [],
     _eventsCount: '1',


### PR DESCRIPTION
The content to be added to Changelog is as follows:

Added support for the following IP filter-rules commands in IotHub:
1. List IP filter rules: azure iothub ipfilter-rules list [resource-group] [name]
2. Set IP filter rules: azure iothub ipfilter-rules set [resource-group] [name] [input-file]
