### PR TITLE
Skip progress indicators if running in non-interactive mode

### DIFF
--- a/lib/util/interaction.js
+++ b/lib/util/interaction.js
@@ -63,7 +63,7 @@ __.extend(Interactor.prototype, {
   
   _drawAndUpdateProgress: function() {
     var self = this;
-    if ( nonInteractiveMode ) {
+    if (nonInteractiveMode) {
       return;
     }
 
@@ -84,7 +84,7 @@ __.extend(Interactor.prototype, {
         clearInterval(self.activeProgressTimer);
         self.activeProgressTimer = null;
       }
-      if ( ! nonInteractiveMode ) {
+      if (!nonInteractiveMode) {
         fs.writeSync(1, '\r+\n');
       }
       self.currentProgress = undefined;
@@ -101,7 +101,7 @@ __.extend(Interactor.prototype, {
   //},
 
   _pauseProgress: function () {
-    if ( nonInteractiveMode ) {
+    if (nonInteractiveMode) {
       return;
     }
 
@@ -111,7 +111,7 @@ __.extend(Interactor.prototype, {
   },
 
   _restartProgress: function (label) {
-    if ( nonInteractiveMode ) {
+    if (nonInteractiveMode) {
       return;
     }
 

--- a/lib/util/interaction.js
+++ b/lib/util/interaction.js
@@ -63,6 +63,9 @@ __.extend(Interactor.prototype, {
   
   _drawAndUpdateProgress: function() {
     var self = this;
+    if ( nonInteractiveMode ) {
+      return;
+    }
 
     fs.writeSync(1, '\r');
     process.stdout.write(self.progressChars[self.progressIndex].cyan);
@@ -81,7 +84,9 @@ __.extend(Interactor.prototype, {
         clearInterval(self.activeProgressTimer);
         self.activeProgressTimer = null;
       }
-      fs.writeSync(1, '\r+\n');
+      if ( ! nonInteractiveMode ) {
+        fs.writeSync(1, '\r+\n');
+      }
       self.currentProgress = undefined;
     }
   },
@@ -96,12 +101,20 @@ __.extend(Interactor.prototype, {
   //},
 
   _pauseProgress: function () {
+    if ( nonInteractiveMode ) {
+      return;
+    }
+
     if (this.currentProgress) {
       fs.writeSync(1, '\r' + this.clearBuffer + '\r');
     }
   },
 
   _restartProgress: function (label) {
+    if ( nonInteractiveMode ) {
+      return;
+    }
+
     if (this.currentProgress) {
       this._drawAndUpdateProgress();
       if (label) {


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* Skip output of progress spinners when running with AZURE_NON_INTERACTIVE_MODE set

mostly resolves #3292 