### PR TITLE
[Batch-beta] Change default VM size to A8 (not D8) for OpenFoam sample

### DIFF
--- a/Documentation/BatchDocumentation/samples/openfoam/pool.openfoam.json
+++ b/Documentation/BatchDocumentation/samples/openfoam/pool.openfoam.json
@@ -5,7 +5,7 @@
             "metadata": {
                 "description": "The size of the virtual machines that runs the application"
             },
-            "defaultValue": "STANDARD_D8",
+            "defaultValue": "STANDARD_A8",
             "allowedValues": [
                 "STANDARD_A8",
                 "STANDARD_A9"


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* 
* 
* 
I'm assuming a typo given this is an MPI workload and the default D8 isn't one of the permitted values...