### PR TITLE
Improvement to azure portal command.

### DIFF
--- a/lib/commands/portal._js
+++ b/lib/commands/portal._js
@@ -25,7 +25,25 @@ exports.init = function(cli) {
     .option('-e, --environment <environment>', $('the publish settings download environment'))
     .option('-r, --realm <realm>', $('the organization\'s realm'))
     .execute(function (options, _) {
-      var targetUrl = profile.current.getEnvironment(options.environment).getPortalUrl(options.realm);
+      // If the environment option is specified, fetch that specific environment
+      // If it is left unspecified, fetch the one associated with current account
+      // If all else fails, fetch the default environment.
+      var environmentName = options.environment;
+      var targetEnvironment;
+      if(!environmentName) {
+        var subscription = profile.current.getSubscription(options.subscription);
+        if(subscription) {
+          targetEnvironment = subscription.environment;
+        }
+        else{
+          targetEnvironment = profile.current.getDefaultEnvironment();
+        }
+      }
+      else{
+        targetEnvironment = profile.current.getEnvironment(environmentName);
+      }
+
+      var targetUrl = targetEnvironment.getPortalUrl(options.realm);
       cli.interaction.launchBrowser(targetUrl, _);
     });
 };

--- a/lib/util/profile/profile.js
+++ b/lib/util/profile/profile.js
@@ -69,6 +69,10 @@ _.extend(Profile.prototype, {
     this.environments[env.name] = env;
   },
 
+  getDefaultEnvironment: function () {
+    return this.environments[Environment.DEFAULT_ENV_NAME];
+  },
+
   getEnvironment: function (envName) {
     if (!envName) {
       return this.environments.AzureCloud;


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* Improvement to azure portal command.
We now try to infer the environment the user is likely to prefer, when
they omitted the -e argument to the command. With this change, if -e is
omitted, we open the portal for the environment associated with the
user's subscription that they are currently signed into. Other cases (
where -e is specified, user is not signed in etc.) remain the same as
before.
* Fixes bug #2074 
