### PR TITLE
Do not prompt for telemetry if AZURE_NON_INTERACTIVE_MODE environment variable is set.

### DIFF
--- a/lib/util/utilsCore.js
+++ b/lib/util/utilsCore.js
@@ -173,6 +173,14 @@ exports.isTelemetryEnabled = function (callback) {
   } else if (process.argv[2] && process.argv[2].toLowerCase() === 'telemetry') {
     return callback(null, outcome);
   } else {
+    // we've determined that this is not a telemetry command and we do not have user's telemetry preference.
+    // we proceed to read out the telemetry prompt and get user preference. But, before that check if we're
+    // in non interactive mode. If so, do not prompt, assume default response of 'no'.
+    // This behavior is intended to make scripting scenarios better. E.g: running azure cli on a CI server.
+    if (process.env['AZURE_NON_INTERACTIVE_MODE']) {
+      return callback(null, outcome);
+    }
+
     var telemetryPromptText = wrap('\nMicrosoft Azure CLI would like to collect data about how users use CLI commands and some problems they encounter.  ' + 
       'Microsoft uses this information to improve our CLI commands.  Participation is voluntary and when you choose to participate your device ' + 
       'automatically sends information to Microsoft about how you use Azure CLI. ' + 


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* Do not prompt for telemetry if AZURE_NON_INTERACTIVE_MODE environment variable is set. This behavior is intended to make scripting scenarios better. E.g: running azure cli on a CI server.
  If the environment variable is not set and if we don't have a telemetry profile, we prompt, once, which is basically existing behavior.
* Fixes #3297 