### PR TITLE
Fixed incorrect timestamp generation

### DIFF
--- a/test/framework/test-logger.js
+++ b/test/framework/test-logger.js
@@ -61,7 +61,7 @@ function getTimeStamp() {
       return '0' + number;
     }
 
-    return number;
+    return String(number);
   }
 
   var now = new Date();


### PR DESCRIPTION
Function `pad` in `getTimeStamp` returns value of `Number` type if that value has already been greater than 10 which may result in generation of incorrect timestamp. For example, Oct. 2, 2017 would be generated as `2017 + 10 + '02' + '_' + ...` resulting in timestamp `202702_...`.

Explicitly converting return value of `pad` to string fixes that.