### PR TITLE
Improved Network DNS Zone Import's data validation

### DIFF
--- a/lib/commands/arm/network/dnsZone._js
+++ b/lib/commands/arm/network/dnsZone._js
@@ -237,8 +237,8 @@ __.extend(DnsZone.prototype, {
     for (var i = 0; i < zfile.sets.length; i++) {
       var recordSet = zfile.sets[i];
       importedSetsCount += self.importRecordSet(resourceGroupName, zoneName, recordSet, options, _);
-      self.output.info(util.format($('%d out of %d record sets proccessed, %d record sets imported successfully'),
-        i + 1, totalSetsCount, importedSetsCount));
+      self.output.info(util.format($('%d out of %d record sets processed, %d import(s) failed'),
+        i + 1, totalSetsCount, (i + 1 - importedSetsCount)));
     }
 
     if (options.debug) console.timeEnd('Time elapsed');
@@ -287,13 +287,13 @@ __.extend(DnsZone.prototype, {
     var self = this;
 
     // Converting record set FQDN name to relative name.\
-    var fqdn = utils.trimTrailingChar(recordSet.name, '.');
+    var fqdnName = utils.trimTrailingChar(recordSet.name, '.');
     recordSet.name = self.zoneFile.covertFromFQDN(recordSet.name, zoneName);
     zoneName = utils.trimTrailingChar(zoneName, '.');
 
     // Note: these rules only apply to the SOA/NS records at the zone apex (record set FQDN = zone name).
     if (recordSet.name === '@') {
-      fqdn = '@';
+      fqdnName = '@';
 
       switch (recordSet.type) {
 
@@ -323,7 +323,7 @@ __.extend(DnsZone.prototype, {
      Records in a record set may be out-of-sequence in the zone file, with records from different record sets in between.
      These must be combined into a single record set.  This record set may then need to be merged with a pre-existing record set in Azure DNS.
      */
-    var progress = self.interaction.progress(util.format($('Importing record set "%s" of type "%s"'), fqdn, recordSet.type));
+    var progress = self.interaction.progress(util.format($('Importing record set "%s" of type "%s"'), fqdnName, recordSet.type));
     var res = self.tryImportRecordSet(resourceGroupName, zoneName, recordSet.name, recordSet.type, parameters, _);
     if (res.statusCode === 412) {
       var existingSet = self.getRecordSet(resourceGroupName, zoneName, recordSet.name, recordSet, _);

--- a/lib/commands/arm/network/dnsZone._js
+++ b/lib/commands/arm/network/dnsZone._js
@@ -237,7 +237,8 @@ __.extend(DnsZone.prototype, {
     for (var i = 0; i < zfile.sets.length; i++) {
       var recordSet = zfile.sets[i];
       importedSetsCount += self.importRecordSet(resourceGroupName, zoneName, recordSet, options, _);
-      self.output.info(util.format($('%d record sets of %d imported'), importedSetsCount, totalSetsCount));
+      self.output.info(util.format($('%d out of %d record sets proccessed, %d record sets imported successfully'),
+        i + 1, totalSetsCount, importedSetsCount));
     }
 
     if (options.debug) console.timeEnd('Time elapsed');
@@ -285,12 +286,15 @@ __.extend(DnsZone.prototype, {
   importRecordSet: function (resourceGroupName, zoneName, recordSet, options, _) {
     var self = this;
 
-    // Converting record set FQDN name to relative name.
+    // Converting record set FQDN name to relative name.\
+    var fqdn = utils.trimTrailingChar(recordSet.name, '.');
     recordSet.name = self.zoneFile.covertFromFQDN(recordSet.name, zoneName);
     zoneName = utils.trimTrailingChar(zoneName, '.');
 
     // Note: these rules only apply to the SOA/NS records at the zone apex (record set FQDN = zone name).
     if (recordSet.name === '@') {
+      fqdn = '@';
+
       switch (recordSet.type) {
 
         // For the SOA, all fields are taken from the zone file, EXCEPT the 'host' parameter, which must be preserved (i.e. zone file host is ignored).
@@ -319,16 +323,16 @@ __.extend(DnsZone.prototype, {
      Records in a record set may be out-of-sequence in the zone file, with records from different record sets in between.
      These must be combined into a single record set.  This record set may then need to be merged with a pre-existing record set in Azure DNS.
      */
-    var progress = self.interaction.progress(util.format($('Importing record set "%s" of type "%s"'), recordSet.name, recordSet.type));
+    var progress = self.interaction.progress(util.format($('Importing record set "%s" of type "%s"'), fqdn, recordSet.type));
     var res = self.tryImportRecordSet(resourceGroupName, zoneName, recordSet.name, recordSet.type, parameters, _);
     if (res.statusCode === 412) {
       var existingSet = self.getRecordSet(resourceGroupName, zoneName, recordSet.name, recordSet, _);
       parameters = recordSetUtils.merge(parameters, existingSet, recordSet.type, options, self.output);
-      self.tryImportRecordSet(resourceGroupName, zoneName, recordSet.name, recordSet.type, parameters, _);
+      res = self.tryImportRecordSet(resourceGroupName, zoneName, recordSet.name, recordSet.type, parameters, _);
     }
     progress.end();
 
-    return 1;
+    return res.statusCode === 200 ? 1 : 0;
   },
 
   tryImportRecordSet: function (resourceGroupName, zoneName, setName, setType, parameters, _) {

--- a/lib/commands/arm/network/zoneFile._js
+++ b/lib/commands/arm/network/zoneFile._js
@@ -120,6 +120,7 @@ __.extend(ZoneFile.prototype, {
 
           continue;
         }
+
         switch (baseRR.type) {
           case 'SOA':
             recordSet = self.parseSOA(baseRR, res.$origin);
@@ -351,13 +352,20 @@ __.extend(ZoneFile.prototype, {
    * that is not fully-qualified (i.e. does not end in ‘.’).
    */
   convertToFQDN: function (value, $origin) {
-    if (value === '@') return $origin;
+    // Covers cases such as "@" and "subdomain.@"
+    if (value.indexOf('@') !== -1) {
+      return value.replace('@', $origin);
+    }
     if (utils.stringEndsWith(value, '.', true)) return value;
     if (!$origin) {
       this.output.warn('$ORIGIN directive is not defined');
       return value;
     } else {
-      return value + '.' + $origin;
+      var fdqn = value + '.';
+      if ($origin !== '.') {
+        fdqn += $origin;
+      }
+      return fdqn;
     }
   },
 

--- a/lib/commands/arm/network/zoneFile._js
+++ b/lib/commands/arm/network/zoneFile._js
@@ -263,7 +263,12 @@ __.extend(ZoneFile.prototype, {
 
     var validTypes = ['A', 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SPF', 'SRV', 'TXT'];
     var validClasses = ['IN', 'CS', 'CH', 'HS'];
-    var rrTokens = rr.trim().split(/\s+/g);
+    
+    /**
+     * One DNS zone file contained additional fields that looked like [AGE:xxxxxx].
+     * Those fields have no application in Azure so they are stripped.
+     */
+    var rrTokens = rr.replace(/\[[^\]]+\]/gi, '').trim().split(/\s+/g);
     var regexp = /^\s/;
     if(rr[0].match(regexp)) {
       rrTokens = [prevRrName].concat(rrTokens);
@@ -317,9 +322,21 @@ __.extend(ZoneFile.prototype, {
       The record name is optional. Where it is omitted, the record has the same record name
       as the previous record in the zone file. That record may have the same type or a different type.
       If record name is not specified, and no previous records have specified it, assume record name is '@'.
+
+      Also, each label must only contain letters, numbers, underscores, and/or dashes. Each label should be
+      separated from other labels by a period. A wildcard is permitted either as the single character in
+      the name, or as the first label in the name.
      */
+
     if (!res.name) {
       res.name = (prevRrName === undefined) ? '@' : prevRrName;
+    } else {
+      var explicitCharacters = res.name.match(/[^a-z0-9\_\-\*\.\@]/gi);
+      var wildcardIndex = res.name.indexOf('*');
+      if (explicitCharacters || wildcardIndex > 0) {
+        res.error = util.format('Record set name "%s" is invalid, skipped', res.name);
+        return res;
+      }
     }
 
     /*

--- a/test/data/zone_file_export.txt
+++ b/test/data/zone_file_export.txt
@@ -1,12 +1,12 @@
 ; Exported zone file from Azure DNS
 ; Resource Group Name: xplat-test-dns-zone
 ; Zone name: exampledns.com
-; Date and time (UTC): Thu Feb 23 2017 19:09:26 GMT+0000
+; Date and time (UTC): Wed Apr 19 2017 13:58:35 GMT+0000
 
 $TTL 172800
 $ORIGIN exampledns.com.
 
-@ 3600 IN SOA ns1-08.azure-dns.com. hostmaster.exampledns.com. (
+@ 3600 IN SOA ns1-05.azure-dns.com. hostmaster.exampledns.com. (
 				2003080800
 				43200
 				900
@@ -14,10 +14,10 @@ $ORIGIN exampledns.com.
 				10800
 				)
 
-@ 172800 IN NS ns1-08.azure-dns.com.
-  172800 IN NS ns2-08.azure-dns.net.
-  172800 IN NS ns3-08.azure-dns.org.
-  172800 IN NS ns4-08.azure-dns.info.
+@ 172800 IN NS ns1-05.azure-dns.com.
+  172800 IN NS ns2-05.azure-dns.net.
+  172800 IN NS ns3-05.azure-dns.org.
+  172800 IN NS ns4-05.azure-dns.info.
 
 default 3600 IN A 0.1.2.3
 

--- a/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_create_should_create_dns_zone.nock.js
+++ b/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_create_should_create_dns_zone.nock.js
@@ -6,15 +6,15 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: 'e55e7c87-7bdc-445b-8213-56cdfca27374',
+    name: 'Free Trial',
     user: {
       name: 'user@domain.example',
       type: 'user'
     },
-    tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+    tenantId: 'fc53715f-c87b-43fc-9876-78ef5139cf26',
     state: 'Enabled',
-    registeredProviders: ['mobileservice', 'website'],
+    registeredProviders: [],
     _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));
@@ -29,36 +29,36 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourcegroups/xplat-test-dns-zone?api-version=2016-09-01')
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourcegroups/xplat-test-dns-zone?api-version=2016-09-01')
   .reply(404, "{\"error\":{\"code\":\"ResourceGroupNotFound\",\"message\":\"Resource group 'xplat-test-dns-zone' could not be found.\"}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   'x-ms-failure-cause': 'gateway',
-  'x-ms-ratelimit-remaining-subscription-reads': '14967',
-  'x-ms-request-id': '14adb8d2-5980-4cee-82b5-3cbc1a2ea7cd',
-  'x-ms-correlation-request-id': '14adb8d2-5980-4cee-82b5-3cbc1a2ea7cd',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111618Z:14adb8d2-5980-4cee-82b5-3cbc1a2ea7cd',
+  'x-ms-ratelimit-remaining-subscription-reads': '14995',
+  'x-ms-request-id': '63514bf1-cf67-4b2c-b787-f8a38dc037bd',
+  'x-ms-correlation-request-id': '63514bf1-cf67-4b2c-b787-f8a38dc037bd',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135727Z:63514bf1-cf67-4b2c-b787-f8a38dc037bd',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Fri, 27 Jan 2017 11:16:18 GMT',
+  date: 'Wed, 19 Apr 2017 13:57:27 GMT',
   connection: 'close',
   'content-length': '111' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourcegroups/xplat-test-dns-zone?api-version=2016-09-01')
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourcegroups/xplat-test-dns-zone?api-version=2016-09-01')
   .reply(404, "{\"error\":{\"code\":\"ResourceGroupNotFound\",\"message\":\"Resource group 'xplat-test-dns-zone' could not be found.\"}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   'x-ms-failure-cause': 'gateway',
-  'x-ms-ratelimit-remaining-subscription-reads': '14967',
-  'x-ms-request-id': '14adb8d2-5980-4cee-82b5-3cbc1a2ea7cd',
-  'x-ms-correlation-request-id': '14adb8d2-5980-4cee-82b5-3cbc1a2ea7cd',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111618Z:14adb8d2-5980-4cee-82b5-3cbc1a2ea7cd',
+  'x-ms-ratelimit-remaining-subscription-reads': '14995',
+  'x-ms-request-id': '63514bf1-cf67-4b2c-b787-f8a38dc037bd',
+  'x-ms-correlation-request-id': '63514bf1-cf67-4b2c-b787-f8a38dc037bd',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135727Z:63514bf1-cf67-4b2c-b787-f8a38dc037bd',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Fri, 27 Jan 2017 11:16:18 GMT',
+  date: 'Wed, 19 Apr 2017 13:57:27 GMT',
   connection: 'close',
   'content-length': '111' });
  return result; },
@@ -66,77 +66,77 @@ function (nock) {
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourcegroups/xplat-test-dns-zone?api-version=2016-09-01', '*')
-  .reply(201, "{\"id\":\"/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone\",\"name\":\"xplat-test-dns-zone\",\"location\":\"southeastasia\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}}", { 'cache-control': 'no-cache',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourcegroups/xplat-test-dns-zone?api-version=2016-09-01', '*')
+  .reply(201, "{\"id\":\"/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone\",\"name\":\"xplat-test-dns-zone\",\"location\":\"southeastasia\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '208',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
-  'x-ms-ratelimit-remaining-subscription-writes': '1193',
-  'x-ms-request-id': '52e5fb0f-d255-4069-b55d-1a56e6fe3f6b',
-  'x-ms-correlation-request-id': '52e5fb0f-d255-4069-b55d-1a56e6fe3f6b',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111622Z:52e5fb0f-d255-4069-b55d-1a56e6fe3f6b',
+  'x-ms-ratelimit-remaining-subscription-writes': '1198',
+  'x-ms-request-id': '2f11976b-085a-4b5c-b6b5-a200d3a37e32',
+  'x-ms-correlation-request-id': '2f11976b-085a-4b5c-b6b5-a200d3a37e32',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135730Z:2f11976b-085a-4b5c-b6b5-a200d3a37e32',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Fri, 27 Jan 2017 11:16:22 GMT',
+  date: 'Wed, 19 Apr 2017 13:57:29 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourcegroups/xplat-test-dns-zone?api-version=2016-09-01', '*')
-  .reply(201, "{\"id\":\"/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone\",\"name\":\"xplat-test-dns-zone\",\"location\":\"southeastasia\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}}", { 'cache-control': 'no-cache',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourcegroups/xplat-test-dns-zone?api-version=2016-09-01', '*')
+  .reply(201, "{\"id\":\"/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone\",\"name\":\"xplat-test-dns-zone\",\"location\":\"southeastasia\",\"tags\":{},\"properties\":{\"provisioningState\":\"Succeeded\"}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-length': '208',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
-  'x-ms-ratelimit-remaining-subscription-writes': '1193',
-  'x-ms-request-id': '52e5fb0f-d255-4069-b55d-1a56e6fe3f6b',
-  'x-ms-correlation-request-id': '52e5fb0f-d255-4069-b55d-1a56e6fe3f6b',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111622Z:52e5fb0f-d255-4069-b55d-1a56e6fe3f6b',
+  'x-ms-ratelimit-remaining-subscription-writes': '1198',
+  'x-ms-request-id': '2f11976b-085a-4b5c-b6b5-a200d3a37e32',
+  'x-ms-correlation-request-id': '2f11976b-085a-4b5c-b6b5-a200d3a37e32',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135730Z:2f11976b-085a-4b5c-b6b5-a200d3a37e32',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Fri, 27 Jan 2017 11:16:22 GMT',
+  date: 'Wed, 19 Apr 2017 13:57:29 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
-  .reply(201, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
+  .reply(201, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '497',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000002-0000-0000-949b-4acc8e78d201',
+  etag: '00000002-0000-0000-519c-55e514b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '185ce1ae-df5f-4384-b8db-4fce0789f26b',
+  'x-ms-request-id': 'db07412c-c8b8-45ac-95fa-76e011ece9e8',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': 'f7f2d871-12e8-49f8-a31a-536a40da180a',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111628Z:f7f2d871-12e8-49f8-a31a-536a40da180a',
-  date: 'Fri, 27 Jan 2017 11:16:27 GMT',
+  'x-ms-correlation-request-id': 'a21fb804-e0c5-429b-adff-e55d39547097',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135737Z:a21fb804-e0c5-429b-adff-e55d39547097',
+  date: 'Wed, 19 Apr 2017 13:57:36 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
-  .reply(201, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
+  .reply(201, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '497',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000002-0000-0000-949b-4acc8e78d201',
+  etag: '00000002-0000-0000-519c-55e514b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '185ce1ae-df5f-4384-b8db-4fce0789f26b',
+  'x-ms-request-id': 'db07412c-c8b8-45ac-95fa-76e011ece9e8',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': 'f7f2d871-12e8-49f8-a31a-536a40da180a',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111628Z:f7f2d871-12e8-49f8-a31a-536a40da180a',
-  date: 'Fri, 27 Jan 2017 11:16:27 GMT',
+  'x-ms-correlation-request-id': 'a21fb804-e0c5-429b-adff-e55d39547097',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135737Z:a21fb804-e0c5-429b-adff-e55d39547097',
+  date: 'Wed, 19 Apr 2017 13:57:36 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_delete_should_delete_dns_zone.nock.js
+++ b/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_delete_should_delete_dns_zone.nock.js
@@ -6,15 +6,15 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: 'e55e7c87-7bdc-445b-8213-56cdfca27374',
+    name: 'Free Trial',
     user: {
       name: 'user@domain.example',
       type: 'user'
     },
-    tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+    tenantId: 'fc53715f-c87b-43fc-9876-78ef5139cf26',
     state: 'Enabled',
-    registeredProviders: ['mobileservice', 'website'],
+    registeredProviders: [],
     _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));
@@ -29,112 +29,112 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .delete('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .delete('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
   .reply(202, "", { 'cache-control': 'private',
   'content-length': '0',
-  location: 'https://management.azure.com/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationResults/delzone63621112601258209109dbc736?api-version=2016-04-01',
+  location: 'https://management.azure.com/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationResults/delzone6362820706850947426ab4c51d?api-version=2016-04-01',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'azure-asyncoperation': 'https://management.azure.com:443/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationStatuses/delzone63621112601258209109dbc736?api-version=2016-04-01',
-  'x-ms-request-id': 'f493724c-b13f-4534-a2df-b8260e928c13',
+  'azure-asyncoperation': 'https://management.azure.com:443/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationStatuses/delzone6362820706850947426ab4c51d?api-version=2016-04-01',
+  'x-ms-request-id': '90746757-2916-47e4-8e8f-16a314983ed1',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '2d157818-0ab8-4750-9c88-8435285187ec',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111641Z:2d157818-0ab8-4750-9c88-8435285187ec',
-  date: 'Fri, 27 Jan 2017 11:16:40 GMT',
+  'x-ms-correlation-request-id': '518c76e1-ff67-4137-a327-ffaba896c363',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135749Z:518c76e1-ff67-4137-a327-ffaba896c363',
+  date: 'Wed, 19 Apr 2017 13:57:48 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .delete('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .delete('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
   .reply(202, "", { 'cache-control': 'private',
   'content-length': '0',
-  location: 'https://management.azure.com/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationResults/delzone63621112601258209109dbc736?api-version=2016-04-01',
+  location: 'https://management.azure.com/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationResults/delzone6362820706850947426ab4c51d?api-version=2016-04-01',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'azure-asyncoperation': 'https://management.azure.com:443/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationStatuses/delzone63621112601258209109dbc736?api-version=2016-04-01',
-  'x-ms-request-id': 'f493724c-b13f-4534-a2df-b8260e928c13',
+  'azure-asyncoperation': 'https://management.azure.com:443/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationStatuses/delzone6362820706850947426ab4c51d?api-version=2016-04-01',
+  'x-ms-request-id': '90746757-2916-47e4-8e8f-16a314983ed1',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '2d157818-0ab8-4750-9c88-8435285187ec',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111641Z:2d157818-0ab8-4750-9c88-8435285187ec',
-  date: 'Fri, 27 Jan 2017 11:16:40 GMT',
+  'x-ms-correlation-request-id': '518c76e1-ff67-4137-a327-ffaba896c363',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135749Z:518c76e1-ff67-4137-a327-ffaba896c363',
+  date: 'Wed, 19 Apr 2017 13:57:48 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationStatuses/delzone63621112601258209109dbc736?api-version=2016-04-01')
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationStatuses/delzone6362820706850947426ab4c51d?api-version=2016-04-01')
   .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'private',
   'content-length': '22',
   'content-type': 'application/json; charset=utf-8',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '6d02a4b9-5b1a-4ef9-871e-b0613cc8fe47',
+  'x-ms-request-id': '0b547c7f-4c00-439c-bce1-6d6fdaa1e6c3',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '1cc597ff-6a7b-42fa-bed0-af972fc4816f',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111712Z:1cc597ff-6a7b-42fa-bed0-af972fc4816f',
-  date: 'Fri, 27 Jan 2017 11:17:11 GMT',
+  'x-ms-correlation-request-id': 'dee23fb6-8f36-4d05-b0d5-4d557e84f659',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135819Z:dee23fb6-8f36-4d05-b0d5-4d557e84f659',
+  date: 'Wed, 19 Apr 2017 13:58:18 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationStatuses/delzone63621112601258209109dbc736?api-version=2016-04-01')
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnsOperationStatuses/delzone6362820706850947426ab4c51d?api-version=2016-04-01')
   .reply(200, "{\"status\":\"Succeeded\"}", { 'cache-control': 'private',
   'content-length': '22',
   'content-type': 'application/json; charset=utf-8',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '6d02a4b9-5b1a-4ef9-871e-b0613cc8fe47',
+  'x-ms-request-id': '0b547c7f-4c00-439c-bce1-6d6fdaa1e6c3',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '1cc597ff-6a7b-42fa-bed0-af972fc4816f',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111712Z:1cc597ff-6a7b-42fa-bed0-af972fc4816f',
-  date: 'Fri, 27 Jan 2017 11:17:11 GMT',
+  'x-ms-correlation-request-id': 'dee23fb6-8f36-4d05-b0d5-4d557e84f659',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135819Z:dee23fb6-8f36-4d05-b0d5-4d557e84f659',
+  date: 'Wed, 19 Apr 2017 13:58:18 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
   .reply(404, "{\"error\":{\"code\":\"ResourceNotFound\",\"message\":\"The Resource 'Microsoft.Network/dnszones/exampledns.com' under resource group 'xplat-test-dns-zone' was not found.\"}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   'x-ms-failure-cause': 'gateway',
-  'x-ms-request-id': '223d78fc-f6fc-4f84-9753-8a050e805fbf',
-  'x-ms-correlation-request-id': '223d78fc-f6fc-4f84-9753-8a050e805fbf',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111714Z:223d78fc-f6fc-4f84-9753-8a050e805fbf',
+  'x-ms-request-id': '128fb757-1373-4e10-b8cd-9da1d8c84f26',
+  'x-ms-correlation-request-id': '128fb757-1373-4e10-b8cd-9da1d8c84f26',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135821Z:128fb757-1373-4e10-b8cd-9da1d8c84f26',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Fri, 27 Jan 2017 11:17:13 GMT',
+  date: 'Wed, 19 Apr 2017 13:58:21 GMT',
   connection: 'close',
   'content-length': '164' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
   .reply(404, "{\"error\":{\"code\":\"ResourceNotFound\",\"message\":\"The Resource 'Microsoft.Network/dnszones/exampledns.com' under resource group 'xplat-test-dns-zone' was not found.\"}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   'x-ms-failure-cause': 'gateway',
-  'x-ms-request-id': '223d78fc-f6fc-4f84-9753-8a050e805fbf',
-  'x-ms-correlation-request-id': '223d78fc-f6fc-4f84-9753-8a050e805fbf',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111714Z:223d78fc-f6fc-4f84-9753-8a050e805fbf',
+  'x-ms-request-id': '128fb757-1373-4e10-b8cd-9da1d8c84f26',
+  'x-ms-correlation-request-id': '128fb757-1373-4e10-b8cd-9da1d8c84f26',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135821Z:128fb757-1373-4e10-b8cd-9da1d8c84f26',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Fri, 27 Jan 2017 11:17:13 GMT',
+  date: 'Wed, 19 Apr 2017 13:58:21 GMT',
   connection: 'close',
   'content-length': '164' });
  return result; }]];

--- a/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_export_should_export_dns_zone_to_zone_file.nock.js
+++ b/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_export_should_export_dns_zone_to_zone_file.nock.js
@@ -6,15 +6,15 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: 'e55e7c87-7bdc-445b-8213-56cdfca27374',
+    name: 'Free Trial',
     user: {
       name: 'user@domain.example',
       type: 'user'
     },
-    tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+    tenantId: 'fc53715f-c87b-43fc-9876-78ef5139cf26',
     state: 'Enabled',
-    registeredProviders: ['mobileservice', 'website'],
+    registeredProviders: [],
     _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));
@@ -29,78 +29,78 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-4cdf-61ec8e78d201\",\"location\":\"global\",\"tags\":{},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":4}}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-54c4-8b0415b9d201\",\"location\":\"global\",\"tags\":{},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":4}}", { 'cache-control': 'private',
   'content-length': '472',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000002-0000-0000-4cdf-61ec8e78d201',
+  etag: '00000002-0000-0000-54c4-8b0415b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '227aec71-c95d-416e-9688-049bfca0e434',
+  'x-ms-request-id': '72e65148-cdb2-48f3-bac2-2e655ce15cee',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '1b335a6a-a190-4ed5-9a2a-5d8953b1a2f7',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111727Z:1b335a6a-a190-4ed5-9a2a-5d8953b1a2f7',
-  date: 'Fri, 27 Jan 2017 11:17:26 GMT',
+  'x-ms-correlation-request-id': '78a46c61-d3a3-434f-9851-083c0244aca5',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135834Z:78a46c61-d3a3-434f-9851-083c0244aca5',
+  date: 'Wed, 19 Apr 2017 13:58:34 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-4cdf-61ec8e78d201\",\"location\":\"global\",\"tags\":{},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":4}}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-54c4-8b0415b9d201\",\"location\":\"global\",\"tags\":{},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":4}}", { 'cache-control': 'private',
   'content-length': '472',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000002-0000-0000-4cdf-61ec8e78d201',
+  etag: '00000002-0000-0000-54c4-8b0415b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '227aec71-c95d-416e-9688-049bfca0e434',
+  'x-ms-request-id': '72e65148-cdb2-48f3-bac2-2e655ce15cee',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '1b335a6a-a190-4ed5-9a2a-5d8953b1a2f7',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111727Z:1b335a6a-a190-4ed5-9a2a-5d8953b1a2f7',
-  date: 'Fri, 27 Jan 2017 11:17:26 GMT',
+  'x-ms-correlation-request-id': '78a46c61-d3a3-434f-9851-083c0244aca5',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135834Z:78a46c61-d3a3-434f-9851-083c0244aca5',
+  date: 'Wed, 19 Apr 2017 13:58:34 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/recordsets?api-version=2016-04-01')
-  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/NS\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/NS\",\"etag\":\"7e2aabe2-f4f8-4f82-a55f-22d67a3f7ed8\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":172800,\"NSRecords\":[{\"nsdname\":\"ns1-08.azure-dns.com.\"},{\"nsdname\":\"ns2-08.azure-dns.net.\"},{\"nsdname\":\"ns3-08.azure-dns.org.\"},{\"nsdname\":\"ns4-08.azure-dns.info.\"}]}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"2914c751-93df-4438-827c-77d8ccb18000\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-08.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"84cc1561-3a3f-447f-af8b-b67161fc5157\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"1acded95-6ae1-489b-a785-63bf509e1182\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}]}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/recordsets?api-version=2016-04-01')
+  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/NS\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/NS\",\"etag\":\"faae4fca-83d1-45ad-ab2a-aea611dd4dde\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":172800,\"NSRecords\":[{\"nsdname\":\"ns1-05.azure-dns.com.\"},{\"nsdname\":\"ns2-05.azure-dns.net.\"},{\"nsdname\":\"ns3-05.azure-dns.org.\"},{\"nsdname\":\"ns4-05.azure-dns.info.\"}]}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"c31e3114-887f-4e83-b224-3a9cf889c952\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-05.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"1017d4dd-9ab6-44dd-b325-134e8e98f84f\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"fb4978c9-4197-454b-b7c2-9e1197b22357\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}]}", { 'cache-control': 'private',
   'content-length': '1721',
   'content-type': 'application/json; charset=utf-8',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'bd0013bf-3582-4cb1-977f-1f964290db8e',
+  'x-ms-request-id': '35572c0c-ee58-4aa9-8fad-3f54eddd1aba',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-reads': '14960',
-  'x-ms-correlation-request-id': '5e770396-196f-4aff-a4f7-f8afeda357f9',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111728Z:5e770396-196f-4aff-a4f7-f8afeda357f9',
-  date: 'Fri, 27 Jan 2017 11:17:27 GMT',
+  'x-ms-ratelimit-remaining-subscription-reads': '14995',
+  'x-ms-correlation-request-id': 'add1779c-4ead-442c-a028-c520496037a2',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135835Z:add1779c-4ead-442c-a028-c520496037a2',
+  date: 'Wed, 19 Apr 2017 13:58:34 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/recordsets?api-version=2016-04-01')
-  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/NS\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/NS\",\"etag\":\"7e2aabe2-f4f8-4f82-a55f-22d67a3f7ed8\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":172800,\"NSRecords\":[{\"nsdname\":\"ns1-08.azure-dns.com.\"},{\"nsdname\":\"ns2-08.azure-dns.net.\"},{\"nsdname\":\"ns3-08.azure-dns.org.\"},{\"nsdname\":\"ns4-08.azure-dns.info.\"}]}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"2914c751-93df-4438-827c-77d8ccb18000\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-08.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"84cc1561-3a3f-447f-af8b-b67161fc5157\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"1acded95-6ae1-489b-a785-63bf509e1182\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}]}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/recordsets?api-version=2016-04-01')
+  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/NS\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/NS\",\"etag\":\"faae4fca-83d1-45ad-ab2a-aea611dd4dde\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":172800,\"NSRecords\":[{\"nsdname\":\"ns1-05.azure-dns.com.\"},{\"nsdname\":\"ns2-05.azure-dns.net.\"},{\"nsdname\":\"ns3-05.azure-dns.org.\"},{\"nsdname\":\"ns4-05.azure-dns.info.\"}]}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"c31e3114-887f-4e83-b224-3a9cf889c952\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-05.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"1017d4dd-9ab6-44dd-b325-134e8e98f84f\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"fb4978c9-4197-454b-b7c2-9e1197b22357\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}]}", { 'cache-control': 'private',
   'content-length': '1721',
   'content-type': 'application/json; charset=utf-8',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'bd0013bf-3582-4cb1-977f-1f964290db8e',
+  'x-ms-request-id': '35572c0c-ee58-4aa9-8fad-3f54eddd1aba',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-reads': '14960',
-  'x-ms-correlation-request-id': '5e770396-196f-4aff-a4f7-f8afeda357f9',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111728Z:5e770396-196f-4aff-a4f7-f8afeda357f9',
-  date: 'Fri, 27 Jan 2017 11:17:27 GMT',
+  'x-ms-ratelimit-remaining-subscription-reads': '14995',
+  'x-ms-correlation-request-id': 'add1779c-4ead-442c-a028-c520496037a2',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135835Z:add1779c-4ead-442c-a028-c520496037a2',
+  date: 'Wed, 19 Apr 2017 13:58:34 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_import_should_import_dns_zone_from_zone_file.nock.js
+++ b/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_import_should_import_dns_zone_from_zone_file.nock.js
@@ -6,15 +6,15 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: 'e55e7c87-7bdc-445b-8213-56cdfca27374',
+    name: 'Free Trial',
     user: {
       name: 'user@domain.example',
       type: 'user'
     },
-    tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+    tenantId: 'fc53715f-c87b-43fc-9876-78ef5139cf26',
     state: 'Enabled',
-    registeredProviders: ['mobileservice', 'website'],
+    registeredProviders: [],
     _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));
@@ -29,34 +29,34 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
   .reply(404, "{\"error\":{\"code\":\"ResourceNotFound\",\"message\":\"The Resource 'Microsoft.Network/dnszones/exampledns.com' under resource group 'xplat-test-dns-zone' was not found.\"}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   'x-ms-failure-cause': 'gateway',
-  'x-ms-request-id': 'e9032873-3b91-45d1-9b1b-38194197e944',
-  'x-ms-correlation-request-id': 'e9032873-3b91-45d1-9b1b-38194197e944',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111716Z:e9032873-3b91-45d1-9b1b-38194197e944',
+  'x-ms-request-id': '759354a9-9f99-4f44-a1b2-65d5d28be90e',
+  'x-ms-correlation-request-id': '759354a9-9f99-4f44-a1b2-65d5d28be90e',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135824Z:759354a9-9f99-4f44-a1b2-65d5d28be90e',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Fri, 27 Jan 2017 11:17:16 GMT',
+  date: 'Wed, 19 Apr 2017 13:58:23 GMT',
   connection: 'close',
   'content-length': '164' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
   .reply(404, "{\"error\":{\"code\":\"ResourceNotFound\",\"message\":\"The Resource 'Microsoft.Network/dnszones/exampledns.com' under resource group 'xplat-test-dns-zone' was not found.\"}}", { 'cache-control': 'no-cache',
   pragma: 'no-cache',
   'content-type': 'application/json; charset=utf-8',
   expires: '-1',
   'x-ms-failure-cause': 'gateway',
-  'x-ms-request-id': 'e9032873-3b91-45d1-9b1b-38194197e944',
-  'x-ms-correlation-request-id': 'e9032873-3b91-45d1-9b1b-38194197e944',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111716Z:e9032873-3b91-45d1-9b1b-38194197e944',
+  'x-ms-request-id': '759354a9-9f99-4f44-a1b2-65d5d28be90e',
+  'x-ms-correlation-request-id': '759354a9-9f99-4f44-a1b2-65d5d28be90e',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135824Z:759354a9-9f99-4f44-a1b2-65d5d28be90e',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  date: 'Fri, 27 Jan 2017 11:17:16 GMT',
+  date: 'Wed, 19 Apr 2017 13:58:23 GMT',
   connection: 'close',
   'content-length': '164' });
  return result; },
@@ -64,205 +64,205 @@ function (nock) {
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
-  .reply(201, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-4cdf-61ec8e78d201\",\"location\":\"global\",\"tags\":{},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
+  .reply(201, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-54c4-8b0415b9d201\",\"location\":\"global\",\"tags\":{},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '472',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000002-0000-0000-4cdf-61ec8e78d201',
+  etag: '00000002-0000-0000-54c4-8b0415b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'bd9de224-0308-4e90-9d46-2af2418f3769',
+  'x-ms-request-id': 'ff2c9f5d-e735-45aa-939d-18245b94ca24',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '41cf1fd4-70c6-46b1-97c9-0518e818c678',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111721Z:41cf1fd4-70c6-46b1-97c9-0518e818c678',
-  date: 'Fri, 27 Jan 2017 11:17:20 GMT',
+  'x-ms-correlation-request-id': 'd7ac7203-4fb0-4678-b5d0-19da5140c5de',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135828Z:d7ac7203-4fb0-4678-b5d0-19da5140c5de',
+  date: 'Wed, 19 Apr 2017 13:58:28 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
-  .reply(201, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-4cdf-61ec8e78d201\",\"location\":\"global\",\"tags\":{},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
+  .reply(201, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-54c4-8b0415b9d201\",\"location\":\"global\",\"tags\":{},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '472',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000002-0000-0000-4cdf-61ec8e78d201',
+  etag: '00000002-0000-0000-54c4-8b0415b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'bd9de224-0308-4e90-9d46-2af2418f3769',
+  'x-ms-request-id': 'ff2c9f5d-e735-45aa-939d-18245b94ca24',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '41cf1fd4-70c6-46b1-97c9-0518e818c678',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111721Z:41cf1fd4-70c6-46b1-97c9-0518e818c678',
-  date: 'Fri, 27 Jan 2017 11:17:20 GMT',
+  'x-ms-correlation-request-id': 'd7ac7203-4fb0-4678-b5d0-19da5140c5de',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135828Z:d7ac7203-4fb0-4678-b5d0-19da5140c5de',
+  date: 'Wed, 19 Apr 2017 13:58:28 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.patch('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/SOA/@?api-version=2016-04-01', '*')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"2914c751-93df-4438-827c-77d8ccb18000\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-08.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}}", { 'cache-control': 'private',
+.patch('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/SOA/@?api-version=2016-04-01', '*')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"c31e3114-887f-4e83-b224-3a9cf889c952\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-05.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}}", { 'cache-control': 'private',
   'content-length': '497',
   'content-type': 'application/json; charset=utf-8',
-  etag: '2914c751-93df-4438-827c-77d8ccb18000',
+  etag: 'c31e3114-887f-4e83-b224-3a9cf889c952',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '85c77e72-174f-4bba-bd27-df3a23c903c7',
+  'x-ms-request-id': '1871b917-2353-46e2-b70a-12a79abb7269',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-writes': '1195',
-  'x-ms-correlation-request-id': 'b1805482-540b-4e97-aae3-af85d5180ac5',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111722Z:b1805482-540b-4e97-aae3-af85d5180ac5',
-  date: 'Fri, 27 Jan 2017 11:17:22 GMT',
+  'x-ms-ratelimit-remaining-subscription-writes': '1199',
+  'x-ms-correlation-request-id': 'e0eca4a4-5b8b-4771-8bfb-0d8f403eca16',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135829Z:e0eca4a4-5b8b-4771-8bfb-0d8f403eca16',
+  date: 'Wed, 19 Apr 2017 13:58:29 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.patch('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/SOA/@?api-version=2016-04-01', '*')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"2914c751-93df-4438-827c-77d8ccb18000\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-08.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}}", { 'cache-control': 'private',
+.patch('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/SOA/@?api-version=2016-04-01', '*')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"c31e3114-887f-4e83-b224-3a9cf889c952\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-05.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}}", { 'cache-control': 'private',
   'content-length': '497',
   'content-type': 'application/json; charset=utf-8',
-  etag: '2914c751-93df-4438-827c-77d8ccb18000',
+  etag: 'c31e3114-887f-4e83-b224-3a9cf889c952',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '85c77e72-174f-4bba-bd27-df3a23c903c7',
+  'x-ms-request-id': '1871b917-2353-46e2-b70a-12a79abb7269',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-writes': '1195',
-  'x-ms-correlation-request-id': 'b1805482-540b-4e97-aae3-af85d5180ac5',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111722Z:b1805482-540b-4e97-aae3-af85d5180ac5',
-  date: 'Fri, 27 Jan 2017 11:17:22 GMT',
+  'x-ms-ratelimit-remaining-subscription-writes': '1199',
+  'x-ms-correlation-request-id': 'e0eca4a4-5b8b-4771-8bfb-0d8f403eca16',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135829Z:e0eca4a4-5b8b-4771-8bfb-0d8f403eca16',
+  date: 'Wed, 19 Apr 2017 13:58:29 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/A/default?api-version=2016-04-01', '*')
-  .reply(201, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"84cc1561-3a3f-447f-af8b-b67161fc5157\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/A/default?api-version=2016-04-01', '*')
+  .reply(201, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"1017d4dd-9ab6-44dd-b325-134e8e98f84f\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}}", { 'cache-control': 'private',
   'content-length': '368',
   'content-type': 'application/json; charset=utf-8',
-  etag: '84cc1561-3a3f-447f-af8b-b67161fc5157',
+  etag: '1017d4dd-9ab6-44dd-b325-134e8e98f84f',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'ab8ca4a0-a0ee-4abb-a516-f75dacff560c',
+  'x-ms-request-id': 'cb0d8817-dbfd-461a-97ea-0c0dcba282bc',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': 'dfaeaba1-4f36-4e64-b85c-956601f85efa',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111723Z:dfaeaba1-4f36-4e64-b85c-956601f85efa',
-  date: 'Fri, 27 Jan 2017 11:17:23 GMT',
+  'x-ms-ratelimit-remaining-subscription-resource-requests': '11991',
+  'x-ms-correlation-request-id': 'a415d0c5-6deb-4d56-937f-4b836728f551',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135830Z:a415d0c5-6deb-4d56-937f-4b836728f551',
+  date: 'Wed, 19 Apr 2017 13:58:29 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/A/default?api-version=2016-04-01', '*')
-  .reply(201, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"84cc1561-3a3f-447f-af8b-b67161fc5157\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/A/default?api-version=2016-04-01', '*')
+  .reply(201, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"1017d4dd-9ab6-44dd-b325-134e8e98f84f\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}}", { 'cache-control': 'private',
   'content-length': '368',
   'content-type': 'application/json; charset=utf-8',
-  etag: '84cc1561-3a3f-447f-af8b-b67161fc5157',
+  etag: '1017d4dd-9ab6-44dd-b325-134e8e98f84f',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'ab8ca4a0-a0ee-4abb-a516-f75dacff560c',
+  'x-ms-request-id': 'cb0d8817-dbfd-461a-97ea-0c0dcba282bc',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': 'dfaeaba1-4f36-4e64-b85c-956601f85efa',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111723Z:dfaeaba1-4f36-4e64-b85c-956601f85efa',
-  date: 'Fri, 27 Jan 2017 11:17:23 GMT',
+  'x-ms-ratelimit-remaining-subscription-resource-requests': '11991',
+  'x-ms-correlation-request-id': 'a415d0c5-6deb-4d56-937f-4b836728f551',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135830Z:a415d0c5-6deb-4d56-937f-4b836728f551',
+  date: 'Wed, 19 Apr 2017 13:58:29 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/CNAME/tc?api-version=2016-04-01', '*')
-  .reply(201, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"1acded95-6ae1-489b-a785-63bf509e1182\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/CNAME/tc?api-version=2016-04-01', '*')
+  .reply(201, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"fb4978c9-4197-454b-b7c2-9e1197b22357\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}", { 'cache-control': 'private',
   'content-length': '369',
   'content-type': 'application/json; charset=utf-8',
-  etag: '1acded95-6ae1-489b-a785-63bf509e1182',
+  etag: 'fb4978c9-4197-454b-b7c2-9e1197b22357',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '7763dab9-52f7-4aa7-a9b3-5a19fb6c0b8b',
+  'x-ms-request-id': '85007d9a-3146-4c02-86b6-b0816b391383',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '0a423eff-8477-4824-b1a3-be4ee89994ff',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111724Z:0a423eff-8477-4824-b1a3-be4ee89994ff',
-  date: 'Fri, 27 Jan 2017 11:17:24 GMT',
+  'x-ms-ratelimit-remaining-subscription-resource-requests': '11996',
+  'x-ms-correlation-request-id': 'a43afbc3-e213-42a6-9bd2-55d0098b630d',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135831Z:a43afbc3-e213-42a6-9bd2-55d0098b630d',
+  date: 'Wed, 19 Apr 2017 13:58:30 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/CNAME/tc?api-version=2016-04-01', '*')
-  .reply(201, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"1acded95-6ae1-489b-a785-63bf509e1182\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/CNAME/tc?api-version=2016-04-01', '*')
+  .reply(201, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"fb4978c9-4197-454b-b7c2-9e1197b22357\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}", { 'cache-control': 'private',
   'content-length': '369',
   'content-type': 'application/json; charset=utf-8',
-  etag: '1acded95-6ae1-489b-a785-63bf509e1182',
+  etag: 'fb4978c9-4197-454b-b7c2-9e1197b22357',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '7763dab9-52f7-4aa7-a9b3-5a19fb6c0b8b',
+  'x-ms-request-id': '85007d9a-3146-4c02-86b6-b0816b391383',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '0a423eff-8477-4824-b1a3-be4ee89994ff',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111724Z:0a423eff-8477-4824-b1a3-be4ee89994ff',
-  date: 'Fri, 27 Jan 2017 11:17:24 GMT',
+  'x-ms-ratelimit-remaining-subscription-resource-requests': '11996',
+  'x-ms-correlation-request-id': 'a43afbc3-e213-42a6-9bd2-55d0098b630d',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135831Z:a43afbc3-e213-42a6-9bd2-55d0098b630d',
+  date: 'Wed, 19 Apr 2017 13:58:30 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/recordsets?api-version=2016-04-01')
-  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/NS\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/NS\",\"etag\":\"7e2aabe2-f4f8-4f82-a55f-22d67a3f7ed8\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":172800,\"NSRecords\":[{\"nsdname\":\"ns1-08.azure-dns.com.\"},{\"nsdname\":\"ns2-08.azure-dns.net.\"},{\"nsdname\":\"ns3-08.azure-dns.org.\"},{\"nsdname\":\"ns4-08.azure-dns.info.\"}]}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"2914c751-93df-4438-827c-77d8ccb18000\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-08.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"84cc1561-3a3f-447f-af8b-b67161fc5157\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"1acded95-6ae1-489b-a785-63bf509e1182\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}]}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/recordsets?api-version=2016-04-01')
+  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/NS\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/NS\",\"etag\":\"faae4fca-83d1-45ad-ab2a-aea611dd4dde\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":172800,\"NSRecords\":[{\"nsdname\":\"ns1-05.azure-dns.com.\"},{\"nsdname\":\"ns2-05.azure-dns.net.\"},{\"nsdname\":\"ns3-05.azure-dns.org.\"},{\"nsdname\":\"ns4-05.azure-dns.info.\"}]}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"c31e3114-887f-4e83-b224-3a9cf889c952\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-05.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"1017d4dd-9ab6-44dd-b325-134e8e98f84f\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"fb4978c9-4197-454b-b7c2-9e1197b22357\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}]}", { 'cache-control': 'private',
   'content-length': '1721',
   'content-type': 'application/json; charset=utf-8',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'eed5fcba-73bb-4fce-af7d-2c43946e10cf',
+  'x-ms-request-id': 'c657b0fc-a6d9-4eaa-94be-b5ea6fd7472a',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-reads': '14893',
-  'x-ms-correlation-request-id': 'b96cfdbf-544d-4b57-b493-80c1ea57f1f5',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111726Z:b96cfdbf-544d-4b57-b493-80c1ea57f1f5',
-  date: 'Fri, 27 Jan 2017 11:17:26 GMT',
+  'x-ms-ratelimit-remaining-subscription-reads': '14995',
+  'x-ms-correlation-request-id': '34d42a1d-0af0-433f-bff9-e42c845454fa',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135833Z:34d42a1d-0af0-433f-bff9-e42c845454fa',
+  date: 'Wed, 19 Apr 2017 13:58:32 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/recordsets?api-version=2016-04-01')
-  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/NS\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/NS\",\"etag\":\"7e2aabe2-f4f8-4f82-a55f-22d67a3f7ed8\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":172800,\"NSRecords\":[{\"nsdname\":\"ns1-08.azure-dns.com.\"},{\"nsdname\":\"ns2-08.azure-dns.net.\"},{\"nsdname\":\"ns3-08.azure-dns.org.\"},{\"nsdname\":\"ns4-08.azure-dns.info.\"}]}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"2914c751-93df-4438-827c-77d8ccb18000\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-08.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"84cc1561-3a3f-447f-af8b-b67161fc5157\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}},{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"1acded95-6ae1-489b-a785-63bf509e1182\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}]}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com/recordsets?api-version=2016-04-01')
+  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/NS\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/NS\",\"etag\":\"faae4fca-83d1-45ad-ab2a-aea611dd4dde\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":172800,\"NSRecords\":[{\"nsdname\":\"ns1-05.azure-dns.com.\"},{\"nsdname\":\"ns2-05.azure-dns.net.\"},{\"nsdname\":\"ns3-05.azure-dns.org.\"},{\"nsdname\":\"ns4-05.azure-dns.info.\"}]}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/SOA\\/@\",\"name\":\"@\",\"type\":\"Microsoft.Network\\/dnszones\\/SOA\",\"etag\":\"c31e3114-887f-4e83-b224-3a9cf889c952\",\"properties\":{\"fqdn\":\"exampledns.com.\",\"TTL\":3600,\"SOARecord\":{\"email\":\"hostmaster.exampledns.com.\",\"expireTime\":1814400,\"host\":\"ns1-05.azure-dns.com.\",\"minimumTTL\":10800,\"refreshTime\":43200,\"retryTime\":900,\"serialNumber\":2003080800}}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/A\\/default\",\"name\":\"default\",\"type\":\"Microsoft.Network\\/dnszones\\/A\",\"etag\":\"1017d4dd-9ab6-44dd-b325-134e8e98f84f\",\"properties\":{\"fqdn\":\"default.exampledns.com.\",\"TTL\":3600,\"ARecords\":[{\"ipv4Address\":\"0.1.2.3\"}]}},{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\\/CNAME\\/tc\",\"name\":\"tc\",\"type\":\"Microsoft.Network\\/dnszones\\/CNAME\",\"etag\":\"fb4978c9-4197-454b-b7c2-9e1197b22357\",\"properties\":{\"fqdn\":\"tc.exampledns.com.\",\"TTL\":3600,\"CNAMERecord\":{\"cname\":\"test.exampledns.com.\"}}}]}", { 'cache-control': 'private',
   'content-length': '1721',
   'content-type': 'application/json; charset=utf-8',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'eed5fcba-73bb-4fce-af7d-2c43946e10cf',
+  'x-ms-request-id': 'c657b0fc-a6d9-4eaa-94be-b5ea6fd7472a',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-reads': '14893',
-  'x-ms-correlation-request-id': 'b96cfdbf-544d-4b57-b493-80c1ea57f1f5',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111726Z:b96cfdbf-544d-4b57-b493-80c1ea57f1f5',
-  date: 'Fri, 27 Jan 2017 11:17:26 GMT',
+  'x-ms-ratelimit-remaining-subscription-reads': '14995',
+  'x-ms-correlation-request-id': '34d42a1d-0af0-433f-bff9-e42c845454fa',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135833Z:34d42a1d-0af0-433f-bff9-e42c845454fa',
+  date: 'Wed, 19 Apr 2017 13:58:32 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_import_should_parse_zone_file.nock.js
+++ b/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_import_should_parse_zone_file.nock.js
@@ -6,15 +6,15 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: 'e55e7c87-7bdc-445b-8213-56cdfca27374',
+    name: 'Free Trial',
     user: {
       name: 'user@domain.example',
       type: 'user'
     },
-    tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+    tenantId: 'fc53715f-c87b-43fc-9876-78ef5139cf26',
     state: 'Enabled',
-    registeredProviders: ['mobileservice', 'website'],
+    registeredProviders: [],
     _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));

--- a/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_list_should_display_all_dns_zones_in_resource_group.nock.js
+++ b/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_list_should_display_all_dns_zones_in_resource_group.nock.js
@@ -6,15 +6,15 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: 'e55e7c87-7bdc-445b-8213-56cdfca27374',
+    name: 'Free Trial',
     user: {
       name: 'user@domain.example',
       type: 'user'
     },
-    tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+    tenantId: 'fc53715f-c87b-43fc-9876-78ef5139cf26',
     state: 'Enabled',
-    registeredProviders: ['mobileservice', 'website'],
+    registeredProviders: [],
     _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));
@@ -29,38 +29,38 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones?api-version=2016-04-01')
-  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}]}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones?api-version=2016-04-01')
+  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}]}", { 'cache-control': 'private',
   'content-length': '522',
   'content-type': 'application/json; charset=utf-8',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'b874b92b-8212-4ed2-9f88-9beee4aa7056',
+  'x-ms-request-id': '04f890ca-8379-4d5d-9b25-e9da2c470431',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-resource-requests': '11983',
-  'x-ms-correlation-request-id': '6ecd30fd-4221-4c77-83ae-b33ca67819fd',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111638Z:6ecd30fd-4221-4c77-83ae-b33ca67819fd',
-  date: 'Fri, 27 Jan 2017 11:16:38 GMT',
+  'x-ms-ratelimit-remaining-subscription-resource-requests': '11995',
+  'x-ms-correlation-request-id': '77a0dc28-5262-4be5-a806-46e5eb4c8393',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135746Z:77a0dc28-5262-4be5-a806-46e5eb4c8393',
+  date: 'Wed, 19 Apr 2017 13:57:46 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones?api-version=2016-04-01')
-  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}]}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones?api-version=2016-04-01')
+  .reply(200, "{\"value\":[{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}]}", { 'cache-control': 'private',
   'content-length': '522',
   'content-type': 'application/json; charset=utf-8',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': 'b874b92b-8212-4ed2-9f88-9beee4aa7056',
+  'x-ms-request-id': '04f890ca-8379-4d5d-9b25-e9da2c470431',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
-  'x-ms-ratelimit-remaining-subscription-resource-requests': '11983',
-  'x-ms-correlation-request-id': '6ecd30fd-4221-4c77-83ae-b33ca67819fd',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111638Z:6ecd30fd-4221-4c77-83ae-b33ca67819fd',
-  date: 'Fri, 27 Jan 2017 11:16:38 GMT',
+  'x-ms-ratelimit-remaining-subscription-resource-requests': '11995',
+  'x-ms-correlation-request-id': '77a0dc28-5262-4be5-a806-46e5eb4c8393',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135746Z:77a0dc28-5262-4be5-a806-46e5eb4c8393',
+  date: 'Wed, 19 Apr 2017 13:57:46 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_set_should_modify_dns_zone.nock.js
+++ b/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_set_should_modify_dns_zone.nock.js
@@ -6,15 +6,15 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: 'e55e7c87-7bdc-445b-8213-56cdfca27374',
+    name: 'Free Trial',
     user: {
       name: 'user@domain.example',
       type: 'user'
     },
-    tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+    tenantId: 'fc53715f-c87b-43fc-9876-78ef5139cf26',
     state: 'Enabled',
-    registeredProviders: ['mobileservice', 'website'],
+    registeredProviders: [],
     _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));
@@ -29,82 +29,82 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '497',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000002-0000-0000-949b-4acc8e78d201',
+  etag: '00000002-0000-0000-519c-55e514b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '282add31-7ed7-4788-95a5-3f6e1d99e7ec',
+  'x-ms-request-id': '0e990736-fc20-499f-af6e-418120f7afcb',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11998',
-  'x-ms-correlation-request-id': '67aa6fdb-8053-4df5-b19f-aec40a0fd141',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111630Z:67aa6fdb-8053-4df5-b19f-aec40a0fd141',
-  date: 'Fri, 27 Jan 2017 11:16:29 GMT',
+  'x-ms-correlation-request-id': 'f2acb4e4-8651-4ff0-b277-425a0b5f3507',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135738Z:f2acb4e4-8651-4ff0-b277-425a0b5f3507',
+  date: 'Wed, 19 Apr 2017 13:57:38 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000002-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '497',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000002-0000-0000-949b-4acc8e78d201',
+  etag: '00000002-0000-0000-519c-55e514b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '282add31-7ed7-4788-95a5-3f6e1d99e7ec',
+  'x-ms-request-id': '0e990736-fc20-499f-af6e-418120f7afcb',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11998',
-  'x-ms-correlation-request-id': '67aa6fdb-8053-4df5-b19f-aec40a0fd141',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111630Z:67aa6fdb-8053-4df5-b19f-aec40a0fd141',
-  date: 'Fri, 27 Jan 2017 11:16:29 GMT',
+  'x-ms-correlation-request-id': 'f2acb4e4-8651-4ff0-b277-425a0b5f3507',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135738Z:f2acb4e4-8651-4ff0-b277-425a0b5f3507',
+  date: 'Wed, 19 Apr 2017 13:57:38 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '510',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000003-0000-0000-949b-4acc8e78d201',
+  etag: '00000003-0000-0000-519c-55e514b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '070a8dd4-91b0-440e-8922-5ede26cd6025',
+  'x-ms-request-id': '686dfe0f-28c2-4feb-9bde-a52d76c5d4b2',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '79dc3569-eb66-4cdd-b18c-67713cb24e47',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111636Z:79dc3569-eb66-4cdd-b18c-67713cb24e47',
-  date: 'Fri, 27 Jan 2017 11:16:35 GMT',
+  'x-ms-correlation-request-id': '8688cb9f-2338-4d7b-ae33-e0aebc0ddffe',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135742Z:8688cb9f-2338-4d7b-ae33-e0aebc0ddffe',
+  date: 'Wed, 19 Apr 2017 13:57:41 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
   .filteringRequestBody(function (path) { return '*';})
-.put('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+.put('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01', '*')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '510',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000003-0000-0000-949b-4acc8e78d201',
+  etag: '00000003-0000-0000-519c-55e514b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '070a8dd4-91b0-440e-8922-5ede26cd6025',
+  'x-ms-request-id': '686dfe0f-28c2-4feb-9bde-a52d76c5d4b2',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11999',
-  'x-ms-correlation-request-id': '79dc3569-eb66-4cdd-b18c-67713cb24e47',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111636Z:79dc3569-eb66-4cdd-b18c-67713cb24e47',
-  date: 'Fri, 27 Jan 2017 11:16:35 GMT',
+  'x-ms-correlation-request-id': '8688cb9f-2338-4d7b-ae33-e0aebc0ddffe',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135742Z:8688cb9f-2338-4d7b-ae33-e0aebc0ddffe',
+  date: 'Wed, 19 Apr 2017 13:57:41 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_show_should_display_details_of_dns_zone.nock.js
+++ b/test/recordings/arm-network-dns-zone-tests/arm_network_dns_zone_show_should_display_details_of_dns_zone.nock.js
@@ -6,15 +6,15 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: 'e55e7c87-7bdc-445b-8213-56cdfca27374',
+    name: 'Free Trial',
     user: {
       name: 'user@domain.example',
       type: 'user'
     },
-    tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+    tenantId: 'fc53715f-c87b-43fc-9876-78ef5139cf26',
     state: 'Enabled',
-    registeredProviders: ['mobileservice', 'website'],
+    registeredProviders: [],
     _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));
@@ -29,40 +29,40 @@ exports.setEnvironment = function() {
 exports.scopes = [[function (nock) { 
 var result = 
 nock('http://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '510',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000003-0000-0000-949b-4acc8e78d201',
+  etag: '00000003-0000-0000-519c-55e514b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '2dfda0d6-2da5-465d-89f5-2a5f8679141c',
+  'x-ms-request-id': '89618ac3-5ea7-459d-9885-8a91de1f4cb7',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11998',
-  'x-ms-correlation-request-id': 'b9376cb1-86d1-4eed-89f2-34db6fce2f62',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111637Z:b9376cb1-86d1-4eed-89f2-34db6fce2f62',
-  date: 'Fri, 27 Jan 2017 11:16:36 GMT',
+  'x-ms-correlation-request-id': '500d9f8b-a497-473c-afb0-d4e1630993c3',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135744Z:500d9f8b-a497-473c-afb0-d4e1630993c3',
+  date: 'Wed, 19 Apr 2017 13:57:43 GMT',
   connection: 'close' });
  return result; },
 function (nock) { 
 var result = 
 nock('https://management.azure.com:443')
-  .get('/subscriptions/2c224e7e-3ef5-431d-a57b-e71f4662e3a6/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
-  .reply(200, "{\"id\":\"\\/subscriptions\\/2c224e7e-3ef5-431d-a57b-e71f4662e3a6\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-949b-4acc8e78d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-08.azure-dns.com.\",\"ns2-08.azure-dns.net.\",\"ns3-08.azure-dns.org.\",\"ns4-08.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
+  .get('/subscriptions/e55e7c87-7bdc-445b-8213-56cdfca27374/resourceGroups/xplat-test-dns-zone/providers/Microsoft.Network/dnszones/exampledns.com?api-version=2016-04-01')
+  .reply(200, "{\"id\":\"\\/subscriptions\\/e55e7c87-7bdc-445b-8213-56cdfca27374\\/resourceGroups\\/xplat-test-dns-zone\\/providers\\/Microsoft.Network\\/dnszones\\/exampledns.com\",\"name\":\"exampledns.com\",\"type\":\"Microsoft.Network\\/dnszones\",\"etag\":\"00000003-0000-0000-519c-55e514b9d201\",\"location\":\"global\",\"tags\":{\"tag1\":\"aaa\",\"tag2\":\"bbb\",\"tag3\":\"ccc\"},\"properties\":{\"maxNumberOfRecordSets\":5000,\"nameServers\":[\"ns1-05.azure-dns.com.\",\"ns2-05.azure-dns.net.\",\"ns3-05.azure-dns.org.\",\"ns4-05.azure-dns.info.\"],\"numberOfRecordSets\":2}}", { 'cache-control': 'private',
   'content-length': '510',
   'content-type': 'application/json; charset=utf-8',
-  etag: '00000003-0000-0000-949b-4acc8e78d201',
+  etag: '00000003-0000-0000-519c-55e514b9d201',
   'x-content-type-options': 'nosniff',
   'strict-transport-security': 'max-age=31536000; includeSubDomains',
-  'x-ms-request-id': '2dfda0d6-2da5-465d-89f5-2a5f8679141c',
+  'x-ms-request-id': '89618ac3-5ea7-459d-9885-8a91de1f4cb7',
   server: 'Microsoft-IIS/8.5',
   'x-aspnet-version': '4.0.30319',
   'x-powered-by': 'ASP.NET',
   'x-ms-ratelimit-remaining-subscription-resource-requests': '11998',
-  'x-ms-correlation-request-id': 'b9376cb1-86d1-4eed-89f2-34db6fce2f62',
-  'x-ms-routing-request-id': 'WESTEUROPE:20170127T111637Z:b9376cb1-86d1-4eed-89f2-34db6fce2f62',
-  date: 'Fri, 27 Jan 2017 11:16:36 GMT',
+  'x-ms-correlation-request-id': '500d9f8b-a497-473c-afb0-d4e1630993c3',
+  'x-ms-routing-request-id': 'WESTEUROPE:20170419T135744Z:500d9f8b-a497-473c-afb0-d4e1630993c3',
+  date: 'Wed, 19 Apr 2017 13:57:43 GMT',
   connection: 'close' });
  return result; }]];

--- a/test/recordings/arm-network-dns-zone-tests/suite.arm-network-dns-zone-tests.nock.js
+++ b/test/recordings/arm-network-dns-zone-tests/suite.arm-network-dns-zone-tests.nock.js
@@ -6,15 +6,15 @@ exports.getMockedProfile = function () {
   var newProfile = new profile.Profile();
 
   newProfile.addSubscription(new profile.Subscription({
-    id: '2c224e7e-3ef5-431d-a57b-e71f4662e3a6',
-    name: 'Node CLI Test',
+    id: 'e55e7c87-7bdc-445b-8213-56cdfca27374',
+    name: 'Free Trial',
     user: {
       name: 'user@domain.example',
       type: 'user'
     },
-    tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+    tenantId: 'fc53715f-c87b-43fc-9876-78ef5139cf26',
     state: 'Enabled',
-    registeredProviders: ['mobileservice', 'website'],
+    registeredProviders: [],
     _eventsCount: '1',
     isDefault: true
   }, newProfile.environments['AzureCloud']));


### PR DESCRIPTION
* Added validation for record set names
* Added code to trim tokens like `[AGE:xxxxxx]` that make DNS zone list input invalid
* Improved `dns zone import` progress' output
* Re-recorded unit tests

The content to be added to Changelog is as follows:
* Network
  * DNS Zone Import's data validation is improved