### PR TITLE
Client side telemetry: adding error classification

### DIFF
--- a/lib/util/telemetry.js
+++ b/lib/util/telemetry.js
@@ -264,6 +264,7 @@ exports.onError = function (err, callback) {
     _stop(_event);
     _event.isSuccess = false;
     _event.stacktrace = _stripUsername(err.stack);
+    _event.errorCategory = err.statusCode ? 'HTTP_Error_' + err.statusCode : 'CLI_Error';
     _appInsights.client.trackEvent('CmdletError', _event);
     _flush(callback);
   } else {


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* Added an error category field to telemetry event data that helps
classifying errors encountered broadly into two categories. Internal CLI
errors are marked as 'CLI_Error' while command service requests that
fail are identified by 'Cmdlet_Error_<HTTP_STATUSCODE>'.
* Added telemetry unit tests that verify error classification.
* Fixes #2779 