### PR TITLE
Change setup authoring to install 32 or 64 bit Node based on target cpu arch

### DIFF
--- a/tools/windows/Product.wxs
+++ b/tools/windows/Product.wxs
@@ -67,7 +67,7 @@
         <Directory Id="APPLICATIONFOLDER">
           <Directory Id="AZURECLIFOLDER" Name="CLI">
             <Directory Id="DynamicCliDir"/>
-			<Directory Id="BIN" Name="Bin" />
+            <Directory Id="BIN" Name="Bin" />
           </Directory>
         </Directory>
       </Directory>
@@ -120,21 +120,21 @@
       </Component>
     </ComponentGroup>
 
-	<ComponentGroup Id="NodeComponentGroup">
-		<Component Id="node_x86" Directory="BIN" Guid="{1560ef26-74b9-410d-b6f0-1a56a241eb8a}">
-			<Condition>NOT VersionNT64</Condition>
-			<File Id="node86.exe" Name="node.exe" Source="$(var.NodeExeSource)\x86\node.exe" KeyPath="yes" Checksum="yes" />
-		</Component>
-		<Component Id="node_x64" Directory="BIN" Guid="{0ddc44fe-156c-464c-882c-5bc841fea74d}">
-			<Condition>VersionNT64</Condition>
-			<File Id="node64.exe" Name="node.exe" Source="$(var.NodeExeSource)\x64\node.exe" KeyPath="yes" Checksum="yes" />
-		</Component>
-	</ComponentGroup>
-	
+    <ComponentGroup Id="NodeComponentGroup">
+      <Component Id="node_x86" Directory="BIN" Guid="{1560ef26-74b9-410d-b6f0-1a56a241eb8a}">
+        <Condition>NOT VersionNT64</Condition>
+        <File Id="node86.exe" Name="node.exe" Source="$(var.NodeExeSource)\x86\node.exe" KeyPath="yes" Checksum="yes" />
+      </Component>
+      <Component Id="node_x64" Directory="BIN" Guid="{0ddc44fe-156c-464c-882c-5bc841fea74d}">
+        <Condition>VersionNT64</Condition>
+        <File Id="node64.exe" Name="node.exe" Source="$(var.NodeExeSource)\x64\node.exe" KeyPath="yes" Checksum="yes" />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="ProductComponents">
       <ComponentGroupRef Id="AzureCliComponentGroup"/>
       <ComponentGroupRef Id="AzureCliSettingsGroup"/>
-	  <ComponentGroupRef Id="NodeComponentGroup"/>
+      <ComponentGroupRef Id="NodeComponentGroup"/>
     </ComponentGroup>
 
   </Fragment>

--- a/tools/windows/Product.wxs
+++ b/tools/windows/Product.wxs
@@ -67,6 +67,7 @@
         <Directory Id="APPLICATIONFOLDER">
           <Directory Id="AZURECLIFOLDER" Name="CLI">
             <Directory Id="DynamicCliDir"/>
+			<Directory Id="BIN" Name="Bin" />
           </Directory>
         </Directory>
       </Directory>
@@ -119,9 +120,21 @@
       </Component>
     </ComponentGroup>
 
+	<ComponentGroup Id="NodeComponentGroup">
+		<Component Id="node_x86" Directory="BIN" Guid="{1560ef26-74b9-410d-b6f0-1a56a241eb8a}">
+			<Condition>NOT VersionNT64</Condition>
+			<File Id="node86.exe" Name="node.exe" Source="$(var.NodeExeSource)\x86\node.exe" KeyPath="yes" Checksum="yes" />
+		</Component>
+		<Component Id="node_x64" Directory="BIN" Guid="{0ddc44fe-156c-464c-882c-5bc841fea74d}">
+			<Condition>VersionNT64</Condition>
+			<File Id="node64.exe" Name="node.exe" Source="$(var.NodeExeSource)\x64\node.exe" KeyPath="yes" Checksum="yes" />
+		</Component>
+	</ComponentGroup>
+	
     <ComponentGroup Id="ProductComponents">
       <ComponentGroupRef Id="AzureCliComponentGroup"/>
       <ComponentGroupRef Id="AzureCliSettingsGroup"/>
+	  <ComponentGroupRef Id="NodeComponentGroup"/>
     </ComponentGroup>
 
   </Fragment>

--- a/tools/windows/Product.wxs
+++ b/tools/windows/Product.wxs
@@ -15,11 +15,11 @@
            Manufacturer="$(var.ProductAuthor)"
            UpgradeCode="6dd1d1f3-4908-450d-8127-d9ce638646d9">
 
-		<Package InstallerVersion="200"
+    <Package InstallerVersion="200"
              Compressed="yes"
              InstallScope="perMachine" />
 
-		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
 
     <Media Id="1" Cabinet="WindowsAzureCLI.cab" EmbedCab="yes" CompressionLevel="high" />
 
@@ -31,27 +31,27 @@
     <Property Id="ARPURLUPDATEINFO" Value="http://www.microsoft.com/windowsazure/sdk" />
     <Property Id="ApplicationFolderName" Value="Microsoft SDKs\Azure" />
     <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
-    
+
     <Feature Id="ProductFeature"
              Title="Microsoft Azure Command Line Tools"
              Level="1"
              AllowAdvertise="no">
-			<ComponentGroupRef Id="ProductComponents" />
-		</Feature>
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
 
     <!--Custom action to propagate path env variable change-->
     <Binary Id="PropagateEnvChangeExe" SourceFile=".\propagate_env_change\propagate_env_change.exe" />
     <Property Id="WixQuietExecCmdLine" Value="propagate_env_change.exe"/>
     <!--Ignoring the return value if case there is app-hang we can't control -->
