### PR TITLE
[BATCH-BETA] Fix typo in add pool package ref parsing

### DIFF
--- a/lib/commands/batch/batch.pool._js
+++ b/lib/commands/batch/batch.pool._js
@@ -305,8 +305,8 @@ exports.init = function(cli) {
     if (parsedJson.packageReferences) {
       logger.warn('You are using an experimental feature {Package Management}.');
       userAgent = batchUtil.PREVIEW_USER_AGENT_SUFFIX;
-
-      var poolOSFlavor = batchPoolUtils.getTargetPoolOSType(parsedJson);
+      
+      var poolOSFlavor = batchPoolUtils.getPoolTargetOSType(parsedJson);
       var cmds = [templateUtils.parsePoolPackageReferences(parsedJson)];
       // Update the start up command
       parsedJson.startTask = templateUtils.constructSetupTask(parsedJson.startTask, cmds, poolOSFlavor);


### PR DESCRIPTION
Fixed a typo in the package reference parsing in the add pool code path.