### PR TITLE
[Windows Installer Build Infrastructure] switch to using npm thats installed

### DIFF
--- a/tools/windows/scripts/prepareRepoClone.cmd
+++ b/tools/windows/scripts/prepareRepoClone.cmd
@@ -126,12 +126,15 @@ popd
 
 echo Preparing to run npm install...
 pushd %TEMP_REPO%
-set NPM=.\bin\node.exe %TEMP_NPM_REPO%\npm-%NPM_VERSION%\cli.js
+set NPMLOCAL=.\bin\node.exe %TEMP_NPM_REPO%\npm-%NPM_VERSION%\cli.js
 echo.
+:: Notice we're not using the locally downloaded npm anymore. 
+:: This is because we've made the build machine have the version we need.
+:: If ever needed, just switch to use "NPMLOCAL" instead of "npm" and we'll be good.
 echo Perform npm version check
-call NPM -v
+call npm -v
 echo Running npm install...
-call NPM install --production
+call npm install --production
 echo.
 echo if YOU SEE A FAILURE AT THE BOTTOM OF THE NPM OUTPUT:
 echo If you do not have Node.js installed on this local machine, the Azure


### PR DESCRIPTION
on the build machine. however, keep the logic to download and use latest
npm around. if ever needed, swap out `npm` command with `NPMLOCAL` thats
defined by the script.