-    <CustomAction Id="PropagateEnvChange" 
-                  BinaryKey="PropagateEnvChangeExe" 
-                  ExeCommand="propagate_env_change.exe" 
-                  Execute="commit" 
+    <CustomAction Id="PropagateEnvChange"
+                  BinaryKey="PropagateEnvChangeExe"
+                  ExeCommand="propagate_env_change.exe"
+                  Execute="commit"
                   Return="ignore"/>
     <InstallExecuteSequence>
       <Custom Action="PropagateEnvChange" Before="InstallFinalize" />
     </InstallExecuteSequence>
-    
+
     <!-- User Interface -->
     <WixVariable Id="WixUILicenseRtf" Value="$(var.ProductResources)License.rtf"/>
     <WixVariable Id="WixUIDialogBmp" Value="$(var.ProductResources)Dialog.bmp" />
@@ -61,8 +61,8 @@
 
   </Product>
 
-	<Fragment>
-		<Directory Id="TARGETDIR" Name="SourceDir">
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFilesFolder">
         <Directory Id="APPLICATIONFOLDER">
           <Directory Id="AZURECLIFOLDER" Name="CLI">
@@ -70,10 +70,10 @@
           </Directory>
         </Directory>
       </Directory>
-		</Directory>
-	</Fragment>
+    </Directory>
+  </Fragment>
 
-	<Fragment>
+  <Fragment>
     <ComponentGroup Id="AzureCliSettingsGroup">
       <Component Id="RemoveCLIFolder"
                  Directory="DynamicCliDir"
@@ -124,5 +124,5 @@
       <ComponentGroupRef Id="AzureCliSettingsGroup"/>
     </ComponentGroup>
 
-	</Fragment>
+  </Fragment>
 </Wix>

--- a/tools/windows/azure-cli.wixproj
+++ b/tools/windows/azure-cli.wixproj
@@ -7,7 +7,7 @@
     <WixTargetsPath>$(WixToolPath)Wix.targets</WixTargetsPath>
     <WixTasksPath>wixtasks.dll</WixTasksPath>
     <AzureCliSource>$(HOMEDRIVE)$(HOMEPATH)\zcli</AzureCliSource>
-	<NodeExeSource>$(HOMEDRIVE)$(HOMEPATH)\zNode</NodeExeSource>
+    <NodeExeSource>$(HOMEDRIVE)$(HOMEPATH)\zNode</NodeExeSource>
   </PropertyGroup>
   <!-- Project -->
   <PropertyGroup>

--- a/tools/windows/azure-cli.wixproj
+++ b/tools/windows/azure-cli.wixproj
@@ -7,6 +7,7 @@
     <WixTargetsPath>$(WixToolPath)Wix.targets</WixTargetsPath>
     <WixTasksPath>wixtasks.dll</WixTasksPath>
     <AzureCliSource>$(HOMEDRIVE)$(HOMEPATH)\zcli</AzureCliSource>
+	<NodeExeSource>$(HOMEDRIVE)$(HOMEPATH)\zNode</NodeExeSource>
   </PropertyGroup>
   <!-- Project -->
   <PropertyGroup>
@@ -23,12 +24,12 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>out\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>out\obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;AzureCliSource=$(AzureCliSource)</DefineConstants>
+    <DefineConstants>Debug;AzureCliSource=$(AzureCliSource);NodeExeSource=$(NodeExeSource)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>out\</OutputPath>
     <IntermediateOutputPath>out\obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>AzureCliSource=$(AzureCliSource)</DefineConstants>
+    <DefineConstants>AzureCliSource=$(AzureCliSource);NodeExeSource=$(NodeExeSource)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="out\azure-cli.wxs">

--- a/tools/windows/scripts/prepareRepoClone.cmd
+++ b/tools/windows/scripts/prepareRepoClone.cmd
@@ -75,7 +75,7 @@ mkdir %TEMP_AUX_REPO%
 echo Downloading node x86 and x64...
 pushd %TEMP_AUX_REPO%
 mkdir %X86%
-pushd %x86%
+pushd %X86%
 curl -o node.exe %NODE_X86_DOWNLOAD_URL%
 if %errorlevel% neq 0 goto ERROR
 popd

--- a/tools/windows/scripts/prepareRepoClone.cmd
+++ b/tools/windows/scripts/prepareRepoClone.cmd
@@ -65,8 +65,8 @@ echo Temporary clone of auxilary repo exists. Removing it...
 pushd %TEMP_AUX_REPO%\..\
 if exist %TEMP_AUX_REPO_FOLDER% rmdir /s /q %TEMP_AUX_REPO_FOLDER%
 if exist %TEMP_AUX_REPO_FOLDER% (
-	echo Failed to delete %TEMP_AUX_REPO_FOLDER%.
-	goto ERROR
+    echo Failed to delete %TEMP_AUX_REPO_FOLDER%.
+    goto ERROR
 )
 popd
 
@@ -167,7 +167,7 @@ for %%i in (
     .gitignore
     ChangeLog.txt
     bin\npm.cmd
-	bin\node.exe
+    bin\node.exe
     LICENSE.txt
 ) do (
     if exist %%i (


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* This change modifies the setup authoring to install 64bit NodeJs on
64bit CPUs and prefer 32bit NodeJs on 32bit CPUs. The CLI authoring
harvests the clone of source repo and deploys it to target directory. We
want to opt out of that process for authoring node.exe. We then author
the appropriate bitness node.exe based on VersionNT64 conditional check.
* Fixes #3451 
