### PR TITLE
add Linux support to showAzureDiskEncryptionStatus

### DIFF
--- a/lib/commands/arm/vm/vmClient._js
+++ b/lib/commands/arm/vm/vmClient._js
@@ -1948,7 +1948,7 @@ __.extend(VMClient.prototype, {
     return virtualMachine.createOrUpdateVM(resourceGroupName, vmModel, false, _);
   },
 
-  showAzureDiskEncryptionStatus: function(resourceGroupName, name, options, _) {
+  showAzureDiskEncryptionStatus: function (resourceGroupName, name, options, _) {
     var subscription = profile.current.getSubscription(this.subscription);
     var serviceClients = this._getServiceClients(subscription);
     var virtualMachine = new VirtualMachine(this.cli, serviceClients);
@@ -1958,67 +1958,96 @@ __.extend(VMClient.prototype, {
       osVolumeEncryptionSettings: null,
       dataVolumesEncrypted: 'NotEncrypted'
     };
-    var extensionStatus = null;
-      
+
     var vmModel = virtualMachine.getVM(resourceGroupName, name, _);
     if (!vmModel) {
       throw new Error(util.format($('Virtual machine "%s" not found under the resource group "%s"'), name, resourceGroupName));
     }
-    if (utils.ignoreCaseEquals(vmModel.storageProfile.osDisk.osType, 'Linux')) {
-      // Default value for OS volumes in Linux VMs
-      encryptionStatus.osVolumeEncrypted = 'Unknown';
-    }
-    if(vmModel.storageProfile.osDisk.encryptionSettings)
-    {
-      encryptionStatus.osVolumeEncryptionSettings = vmModel.storageProfile.osDisk.encryptionSettings;
-      if((encryptionStatus.osVolumeEncryptionSettings.enabled) &&
-        (encryptionStatus.osVolumeEncryptionSettings.diskEncryptionKey.secretUrl)) {
-          encryptionStatus.osVolumeEncrypted = 'Encrypted';
-      }
 
-      // get extension model view            
+    if (vmModel.storageProfile.osDisk.encryptionSettings) {
       var extensionName = '';
       var publisherName = '';
-
       if (utils.ignoreCaseEquals(vmModel.storageProfile.osDisk.osType, 'Linux')) {
-          extensionName = vmConstants.EXTENSIONS.AZURE_DISK_ENCRYPTION_LINUX_EXTENSION_NAME;
-          publisherName = vmConstants.EXTENSIONS.AZURE_DISK_ENCRYPTION_LINUX_EXTENSION_PUBLISHER;
+        extensionName = vmConstants.EXTENSIONS.AZURE_DISK_ENCRYPTION_LINUX_EXTENSION_NAME;
+        publisherName = vmConstants.EXTENSIONS.AZURE_DISK_ENCRYPTION_LINUX_EXTENSION_PUBLISHER;
       }
-      else if(utils.ignoreCaseEquals(vmModel.storageProfile.osDisk.osType, 'Windows')) {
-          extensionName = vmConstants.EXTENSIONS.AZURE_DISK_ENCRYPTION_WINDOWS_EXTENSION_NAME;
-          publisherName = vmConstants.EXTENSIONS.AZURE_DISK_ENCRYPTION_WINDOWS_EXTENSION_PUBLISHER;
+      else if (utils.ignoreCaseEquals(vmModel.storageProfile.osDisk.osType, 'Windows')) {
+        extensionName = vmConstants.EXTENSIONS.AZURE_DISK_ENCRYPTION_WINDOWS_EXTENSION_NAME;
+        publisherName = vmConstants.EXTENSIONS.AZURE_DISK_ENCRYPTION_WINDOWS_EXTENSION_PUBLISHER;
       }
 
+      var extensionStatus = null;
       try {
-        var getOptions = { expand : 'instanceView' };
+        var getOptions = { expand: 'instanceView' };
         extensionStatus = serviceClients.computeManagementClient.virtualMachineExtensions.get(resourceGroupName, name, extensionName, getOptions, _);
       }
       catch (e) {
         extensionStatus = null;
       }
 
-      if(extensionStatus &&
+      // attempt to retrieve extension status message  
+      if (extensionStatus &&
         extensionStatus.instanceView &&
         extensionStatus.instanceView.statuses &&
         (extensionStatus.instanceView.statuses.length >= 1) &&
         utils.ignoreCaseEquals(extensionStatus.publisher, publisherName) &&
-        utils.ignoreCaseEquals(extensionStatus.virtualMachineExtensionType, extensionName))
-      {
+        utils.ignoreCaseEquals(extensionStatus.virtualMachineExtensionType, extensionName)) {
         encryptionStatus.progressMessage = extensionStatus.instanceView.statuses[0].message;
       }
 
-      if((extensionStatus) &&
+      // attempt to retrieve extension substatus message 
+      var substatusMessage = null;
+      if (extensionStatus &&
+        extensionStatus.instanceView &&
+        extensionStatus.instanceView.substatuses &&
+        (extensionStatus.instanceView.substatuses.length >= 1) &&
+        utils.ignoreCaseEquals(extensionStatus.publisher, publisherName) &&
+        utils.ignoreCaseEquals(extensionStatus.virtualMachineExtensionType, extensionName)) {
+        substatusMessage = extensionStatus.instanceView.substatuses[0].message;
+      }
+
+      // retrieve os volume encryption settings
+      encryptionStatus.osVolumeEncryptionSettings = vmModel.storageProfile.osDisk.encryptionSettings;
+
+      if (utils.ignoreCaseEquals(vmModel.storageProfile.osDisk.osType, 'Linux')) {
+        // Linux - get os and data volume encryption state from the instance view status message
+        var messageObject = null;
+        try {
+          messageObject = JSON.parse(substatusMessage);
+        }
+        catch (e) {
+          messageObject = null;  // outdated versions of guest agent produce messages that cannot be parsed
+        }
+
+        if (messageObject && messageObject.hasOwnProperty('os')) {
+          encryptionStatus.osVolumeEncrypted = messageObject.os;
+        } else {
+          encryptionStatus.osVolumeEncrypted = 'Unknown';
+        }
+
+        if (messageObject && messageObject.hasOwnProperty('data')) {
+          encryptionStatus.dataVolumesEncrypted = messageObject.data;
+        } else {
+          encryptionStatus.dataVolumesEncrypted = 'Unknown';
+        }
+      }
+      else if (utils.ignoreCaseEquals(vmModel.storageProfile.osDisk.osType, 'Windows')) {
+        // Windows - get os and data volume encryption state from the vm model 
+        if (encryptionStatus.osVolumeEncryptionSettings.enabled && encryptionStatus.osVolumeEncryptionSettings.diskEncryptionKey.secretUrl) {
+          encryptionStatus.osVolumeEncrypted = 'Encrypted';
+        }
+
+        if ((extensionStatus) &&
           utils.ignoreCaseEquals(extensionStatus.publisher, publisherName) &&
           utils.ignoreCaseEquals(extensionStatus.virtualMachineExtensionType, extensionName) &&
-          utils.ignoreCaseEquals(extensionStatus.provisioningState, vmConstants.EXTENSIONS.EXTENSION_PROVISIONING_SUCCEEDED))
-      {
-        if(!extensionStatus.settings.VolumeType ||
+          utils.ignoreCaseEquals(extensionStatus.provisioningState, vmConstants.EXTENSIONS.EXTENSION_PROVISIONING_SUCCEEDED)) {
+          if (!extensionStatus.settings.VolumeType ||
             utils.ignoreCaseEquals(extensionStatus.settings.VolumeType, 'All') ||
             utils.ignoreCaseEquals(extensionStatus.settings.VolumeType, 'Data') ||
-            (utils.stringIsNullOrEmpty(extensionStatus.settings.VolumeType)))
-        {
-          if(utils.ignoreCaseEquals(extensionStatus.settings.EncryptionOperation, 'EnableEncryption')) {
-            encryptionStatus.dataVolumesEncrypted = 'Encrypted';
+            (utils.stringIsNullOrEmpty(extensionStatus.settings.VolumeType))) {
+            if (utils.ignoreCaseEquals(extensionStatus.settings.EncryptionOperation, 'EnableEncryption')) {
+              encryptionStatus.dataVolumesEncrypted = 'Encrypted';
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes an issue where incorrect or unhelpful status was being reported for Linux volumes.  When a Linux VM is being queried this code will now pull the encryption state of OS and data volumes from the extension's instanceview substatus message field.   