### PR TITLE
Add support for passing daemon as task

### DIFF
--- a/lib/commands/arm/vm/vm._js
+++ b/lib/commands/arm/vm/vm._js
@@ -636,7 +636,7 @@ exports.init = function (cli) {
       .option('-j, --bootstrap-options <bootstrap-json-attribute>', $('Bootstrap options in JSON format. Ex: -j \'{"chef_node_name":"test_node"}\''))
       .option('--bootstrap-version <number>', $('chef-client version to be installed'))
       .option('--chef-service-interval <chef-service-interval>', $('It specifies the frequency (in minutes) at which the chef-service runs. Pass 0 if you don\'t want the chef-service to be installed on the target machine.'))
-      .option('--daemon <daemon>', $('Configures the chef-client service for unattended execution. The node platform to be Windows. Options: \'none\' or \'service\'. \n \'none\' - Currently prevents the chef-client service from being configured as a service. \n \'service\' - Configures the chef-client to run automatically in the background as a service.'))
+      .option('--daemon <daemon>', $('Configures the chef-client service for unattended execution. The node platform to be Windows. Options: \'none\' or \'service\' or \'task\'. \n \'none\' - Currently prevents the chef-client service from being configured as a service. \n \'service\' - Configures the chef-client to run automatically in the background as a service. \n \'task\' - Configures the chef-client to run automatically in the background as a scheduled task.'))
       .option('-u, --uninstall', $('uninstall extension'))
       .option('-t, --tags <tags>', $('Tags to set to the resource group. Can be multiple. ' +
               'In the format of \'name=value\'. Name is required and value is optional. For example, -t tag1=value1;tag2'))

--- a/lib/commands/arm/vm/vmClient._js
+++ b/lib/commands/arm/vm/vmClient._js
@@ -1142,7 +1142,7 @@ __.extend(VMClient.prototype, {
     pubConfig['chef_service_interval'] = options.chefServiceInterval;
 
     if (virtualMachine.storageProfile.osDisk.osType === 'Windows' && options.daemon) {
-      if (['none', 'service'].indexOf(options.daemon) != -1) {
+      if (['none', 'service', 'task'].indexOf(options.daemon) != -1) {
         pubConfig['daemon'] = options.daemon;
       } else {
         throw new Error(util.format($('Invalid user input for --daemon option.')));

--- a/lib/commands/asm/vm._js
+++ b/lib/commands/asm/vm._js
@@ -212,7 +212,7 @@ exports.init = function(cli) {
     .option('-s, --subscription <id>', $('the subscription id'))
     .option('--chef-service-interval <chef-service-interval>', $('It specifies the frequency (in minutes) at which the chef-service runs. Pass 0 if you don\'t want the chef-service to be installed on the target machine.'))
     .option('--json-attributes <json-attributes>', $('A JSON string to be added to the first run of chef-client. Ex: --json-attributes \'{"foo" : "bar"}\''))
-    .option('--daemon <daemon>', $('Configures the chef-client service for unattended execution. The node platform to be Windows. Options: \'none\' or \'service\'. \n \'none\' - Currently prevents the chef-client service from being configured as a service. \n \'service\' - Configures the chef-client to run automatically in the background as a service.'))
+    .option('--daemon <daemon>', $('Configures the chef-client service for unattended execution. The node platform to be Windows. Options: \'none\' or \'service\' or \'task\'. \n \'none\' - Currently prevents the chef-client service from being configured as a service. \n \'service\' - Configures the chef-client to run automatically in the background as a service. \n \'task\' - Configures the chef-client to run automatically in the background as a scheduled task.'))
     .option('--secret <secret-key>', $('The secret key to use to encrypt data bag item values.'))
     .option('--secret-file <secret-file>', $('A file containing the secret key to use to encrypt data bag item values.'))
     .execute(function(vmName, options, callback) {

--- a/lib/commands/asm/vm/vmclient.js
+++ b/lib/commands/asm/vm/vmclient.js
@@ -3164,7 +3164,7 @@ _.extend(VMClient.prototype, {
               config['bootstrap_version'] = options.bootstrapVersion;
               config['chef_service_interval'] = options.chefServiceInterval;
               if (options.referenceName == 'ChefClient' && options.daemon) {
-                if (['none', 'service'].indexOf(options.daemon) != -1) {
+                if (['none', 'service', 'task'].indexOf(options.daemon) != -1) {
                   config['daemon'] = options.daemon;
                 } else {
                   return callback(

--- a/lib/plugins.asm.json
+++ b/lib/plugins.asm.json
@@ -43755,7 +43755,7 @@
                   "optional": 0,
                   "bool": true,
                   "long": "--daemon",
-                  "description": "Configures the chef-client service for unattended execution. The node platform to be Windows. Options: 'none' or 'service'. \n 'none' - Currently prevents the chef-client service from being configured as a service. \n 'service' - Configures the chef-client to run automatically in the background as a service."
+                  "description": "Configures the chef-client service for unattended execution. The node platform to be Windows. Options: 'none' or 'service' or 'task'. \n 'none' - Currently prevents the chef-client service from being configured as a service. \n 'service' - Configures the chef-client to run automatically in the background as a service. \n 'task' - Configures the chef-client to run automatically in the background as a scheduled task."
                 },
                 {
                   "flags": "--secret <secret-key>",


### PR DESCRIPTION
Currently `azure-xplat-cli` accepts daemon as none and service. We need to add support to accept `task` as well.
