### PR TITLE
update user agent logic for cli

### DIFF
--- a/cli.njsproj
+++ b/cli.njsproj
@@ -82,6 +82,7 @@
     <Compile Include="lib\commands\arm\datalakestore\datalakestore.utils.js" />
     <Compile Include="lib\util\authentication\adalAuthForUser.js" />
     <Compile Include="lib\util\authentication\adalAuthForServicePrincipal.js" />
+    <Compile Include="lib\util\cliUserAgentFilter.js" />
     <Compile Include="lib\util\interaction.js" />
     <Compile Include="lib\util\profile\account.js" />
     <Compile Include="lib\util\storage.util.js" />
@@ -257,6 +258,7 @@
     <Compile Include="test\commands\cli.storage.service-tests.js" />
     <Compile Include="test\commands\cli.storage.table-tests.js" />
     <Compile Include="test\commands\cli.telemetry-test.js" />
+    <Compile Include="test\commands\cli.useragent-test.js" />
     <Compile Include="test\commands\cli.vm.acl-tests.js" />
     <Compile Include="test\commands\cli.vm.capture-tests.js" />
     <Compile Include="test\commands\cli.vm.create_affin_vnet_vm-tests.js" />

--- a/lib/util/cliUserAgentFilter.js
+++ b/lib/util/cliUserAgentFilter.js
@@ -1,0 +1,34 @@
+﻿//
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+'use strict';
+
+var Constants = require('./constants');
+
+/**
+* Creates a filter to add the user agent header in a request.
+*
+* @param {string} userAgent The user agent string to use.
+*/
+exports.create = function (userAgent) {
+  return function handle(resource, next, callback) {
+    // regardless of whether the UA has been set by someone,
+    // just set it flatly to xplat-cli's UA. The app takes care of
+    // constructing the right string, see utils.js
+    resource.headers[Constants.USER_AGENT] = userAgent;
+    return next(resource, callback);
+  };
+};

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -94,6 +94,8 @@ var Constants = {
   */
   TELEMETRY_INSTRUMENTATION_KEY: '218959e7-a213-4923-a22b-d8b001062f28',
 
+  USER_AGENT: 'user-agent',
+
   XMS_COMMAND_NAME: 'x-ms-command-name',
   XMS_PARAMETER_SET_NAME: 'x-ms-parameter-set-name'
 };

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -30,6 +30,7 @@ var log = require('./logging');
 var utilsCore = require('./utilsCore');
 var userAgentCore = require('./userAgentCore');
 var commandMetadataFilter = require('./commandMetadataFilter');
+var cliUserAgentFilter = require('./cliUserAgentFilter');
 
 var locale = require('../locales/en-us.json');
 
@@ -38,7 +39,8 @@ var END_CERT = '-----END CERTIFICATE-----';
 
 exports.POLL_REQUEST_INTERVAL = 1000;
 
-var moduleVersion = require('../../package.json').version;
+var cliPackageJson = require('../../package.json');
+var moduleVersion = cliPackageJson.version;
 
 exports.moduleVersion = moduleVersion;
 
@@ -50,10 +52,12 @@ exports.pathExistsSync = utilsCore.pathExistsSync;
 
 var getUserAgent = exports.getUserAgent = function () {
   var userAgent = util.format('AzureXplatCLI/%s', moduleVersion);
+  // if this env var is set, then use that in User Agent header
   if (process.env.AZURE_HTTP_USER_AGENT) {
     userAgent += ';' + process.env.AZURE_HTTP_USER_AGENT;
   }
   else {
+    // else, construct our custom User Agent header.
     // add OS and command info into the user agent.
     // Note: Do this only if the above env variable is *not set*.
     var _userAgentInfo = userAgentCore.getUserAgentData();
@@ -62,6 +66,10 @@ var getUserAgent = exports.getUserAgent = function () {
         return key + ':' + _userAgentInfo[key];
       }).join(';');
     }
+
+    // add Azure SDK for Node signature as this app is written on top of it.
+    var nodeSDKSuffix = util.format(';Azure-SDK-For-Node;ms-rest/%s', cliPackageJson.dependencies['ms-rest']);
+    userAgent += nodeSDKSuffix;
   }
 
   return userAgent;
@@ -75,7 +83,7 @@ exports.createClient = function (factoryMethod, credentials, endpoint, options) 
   var client = factoryMethod(credentials,
     exports.stringTrimEnd(endpoint, '/'))
     .withFilter(exports.certAuthFilter(credentials))
