### PR TITLE
login:allow accesstokens.json to be configurable through env var

### DIFF
--- a/lib/util/authentication/adalAuth.js
+++ b/lib/util/authentication/adalAuth.js
@@ -23,7 +23,8 @@ var _ = require('underscore');
 var adal = require('adal-node');
 
 var utils = require('../utils');
-var defaultTokenCacheFile = path.join(utils.azureDir(), 'accessTokens.json');
+var defaultTokenCacheFile = process.env['AZURE_ACCESS_TOKEN_FILE'] ||
+                            path.join(utils.azureDir(), 'accessTokens.json');
 
 var useSecureTokenStorage = process.env['AZURE_USE_SECURE_TOKEN_STORAGE']; 
 var TokenStorage;


### PR DESCRIPTION
Doing for cloud console, that they like to redirect to /tmpfs (in memort) for better security 