### PR TITLE
Dns zone commands hot fixes

### DIFF
--- a/lib/commands/arm/network/dnsZone._js
+++ b/lib/commands/arm/network/dnsZone._js
@@ -424,8 +424,7 @@ __.extend(DnsZone.prototype, {
     if(!recordSet) {
       throw new Error(util.format($('A record set with name "%s" of type "%s" not found in the DNS zone "%s"'), setName, options.type, zoneName));
     }
-
-    options.type = self._validateType(options.type);
+    
     if (!options.quiet && !self.interaction.confirm(util.format($('Delete DNS record set "%s" from DNS zone "%s"? [y/n] '), setName, zoneName), _)) {
       return;
     }
@@ -495,6 +494,7 @@ __.extend(DnsZone.prototype, {
 
     var progress = self.interaction.progress(util.format($('Looking up the DNS Record Set "%s" of type "%s"'), setName, setType));
     try {
+      setType = setType.toUpperCase();
       var recordSet = self.dnsManagementClient.recordSets.get(resourceGroupName, zoneName, setName, setType, _);
       recordSetUtils.removeEmptyRecords(recordSet);
       return recordSet;

--- a/lib/commands/arm/network/dnsZone._js
+++ b/lib/commands/arm/network/dnsZone._js
@@ -624,7 +624,7 @@ __.extend(DnsZone.prototype, {
         options.text = self.interaction.promptIfNotGiven($('Text for TXT record type: '), options.text, _);
         break;
       case constants.dnsZone.PTR:
-        options.ptrdName = self.interaction.promptIfNotGiven($('PTR domain name for PTR record: '), options.ptrdName, _);
+        options.ptrdname = self.interaction.promptIfNotGiven($('PTR domain name for PTR record: '), options.ptrdname, _);
         break;
       default:
         break;

--- a/lib/commands/arm/network/zoneFile._js
+++ b/lib/commands/arm/network/zoneFile._js
@@ -147,9 +147,9 @@ __.extend(ZoneFile.prototype, {
       if (recordSet) {
         var index = utils.indexOfCaseIgnore(res.sets, {name: recordSet.name, type: recordSet.type});
         if (index === -1) {
-          res.sets.push(recordSet); // create new RecordSet
+          res.sets.push(recordSet); // create new RecordSet.
         } else {
-          res.sets[index].records.push(recordSet.records[0]); // Use existing Record set
+          res.sets[index].records.push(recordSet.records[0]); // Use existing Record set.
           if (recordSet.ttl !== res.sets[index].ttl) {
             var minTtl = recordSet.ttl < res.sets[index].ttl ? recordSet.ttl : res.sets[index].ttl;
             this.output.info(util.format('The TTLs %s and %s for record set "%s" of type "%s" are conflicts, using lower TTL of %s',
@@ -465,7 +465,7 @@ __.extend(ZoneFile.prototype, {
       name: rr.name,
       type: rr.type,
       ttl: rr.ttl,
-      PTRRecords: [{
+      records: [{
         ptrdname: self.convertToFQDN(rr.data[0], $origin)
       }]
     };

--- a/lib/commands/arm/network/zoneFile._js
+++ b/lib/commands/arm/network/zoneFile._js
@@ -348,7 +348,8 @@ __.extend(ZoneFile.prototype, {
     if (value === zoneSuffix) {
       return '@';
     } else {
-      var relativeName = value.replace('.' + zoneSuffix, '');
+      var pattern = new RegExp('.' + zoneSuffix, 'i');
+      var relativeName = value.replace(pattern, '');
       return relativeName;
     }
   },


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* Fixed issues in PTR record set records import
* Fixed issue with ```record-set add-record``` command adding PTR type record
* Fixed issue [#3282](https://github.com/Azure/azure-xplat-cli/issues/3282) with ```record-set delete``` commands: ```type``` option is not case sensitive anymore