### PR TITLE
add --skip-vm-backup option for Linux to fix #3503

### DIFF
--- a/lib/commands/arm/vm/vm._js
+++ b/lib/commands/arm/vm/vm._js
@@ -464,6 +464,7 @@ exports.init = function (cli) {
     .option('-e, --extension-version <extension-version>', util.format($('Version of AzureDiskEncryption extension. Default values are [%s] for Windows'), vmConstants.EXTENSIONS.AZURE_DISK_ENCRYPTION_WINDOWS_EXTENSION_VERSION))
     .option('-s, --subscription <subscription>', $('the subscription identifier'))
     .option('-d, --disable-auto-upgrade-minor-version', $('Disable auto-upgrade of minor version'))
+    .option('-m, --skip-vm-backup', $('Skip VM backup for Linux'))
     .execute(function (resourceGroup, name, options, _) {
       resourceGroup = cli.interaction.promptIfNotGiven($('Resource group name: '), resourceGroup, _);
       name = cli.interaction.promptIfNotGiven($('Virtual machine name: '), name, _);

--- a/lib/commands/arm/vm/vmClient._js
+++ b/lib/commands/arm/vm/vmClient._js
@@ -1842,7 +1842,7 @@ __.extend(VMClient.prototype, {
          throw new Error($('--volume-type option is missing (must be OS, Data, or All)'));
     }    
 
-    if (utils.ignoreCaseEquals(vmResult.storageProfile.osDisk.osType, 'Linux')) {
+    if (utils.ignoreCaseEquals(vmResult.storageProfile.osDisk.osType, 'Linux') && (!options.skipVmBackup)) {
         var createResult = this.createVMBackup(resourceGroupName, name, options, _);
         if (!createResult) {
             throw new Error($('create backup failed.'));


### PR DESCRIPTION
* Unblocks managed disk scenario by adding a **--skip-vm-backup** option to the enable-encryption command. 
* Tested manually since automated testing for Linux target scenario is blocked. 
* More tests to increase Linux target VM coverage are scheduled to be included prior to next release. 
* Keeps the CLI in parity with similar change submitted simultaneously to azure-powershell :
https://github.com/Azure/azure-powershell/pull/3510
