### PR TITLE
upgrade easy table dependency

### DIFF
--- a/lib/util/logging.js
+++ b/lib/util/logging.js
@@ -130,25 +130,17 @@ log.table = function (level, data, transform) {
     log.log(level, 'table', data);
   } else {
     var table = new Table();
-    table.LeftPadder = Table.LeftPadder;
+    table.leftPadder = Table.leftPadder;
     table.padLeft = Table.padLeft;
-    table.RightPadder = Table.RightPadder;
+    table.rightPadder = Table.rightPadder;
     table.padRight = Table.padRight;
 
     if (data && data.forEach) {
-      data.forEach(function (item) { transform(table, item); table.newLine(); });
+      data.forEach(function (item) { transform(table, item); table.newRow(); });
     } else if (data) {
       for (var item in data) {
         transform(table, item);
-        table.newLine();
-      }
-    }
-
-    for (var i in table.lines) {
-      for (var column in table.columns) {
-        if (!table.lines[i].hasOwnProperty(column)) {
-          table.lines[i][column] = '';
-        }
+        table.newRow();
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "colors": "1.1.2",
     "commander": "1.0.4",
     "date-utils": "1.2.21",
-    "easy-table": "0.0.1",
+    "easy-table": "1.1.0",
     "event-stream": "3.1.5",
     "eyes": "0.x.x",
     "github": "0.1.6",


### PR DESCRIPTION
The content to be added to Changelog is as follows:
* Fixed bug https://github.com/Azure/azure-xplat-cli/issues/3605. The issue is that, xplat-cli fails to install with npm5. The root cause was we're using an old version of `easy-table` package that has a bug with file system permissions and was later fixed. This PR updates the version of `easy-table` to a more recent one.