### PR TITLE
Travis CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: required
+
 language: node_js
 
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 script:
   - npm -s run-script jshint
   - npm -s run-script unit-arm
+  - npm -s run-script unit-arm-deployment
   - npm -s run-script unit
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ install:
   - npm install
 
 script:
-  - npm test
+  - npm -s run-script jshint
+  - npm -s run-script unit-arm
+  - npm -s run-script unit
 
 after_script:
   - echo "========== test log: ============"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ install:
   - npm --version
   - npm install
 
+before_script:
+  - echo "======== startup memory info ========"
+  - free -h -t
+
 script:
   - npm -s run-script jshint
   - npm -s run-script unit-arm

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,13 @@ install:
   - npm --version
   - npm install
 
-before_script:
-  - echo "======== startup memory info ========"
-  - free -h -t
+# this is purely for debugging purposes. Do not delete, but enable when you need memory diagnostics.
+# before_script:
+#  - echo "======== startup memory info ========"
+#  - free -h -t
 
+# Deliberately splitting the test suite to keep memory pressure low on nodejs process.
+# Combining these as a single job may lead to OOM exceptions.
 script:
   - npm -s run-script jshint
   - npm -s run-script unit-arm

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "test": "npm -s run-script jshint && npm -s run-script unit-arm && npm -s run-script unit",
     "unit": "node --max_old_space_size=4096 scripts/unit.js testlist.txt",
     "unit-arm": "node --max_old_space_size=4096 scripts/unit.js testlist-arm.txt",
+    "unit-arm-deployment": "node --max_old_space_size=4096 scripts/unit.js testlist-arm-deployment.txt",
     "unit-vm": "node scripts/unit.js testlist-vm.txt",
     "unit-vm-live": "node scripts/unit.js testlist-vm-live.txt",
     "unit-arm-vm": "node scripts/unit.js testlist-arm-vm.txt",

--- a/package.json
+++ b/package.json
@@ -133,8 +133,8 @@
   },
   "scripts": {
     "test": "npm -s run-script jshint && npm -s run-script unit-arm && npm -s run-script unit",
-    "unit": "node scripts/unit.js testlist.txt",
-    "unit-arm": "node scripts/unit.js testlist-arm.txt",
+    "unit": "node --max_old_space_size=4096 scripts/unit.js testlist.txt",
+    "unit-arm": "node --max_old_space_size=4096 scripts/unit.js testlist-arm.txt",
     "unit-vm": "node scripts/unit.js testlist-vm.txt",
     "unit-vm-live": "node scripts/unit.js testlist-vm-live.txt",
     "unit-arm-vm": "node scripts/unit.js testlist-arm-vm.txt",

--- a/test/testlist-arm-deployment.txt
+++ b/test/testlist-arm-deployment.txt
@@ -1,0 +1,3 @@
+commands/arm/group/arm.group-tests.js
+commands/arm/group/arm.group.deployment-tests.js
+commands/arm/group/arm.group.deployment.operation-tests.js

--- a/test/testlist-arm.txt
+++ b/test/testlist-arm.txt
@@ -96,9 +96,6 @@ commands/arm/devtestlabs/arm.devtestlabs-tests.js
 commands/arm/iothub/arm.iothub-tests.js
 #please put the following group tests to the last, as it uses the different subscription
 #and it exposes a test framework bug which failed vm tests randomly
-commands/arm/group/arm.group-tests.js
-commands/arm/group/arm.group.deployment-tests.js
-commands/arm/group/arm.group.deployment.operation-tests.js
 commands/arm/cdnMangement/arm.cdnMangement-tests.js
 commands/arm/policy/arm.policy.definition-tests.js
 commands/arm/policy/arm.policy.assignment-tests.js


### PR DESCRIPTION
1. Splitting test commands invoked from travis CI into arm and asm tests. While the breakdown makes sense logically, the intention behind is to shutdown and restart node process inbetween to see if this reduces the memory pressure enough to resolve the intermittent out-of-memory problems we've been observing.
1. upgrade CI environment from `Precise` to `Trusty`. This should get us VMs with 7.5G memory (See [travis-documentation](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments) and [announcement](http://blog.travis-ci.com/2015-10-14-opening-up-ubuntu-trusty-beta/))
1. pass --max_old_space_size to increase V8's default memory limit constraints. (See [this](https://github.com/nodejs/node/issues/13018), [this](https://github.com/nodejs/node/issues/10137) and [this](https://stackoverflow.com/questions/38558989/node-js-heap-out-of-memory))
1. split out group deployment tests, which seems to be the exact place where every OOM seems to happen.
1. Better diagnostics: display available system memory before running tests