### PR TITLE
Update for Storage commands

### DIFF
--- a/lib/commands/storage/storage.blob._js
+++ b/lib/commands/storage/storage.blob._js
@@ -252,7 +252,7 @@ exports.init = function(cli) {
 
   blob.command('upload [file] [container] [blob]')
     .usage('[options] [file] [container] [blob]')
-    .description($('Upload the specified file to storage blob'))
+    .description($('Upload the specified file to storage blob. To upload to large block blob, please run on 64-bit machine with 64-bit node.'))
     .option('-f, --file <file>', $('the local file path'))
     .option('--container <container>', $('the storage container name'))
     .option('-b, --blob <blobName>', $('the storage blob name'))

--- a/lib/util/storage.util._js
+++ b/lib/util/storage.util._js
@@ -292,8 +292,10 @@ StorageUtil.BlobSnapshotDeletion = {
 
 StorageUtil.MaxPolicyCount = 5;
 
+// 100 MB X 50000 blocks
+StorageUtil.MaxBlockBlobSize = 50000 * 100 * 1024 * 1024; 
+
 // 4 MB X 50000 blocks
-StorageUtil.MaxBlockBlobSize = 50000 * 4 * 1024 * 1024; 
 StorageUtil.MaxAppendBlobSize = 50000 * 4 * 1024 * 1024;
 
 // 1 TB

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "azure-asm-storage": "0.12.0",
     "azure-asm-subscription": "0.10.1",
     "azure-asm-website": "0.10.4",
-    "azure-storage": "1.3.0",
+    "azure-storage": "2.0.0",
     "azure-arm-batch": "0.3.0",
     "azure-batch": "0.5.2",
     "azure-servicefabric": "0.1.5",

--- a/test/commands/arm/group/arm.group.deployment-tests.js
+++ b/test/commands/arm/group/arm.group.deployment-tests.js
@@ -333,6 +333,12 @@ describe('arm', function () {
               var key = JSON.parse(keyResult.text)[0].value;
               keyResult.exitStatus.should.equal(0);
 
+              // storage data plane SDK rely on the setTimeout for client side timeout 
+              
+              if (suite.isPlayback()) {
+                setTimeout = originalSetTimeout;
+              }
+
               suite.execute('storage container create --container %s -a %s -k %s -p Off --json', storageContainerName, storageAccountName, key, function (containerResult) {
                 containerResult.exitStatus.should.equal(0);
 
@@ -347,6 +353,12 @@ describe('arm', function () {
                     // the new URIwithSAS created in that recorded session. The reason is nock will record requests with the expiration time
                     // set to thiry minutes after the SAS token generation relative to the time the test was recorded.
                     URIwithSAS = 'https://xstorageaccount764.blob.core.windows.net/xstoragecontainer6074/arm-deployment-template.json?se=2016-10-07T04%3A17%3A00Z&sp=r&sv=2015-12-11&sr=b&sig=8qPO0%2B3yrsXtCD9PixZjAM0rhl10E9yUzd6WgQ3PHts%3D';
+
+                    if (suite.isPlayback()) {
+                      setTimeout = function (action, timeout) {
+                        process.nextTick(action);
+                      };
+                    }
 
                     suite.execute('group deployment create --template-uri %s -g %s -n %s -e %s --nowait --json', URIwithSAS, groupName, deploymentName, parameterFile, function (deployResult) { 
                       deployResult.exitStatus.should.equal(0);
@@ -388,6 +400,11 @@ describe('arm', function () {
               var key = JSON.parse(keyResult.text)[0].value;
               keyResult.exitStatus.should.equal(0);
 
+              // storage data plane SDK rely on the setTimeout for client side timeout 
+              if (suite.isPlayback()) {
+                setTimeout = originalSetTimeout;
+              }
+
               suite.execute('storage container create --container %s -a %s -k %s -p Off --json', storageContainerName, storageAccountName, key, function (containerResult) {
                 containerResult.exitStatus.should.equal(0);
 
@@ -403,6 +420,12 @@ describe('arm', function () {
                     // set to thiry minutes after the SAS token generation relative to the time the test was recorded.
                     URIwithSAS = 'https://xstorageaccount2031.blob.core.windows.net/xstoragecontainer7970/arm-deployment-template.json?se=2016-10-07T03%3A50%3A00Z&sp=r&sv=2015-12-11&sr=b&sig=wm50z9hmC3tHm52rWBYFQNngXLj2aTTnj47k%2Bkdvv8M%3D';
 
+                    if (suite.isPlayback()) {
+                      setTimeout = function (action, timeout) {
+                        process.nextTick(action);
+                      };
+                    }
+                    
                     suite.execute('group deployment create --template-uri %s -g %s -e %s --nowait --json', URIwithSAS, groupName, parameterFile, function (deployResult) { 
                       deployResult.exitStatus.should.equal(0);
                       var deployment = JSON.parse(deployResult.text);


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* Updated azure-storage module to 2.0.0
* Supported large block blob

Besides the Changelog, we'd like to request update the ReadMe to suggest user to: 
* Use 64-bit Windows for large block blob transfer
* Install 64-bit node on 64-bit Linux machine

Please let me know if this doable. 