-    .withFilter(azureCommon.UserAgentFilter.create(exports.getUserAgent()))
+    .withFilter(cliUserAgentFilter.create(exports.getUserAgent()))
     .withFilter(exports.createPostBodyFilter())
     .withFilter(polishErrorCausedByArmProviderNotRegistered())
     .withFilter(commandMetadataFilter.create(userAgentCore.getCommandData()));
@@ -123,7 +131,7 @@ exports.createAutoRestClient = function (FactoryMethod, subscription, options) {
   factoryMethodOptions.filters = [
     exports.certAuthFilter(credentials),
     log.createLogFilter(),
-    azureCommon.UserAgentFilter.create(exports.getUserAgent()),
+    cliUserAgentFilter.create(exports.getUserAgent()),
     exports.createPostBodyFilter(),
     exports.createFollowRedirectFilter(),
     polishErrorCausedByArmProviderNotRegistered(),
@@ -245,7 +253,7 @@ exports.createWebSiteExtensionsClient = function (siteName, hostNameSuffix, user
     password: password,
   }), baseUri)
     .withFilter(log.createLogFilter())
-    .withFilter(azureCommon.UserAgentFilter.create(getUserAgent()))
+    .withFilter(cliUserAgentFilter.create(getUserAgent()))
     .withFilter(createPostBodyFilter())
     .withFilter(createFollowRedirectFilter())
     .withFilter(commandMetadataFilter.create(userAgentCore.getCommandData()));
@@ -305,7 +313,7 @@ exports.createBatchClient = function (accountName, accountKey, taskUri) {
   var options = {};
   options.filters = [
       log.createLogFilter(),
-      azureCommon.UserAgentFilter.create(exports.getUserAgent()),
+      cliUserAgentFilter.create(exports.getUserAgent()),
       exports.createPostBodyFilter(),
       exports.createFollowRedirectFilter(),
       commandMetadataFilter.create(userAgentCore.getCommandData())
@@ -431,7 +439,7 @@ exports.createKeyVaultClient = function (subscription) {
   var options = {
     filters: [
       exports.certAuthFilter(credentials),
-      azureCommon.UserAgentFilter.create(exports.getUserAgent()),
+      cliUserAgentFilter.create(exports.getUserAgent()),
       exports.createPostBodyFilter(),
       polishErrorCausedByArmProviderNotRegistered(),
       commandMetadataFilter.create(userAgentCore.getCommandData())

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "Zavery, Amar <amzavery@microsoft.com>",
     "Wang, Yugang <yugangw@microsoft.com>",
     "Chen, Hao <hach@microsoft.com>",
-    "Krishan, Balaji <balajikris@microsoft.com>"
+    "Krishnan, Balaji <balajik@microsoft.com>"
   ],
   "version": "0.10.12",
   "description": "Microsoft Azure Cross Platform Command Line tool",
@@ -89,8 +89,8 @@
     "jwt-decode": "^2.1.0",
     "kuduscript": "1.0.13",
     "moment": "^2.8.0",
-    "ms-rest": "^1.12.0",
-    "ms-rest-azure": "^1.12.0",
+    "ms-rest": "^1.15.7",
+    "ms-rest-azure": "^1.15.7",
     "node-forge": "0.6.23",
     "omelette": "0.3.2",
     "openssl-wrapper": "0.2.1",

--- a/test/commands/cli.useragent-test.js
+++ b/test/commands/cli.useragent-test.js
@@ -1,0 +1,39 @@
+﻿//
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+var should = require('should');
+
+describe('cli', function () {
+  describe('user-agent', function () {
+    var util = require('../../lib/util/utils');
+
+    it('should construct unique user agent string', function (done) {
+      var userAgentInfo = util.getUserAgent();
+      userAgentInfo.should.be.type('string');
+      userAgentInfo.should.be.ok;
+
+      var uaParts = userAgentInfo.split(';');
+      uaParts.should.be.ok;
+      uaParts[0].should.startWith('AzureXplatCLI');
+
+      var length = uaParts.length;
+      uaParts[length - 2].should.eql('Azure-SDK-For-Node');
+      uaParts[length - 1].should.startWith('ms-rest');
+
+      done();
+    });
+  })
+});


### PR DESCRIPTION
1. use xplat cli's own unique user agent filter instead of mixing with
the rdfe runtime's filter. this was the rootcause of some bugs on how it
operates alongside of ms-rest runtime's own user agent filter as the cli
relies on ms-rest runtime to make requests. xplat cli's user agent
filter now correctly puts it UserAgent header in the request.

2. update ms-rest and ms-rest-azure runtime dependency