### PR TITLE
cloud shell: able to consume accounts created by CLI 2.0 in the cloud shell

### DIFF
--- a/lib/util/profile/subscription.js
+++ b/lib/util/profile/subscription.js
@@ -174,7 +174,7 @@ _.extend(Subscription.prototype, {
     return _.extend(
       _.pick(this,
         'id', 'name', 'user', 'managementCertificate', 'accessToken', 'tenantId', 
-        'state', 'isDefault', 'registeredProviders', 'cloudShellID'),
+        'state', 'isDefault', 'registeredProviders'),
       { environmentName: this.environment.name },
       this.values);
   },

--- a/lib/util/profile/subscription.js
+++ b/lib/util/profile/subscription.js
@@ -138,16 +138,16 @@ _.extend(Subscription.prototype, {
     if (this.user) {
       switch (this.user.type) {
         case 'user':
-          cred = new (require('../authentication/adalAuthForUser').UserTokenCredentials)(authConfig, this.user.name);
+          if (this.user.cloudShellID) {
+            cred = new msRestAzure.MSIVmTokenCredentials();
+          } else {
+            cred = new (require('../authentication/adalAuthForUser').UserTokenCredentials)(authConfig, this.user.name);
+          }
           break;
 
         case 'servicePrincipal':
           authConfig.tenantId = this.tenantId;
-          if (this.name.startsWith('MSI@')) {
-            cred = new msRestAzure.MSIVmTokenCredentials({ 'port': parseInt(this.name.substring(4)) });
-          } else {
-            cred = new (require('../authentication/adalAuthForServicePrincipal').ServicePrincipalTokenCredentials)(authConfig, this.user.name);
-          }
+          cred = new (require('../authentication/adalAuthForServicePrincipal').ServicePrincipalTokenCredentials)(authConfig, this.user.name);
           break;
 
         default:
@@ -174,7 +174,7 @@ _.extend(Subscription.prototype, {
     return _.extend(
       _.pick(this,
         'id', 'name', 'user', 'managementCertificate', 'accessToken', 'tenantId', 
-        'state', 'isDefault', 'registeredProviders'),
+        'state', 'isDefault', 'registeredProviders', 'cloudShellID'),
       { environmentName: this.environment.name },
       this.values);
   },


### PR DESCRIPTION
The account created by CLI 2.0 has main properties updated per review with the cloud shell team, so i am updating 1.0 accordingly