### PR TITLE
cloud-shell: set 'expiresIn' with an integer value

### DIFF
--- a/lib/util/profile/account.js
+++ b/lib/util/profile/account.js
@@ -264,7 +264,7 @@ Account.prototype._buildTokenEntry = function (accessToken) {
   nameParts = decodedToken['unique_name'].split('#');
   return {
     '_clientId': constants.XPLAT_CLI_CLIENT_ID,
-    'expiresIn': '3600', //not accurate, but okay, as portal invokes us every 15 mins
+    'expiresIn': 3600, //not accurate, but okay, as portal invokes us every 15 mins
     'expiresOn': (new Date()).add({ seconds : 3600 * 24 }),
     'userId': nameParts[1] || nameParts[0],
     '_authority': this._env.activeDirectoryEndpointUrl + '/' + decodedToken.tid,

--- a/test/util/profile/account-tests.js
+++ b/test/util/profile/account-tests.js
@@ -406,6 +406,7 @@ describe('account', function () {
       tokensToAddIntoCache.should.have.length(1)
       tokensToAddIntoCache[0]._userId.should.equal(expectedUserName);
       tokensToAddIntoCache[0].isMRRT.should.be.true;
+      tokensToAddIntoCache[0].expiresIn.should.equal(3600)
     });
 
     it('should return listed subscriptions', function () {


### PR DESCRIPTION
This field is not really used by either ADAL or CLI for token refreshing. But still a bug as ADAL sets it using integer type, so we have inconsistency here.