### PR TITLE
cloud console: fill in isMRRT field when being invoked with raw tokens

### DIFF
--- a/lib/util/profile/account.js
+++ b/lib/util/profile/account.js
@@ -269,6 +269,7 @@ Account.prototype._buildTokenEntry = function (accessToken) {
     'userId': nameParts[1] || nameParts[0],
     '_authority': this._env.activeDirectoryEndpointUrl + '/' + decodedToken.tid,
     'resource': decodedToken.aud,
+    'isMRRT': true,
     'accessToken': accessToken,
     'tokenType': 'Bearer',
     'oid': decodedToken.oid

--- a/test/util/profile/account-tests.js
+++ b/test/util/profile/account-tests.js
@@ -405,6 +405,7 @@ describe('account', function () {
     it('should add new token entries into cache', function () {
       tokensToAddIntoCache.should.have.length(1)
       tokensToAddIntoCache[0]._userId.should.equal(expectedUserName);
+      tokensToAddIntoCache[0].isMRRT.should.be.true;
     });
 
     it('should return listed subscriptions', function () {


### PR DESCRIPTION
All tokens to access azure resource can be acquired using multi-resource-refresh-tokens, hence this filed should `true`