### PR TITLE
Update Storage Commands

### DIFF
--- a/lib/commands/storage/storage.blob._js
+++ b/lib/commands/storage/storage.blob._js
@@ -373,6 +373,7 @@ exports.init = function(cli) {
     .option('--dest-container <destContainer>', $('the destination storage container name'))
     .option('--dest-blob <destBlob>', $('the destination storage blob name'))
     .option('--dest-lease <destLeaseId>', $('the lease ID of the destination blob '))
+    .option('--incremental', $('whether start page blob incremental copy or not. If yes, the source must be a page blob snapshot. Refer to https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/incremental-copy-blob for more detailed information.'))
     .option('-q, --quiet', $('overwrite the destination blob without confirmation'))
     .addStorageAccountOption()
     .execute(startBlobCopy);

--- a/lib/plugins.asm.json
+++ b/lib/plugins.asm.json
@@ -18377,6 +18377,14 @@
                       "description": "the lease ID of the destination blob "
                     },
                     {
+                      "flags": "--incremental",
+                      "required": 0,
+                      "optional": 0,
+                      "bool": true,
+                      "long": "--incremental",
+                      "description": "whether start page blob incremental copy or not. If yes, the source must be a page blob snapshot. Refer to https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/incremental-copy-blob for more detailed information."
+                    },
+                    {
                       "flags": "-q, --quiet",
                       "required": 0,
                       "optional": 0,

--- a/lib/util/storage.util._js
+++ b/lib/util/storage.util._js
@@ -2032,6 +2032,7 @@ StorageUtil.getStartCopyParameters = function (copyType, sourceUri, options) {
     operationInfo.options = StorageUtil.getStorageOperationDefaultOption();
     operationInfo.options.sourceLeaseId = options.sourceLease;
     operationInfo.options.leaseId = options.destLease;
+    operationInfo.options.isIncrementalCopy = options.incremental;
     return operationInfo;
   };
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "azure-asm-storage": "0.12.0",
     "azure-asm-subscription": "0.10.1",
     "azure-asm-website": "0.10.4",
-    "azure-storage": "2.0.0",
+    "azure-storage": "2.1.0",
     "azure-arm-batch": "0.3.0",
     "azure-batch": "0.5.2",
     "azure-servicefabric": "0.1.5",


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* Upgraded azure-storage to 2.1.0
* Added `--incremental` parameter to `azure storage blob copy start` command to support page blob incremental copy