### PR TITLE
updating README for npm5 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Please take a look at the list of supported environment variables over [here](ht
 - Uninstall the previously installed CLI
    - If you installed via MSI, then uninstall the windows MSI. For mac installer `sudo azure-uninstall -g`
    - If you installed via npm then execute: `npm uninstall -g azure-cli`
-- Clear the global cache: `npm cache verify`
+- Clear the global cache: 
+   - If npm4.0 or before: `npm cache clear -g`
+   - If npm5.0 or greater `npm cache verify`
 - Delete the .streamline folder from the User’s home profile `C:\Users\<username>\.streamline` | `~/.streamline`, if present.
 - Download the tarball from this link: `https://github.com/Azure/azure-xplat-cli/archive/<branch-name>.tar.gz`
 - Install from the tarball: `npm install –g <path to the downloaded tarball>`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please take a look at the list of supported environment variables over [here](ht
 - Uninstall the previously installed CLI
    - If you installed via MSI, then uninstall the windows MSI. For mac installer `sudo azure-uninstall -g`
    - If you installed via npm then execute: `npm uninstall -g azure-cli`
-- Clear the global cache: `npm cache clear –g`
+- Clear the global cache: `npm cache verify`
 - Delete the .streamline folder from the User’s home profile `C:\Users\<username>\.streamline` | `~/.streamline`, if present.
 - Download the tarball from this link: `https://github.com/Azure/azure-xplat-cli/archive/<branch-name>.tar.gz`
 - Install from the tarball: `npm install –g <path to the downloaded tarball>`


### PR DESCRIPTION
Based on the following error, updated to use the recommended verify command. I didn't realize until I was through several of the commands that I wanted to the next step. As such, I would also recommend moving the install from npm step to be the first install step since that's what most would likely take.

$ npm cache clear -g
npm ERR! As of npm@5, the npm cache self-heals from corruption issues and data extracted from the cache is guaranteed to be valid. If you want to make sure everything is consistent, use 'npm cache verify' instead.
npm ERR! 
npm ERR! If you're sure you want to delete the entire cache, rerun this command with --force.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/carlo.wahlstedt/.npm/_logs/2017-08-02T13_23_36_247Z-debug.log

The content to be added to Changelog is as follows:
* 
* 
* 